### PR TITLE
Resolve symlinks in CWD for path operations

### DIFF
--- a/api/generated_files.go
+++ b/api/generated_files.go
@@ -169,8 +169,9 @@ func resolveToAbsolutePath(rawPath string) (string, error) {
 	// This ensures consistent paths even when the output directory doesn't exist yet
 	resolvedDir, err := filepath.EvalSymlinks(currentDir)
 	if err != nil {
-		// Fall back to unresolved path if symlink resolution fails
-		resolvedDir = currentDir
+		// If we can't resolve symlinks on the CWD, it's a sign of a problem.
+		// It's better to fail fast than to proceed with a potentially incorrect path.
+		return "", fmt.Errorf("failed to resolve symlinks for current working directory %q: %w", currentDir, err)
 	}
 
 	return filepath.Join(resolvedDir, rawPath), nil

--- a/api/path_validation.go
+++ b/api/path_validation.go
@@ -259,8 +259,9 @@ func ValidateAbsolutePathInCwd(path string) error {
 	// This ensures consistent comparison when both paths involve symlinks
 	resolvedCwd, err := filepath.EvalSymlinks(cwd)
 	if err != nil {
-		// If we can't resolve symlinks, fall back to the original CWD
-		resolvedCwd = cwd
+		// If we can't resolve symlinks on the CWD, it's a sign of a problem.
+		// It's better to fail fast than to proceed with a potentially incorrect path.
+		return fmt.Errorf("failed to resolve symlinks for current working directory %q: %w", cwd, err)
 	}
 
 	// The path must be within or equal to the current working directory


### PR DESCRIPTION
Updated path resolution and validation logic to resolve symlinks in the current working directory, ensuring consistent behavior across platforms (notably macOS where /tmp is a symlink).