### PR TITLE
Add docs on shell execution context

### DIFF
--- a/api/exec.go
+++ b/api/exec.go
@@ -241,13 +241,13 @@ func detectInterpreter(script string, providedLang string) (string, []string) {
 
 		// Handle common patterns
 		if strings.Contains(shebang, "/env ") {
-			// #!/usr/bin/env python3 -> ["python3"]
+			// e.g. #!/usr/bin/env python3 -> ["python3"]
 			parts := strings.Fields(shebang)
 			if len(parts) >= 2 {
 				return parts[1], parts[2:]
 			}
 		} else {
-			// #!/bin/bash -> ["bash"]
+			// e.g. #!/bin/bash -> ["bash"]
 			parts := strings.Fields(shebang)
 			if len(parts) >= 1 {
 				// Get just the binary name (e.g., "bash" from "/bin/bash")

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "molecular-mercury",

--- a/docs/src/content/docs/authoring/blocks/Check.md
+++ b/docs/src/content/docs/authoring/blocks/Check.md
@@ -246,6 +246,12 @@ Use Admonition blocks to group related checks:
 <Check id="check-3" ... />
 ```
 
+## Shell Execution Context
+
+Scripts run in a **non-interactive shell**, which means shell aliases (like `ll`) and shell functions (like `nvm`, `rvm`) are **not available**. Environment variables are inherited from the process that launched Runbooks.
+
+For full details on interpreter detection and workarounds, see [Shell Execution Context](/security/shell-execution-context/).
+
 ## Security Considerations
 
 ### Avoid Hardcoded Secrets

--- a/docs/src/content/docs/authoring/blocks/Command.md
+++ b/docs/src/content/docs/authoring/blocks/Command.md
@@ -309,6 +309,12 @@ fi
 />
 ```
 
+## Shell Execution Context
+
+Scripts run in a **non-interactive shell**, which means shell aliases (like `ll`) and shell functions (like `nvm`, `rvm`) are **not available**. Environment variables are inherited from the process that launched Runbooks.
+
+For full details on interpreter detection and workarounds, see [Shell Execution Context](/security/shell-execution-context/).
+
 ## Security Considerations
 
 ### Avoid Hardcoded Secrets

--- a/docs/src/content/docs/security/execution-model.md
+++ b/docs/src/content/docs/security/execution-model.md
@@ -120,9 +120,11 @@ Regardless of mode, the actual execution process is:
 2. **Render templates**: If script contains template variables like `{{ .VarName }}`, substitute them
 3. **Create temp file**: Write script content to a temporary file
 4. **Make executable**: Set file permissions (`chmod 0700`)
-5. **Detect interpreter**: Read shebang line (e.g., `#!/bin/bash`) or use component's `language` prop
-6. **Execute**: Run script with detected interpreter
+5. **Detect interpreter**: Read shebang line (e.g., `#!/bin/bash`) or default to `bash`
+6. **Execute**: Run script with detected interpreter in a non-interactive shell
 7. **Stream output**: Send stdout/stderr back to browser via Server-Sent Events (SSE)
 8. **Clean up**: Delete temporary file
 
 **Security note:** Scripts run with your user's full environment variables and permissions. Runbooks is designed for **trusted runbooks only** - it's meant to streamline tasks you would otherwise run manually in your terminal.
+
+For details on interpreter detection and shell limitations (aliases, functions, RC files), see [Shell Execution Context](/security/shell-execution-context/).

--- a/docs/src/content/docs/security/shell-execution-context.md
+++ b/docs/src/content/docs/security/shell-execution-context.md
@@ -1,0 +1,93 @@
+---
+title: Shell Execution Context
+description: Understanding how Runbooks executes scripts in a non-interactive shell
+---
+
+Scripts executed by Runbooks in [Check](/authoring/blocks/check) or [Command](/authoring/blocks/command) blocks run in a **non-interactive shell**. This has important implications for what works and what doesn't.
+
+## What's Available
+
+| Feature | Available? | Notes |
+|---------|------------|-------|
+| Environment variables | ✅ Yes | Inherited from the process that launched Runbooks |
+| Binaries in `$PATH` | ✅ Yes | `git`, `aws`, `terraform`, etc. |
+| Shell aliases | ❌ No | `ll`, `la`, custom aliases |
+| Shell functions | ❌ No | `nvm`, `rvm`, `assume`, etc. |
+| RC files | ❌ No | `.bashrc`, `.zshrc` are NOT sourced |
+
+## Example: Aliases vs Binaries
+
+```bash
+# ❌ Will NOT work - ll is typically a bash alias for "ls -l"
+<Check command="ll" ... />
+
+# ✅ Will work - ls is an actual binary
+<Check command="ls -l" ... />
+```
+
+## Why This Matters
+
+Many developer tools are implemented as **shell functions** rather than standalone binaries. These functions are often defined in your shell's RC files (`.bashrc`, `.zshrc`) and only exist in interactive shell sessions.
+
+Common tools that are shell functions (not binaries):
+- **nvm** — Node Version Manager
+- **rvm** — Ruby Version Manager  
+- **pyenv** shell integration
+- **conda activate**
+- **assume** — Shell function from [Granted](https://docs.commonfate.io/granted/introduction)
+
+These tools need to be shell functions because they modify your current shell's environment (e.g., changing `$PATH` or setting environment variables), which can't be done from a subprocess.
+
+## Workarounds
+
+For tools that are shell functions, instead of invoking them directly, you can check for the underlying installation instead:
+
+```bash
+#!/bin/bash
+# Instead of running "nvm --version" (won't work), check if nvm is installed:
+if [ -d "$HOME/.nvm" ] && [ -s "$HOME/.nvm/nvm.sh" ]; then
+    echo "✅ nvm is installed"
+    exit 0
+else
+    echo "❌ nvm is not installed"
+    exit 1
+fi
+```
+
+If you absolutely need shell functions, you can source the RC file in your script that runs in the Check or Command block (use with caution):
+
+```bash
+#!/bin/bash
+# Source shell config to get functions (not recommended for portability)
+source ~/.bashrc 2>/dev/null || source ~/.zshrc 2>/dev/null
+
+# Now nvm should be available
+nvm --version
+```
+
+## Interpreter Detection
+
+Runbooks determines which interpreter to use for your script:
+
+1. **Shebang line** — If your script starts with `#!/bin/bash`, `#!/usr/bin/env python3`, etc., that interpreter is used
+2. **Default** — If no shebang is present, `bash` is used
+
+### Common Shebangs
+
+| Shebang | Interpreter |
+|---------|-------------|
+| `#!/bin/bash` | Bash shell |
+| `#!/bin/zsh` | Zsh shell |
+| `#!/usr/bin/env python3` | Python 3 |
+| `#!/usr/bin/env node` | Node.js |
+
+### Best Practice
+
+Always include a shebang in your scripts to ensure predictable execution:
+
+```bash
+#!/bin/bash
+set -e
+# Your script here...
+```
+

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -207,6 +207,8 @@ header.header {
    ============================================ */
 
 .sl-markdown-content table {
+  width: fit-content;
+  max-width: 100%;
   border-radius: 0.5rem;
   overflow: hidden;
   border: 1px solid var(--sl-color-gray-6);
@@ -222,6 +224,12 @@ header.header {
 
 .sl-markdown-content tbody tr:last-child {
   border-bottom: none;
+}
+
+.sl-markdown-content th,
+.sl-markdown-content td {
+  padding: 0.75rem 1rem;
+  text-align: left;
 }
 
 .sl-markdown-content th {


### PR DESCRIPTION
I was writing a runbook and tried to run the following Check:

```mdx
<Check
  id="check-assume"
  command="assume --version"
  title="Verify assume Command"
  description="The assume command is used to assume AWS roles"
  successMessage="assume command is available!"
  failMessage="assume command not found. You may need to run 'granted browser set' to configure Granted."
/>
```

But this output a completely empty log file...and yet sill succeeded. This turned out to be because of this:

```
$ which assume
assume: aliased to source assume
```

So `assume` is just a shell function, but Runbooks doesn't source shell startup files like `~/.bashrc` or `~/.zshrc`, so any shell functions defined there won't be available in a non-interactive shell. Because the shell function doesn't exist in the script's execution context, the command "succeeds" and produces no output.

That is not at all obvious, so this PR adds docs clarifying what's happening.