### PR TITLE
Fix PTY completion deadlock on macOS

### DIFF
--- a/api/exec.go
+++ b/api/exec.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -317,6 +318,10 @@ func startCommandExecution(ctx context.Context, cmdConfig execCommandConfig, use
 			// PTY started successfully - stream output and wait for completion
 			go streamPTYOutput(ptmx, outputChan)
 			go func() {
+				if runtime.GOOS == "darwin" {
+					doneChan <- waitForPTYProcess(cmd, ptmx)
+					return
+				}
 				doneChan <- cmd.Wait()
 			}()
 			return nil


### PR DESCRIPTION
### Motivation
- PTY-based command execution could hang on macOS because the PTY master does not return EOF when the child exits, causing the reader in `streamPTYOutput` to block and `cmd.Wait()` to deadlock. 
- The change ensures the PTY master is closed when the child process exits so readers unblock and the execution completes reliably on macOS.

### Description
- Added a new helper `waitForPTYProcess` in `api/exec_pty.go` that calls `cmd.Process.Wait()`, closes the PTY master (`ptmx`), and converts the result into a `Cmd`-style error (returns `*exec.ExitError` on failure).
- Updated the PTY execution path in `startCommandExecution` (in `api/exec.go`) to route macOS (`runtime.GOOS == "darwin"`) waits through `waitForPTYProcess` to avoid the PTY read deadlock while keeping `streamPTYOutput` for live streaming.
- Imported `runtime` in `api/exec.go` and kept existing fallback to pipe-based execution unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982e7be42188320846cc1aeeb97d2a9)