### PR TITLE
Enable instant updates to changed files

### DIFF
--- a/web/src/components/mdx/Template/Template.tsx
+++ b/web/src/components/mdx/Template/Template.tsx
@@ -250,6 +250,8 @@ function Template({
     if (validatedTree) {
       setFileTree(validatedTree);
     }
+    // Trigger immediate changelog refresh so changes appear without waiting for next poll
+    invalidateTree();
   }, [renderResult, setFileTree, target, invalidateTree]);
 
   // Debounce timer ref for auto-render

--- a/web/src/components/mdx/TemplateInline/TemplateInline.tsx
+++ b/web/src/components/mdx/TemplateInline/TemplateInline.tsx
@@ -215,6 +215,8 @@ function TemplateInline({
             invalidateTree();
           } else {
             setFileTree(newFileTree);
+            // Trigger immediate changelog refresh so changes appear without waiting for next poll
+            invalidateTree();
           }
         })
         .catch(err => {

--- a/web/src/hooks/useApiBoilerplateRender.ts
+++ b/web/src/hooks/useApiBoilerplateRender.ts
@@ -2,6 +2,7 @@ import { useApi } from './useApi';
 import type { UseApiReturn } from './useApi';
 import { useMemo, useCallback, useEffect } from 'react';
 import { useFileTree } from './useFileTree';
+import { useGitWorkTree } from '@/contexts/useGitWorkTree';
 import type { FileTreeNode } from '@/components/artifacts/code/FileTree';
 
 interface BoilerplateRenderResult {
@@ -45,6 +46,7 @@ export function useApiBoilerplateRender(
   target?: 'generated' | 'worktree'
 ): UseApiBoilerplateRenderResult {
   const { setFileTree } = useFileTree();  // The FileTree is where we render the list of generated files
+  const { invalidateTree } = useGitWorkTree();
 
   // Build the request body - both templatePath and templateId are required
   const requestBody = useMemo(() => {
@@ -77,8 +79,10 @@ export function useApiBoilerplateRender(
     const fileTreeData = apiResult.data?.fileTree;
     if (fileTreeData && Array.isArray(fileTreeData)) {
       setFileTree(fileTreeData);
+      // Trigger immediate changelog refresh so changes appear without waiting for next poll
+      invalidateTree();
     }
-  }, [apiResult.data?.fileTree, setFileTree, target]);
+  }, [apiResult.data?.fileTree, setFileTree, target, invalidateTree]);
 
   return {
     ...apiResult,


### PR DESCRIPTION
Previously, when a runbooks user would make changes to repository files, there would be a wait of up to 3 seconds while Runbooks would wait to poll the filesytem for any updates. This was a frustrating delay, so this PR has all template generations and command and check scripts trigger an instant poll. It makes for a much nicer UX!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The changelog and workspace now refresh immediately after rendering templates and processing files, rather than waiting for the next scheduled update, providing faster feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->