### PR TITLE
Fix docs site layout by removing excessive margin

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -36,6 +36,7 @@
   /* Content settings */
   --sl-content-width: 50rem;
   --sl-sidebar-width: 20rem;
+  --sl-content-margin-inline: 0;
   
   /* Typography */
   --sl-line-height: 1.7;


### PR DESCRIPTION
Set --sl-content-margin-inline to 0 to override Starlight's default margin that was causing the content container to display incorrectly at wider viewport widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)