### PR TITLE
Fix link to "Write Your First Runbook"

### DIFF
--- a/docs/src/content/docs/intro/overview.mdx
+++ b/docs/src/content/docs/intro/overview.mdx
@@ -74,6 +74,6 @@ Note that for now, you will need to manually download the full Runbook directory
 
 ## Next
 
-To see a Runbook in action, let's [Install Runbooks](/intro/installation/) and then [Write Your First Runbook](/setup/write_your_first_runbook).
+To see a Runbook in action, let's [Install Runbooks](/intro/installation/) and then [Write Your First Runbook](/intro/write_your_first_runbook).
 
 


### PR DESCRIPTION
Noticed a broken link while browsing https://runbooks.gruntwork.io/intro/overview/. This should address it.