### PR TITLE
Automatically create new homebrew releases

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -145,22 +145,38 @@ jobs:
 
           git checkout -b "$BRANCH"
           git add Formula/
+
+          # If the formulae already match main (e.g., a previous run's PR was merged),
+          # there is nothing left to do.
+          if git diff --cached --quiet; then
+            echo "Formula is already up to date on main — nothing to do."
+            exit 0
+          fi
+
           git \
             -c user.name="gruntwork-homebrew-tap[bot]" \
             -c user.email="gruntwork-homebrew-tap[bot]@users.noreply.github.com" \
             commit -m "Update ${TOOL_NAME} to ${TAG}"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
-          PR_URL=$(gh pr create \
+          # Re-use an existing PR if one was already opened for this branch.
+          EXISTING_PR=$(gh pr list \
             --repo gruntwork-io/homebrew-tap \
-            --base main \
             --head "$BRANCH" \
-            --title "Update ${TOOL_NAME} to ${TAG}" \
-            --body "Automated formula update for **${TOOL_NAME}** to [\`${TAG}\`](https://github.com/gruntwork-io/${TOOL_NAME}/releases/tag/${TAG}).")
+            --json url \
+            --jq '.[0].url // empty')
 
-          gh pr review "$PR_URL" \
-            --repo gruntwork-io/homebrew-tap \
-            --approve
+          if [[ -n "$EXISTING_PR" ]]; then
+            PR_URL="$EXISTING_PR"
+            echo "PR already exists: ${PR_URL}"
+          else
+            PR_URL=$(gh pr create \
+              --repo gruntwork-io/homebrew-tap \
+              --base main \
+              --head "$BRANCH" \
+              --title "Update ${TOOL_NAME} to ${TAG}" \
+              --body "Automated formula update for **${TOOL_NAME}** to [\`${TAG}\`](https://github.com/gruntwork-io/${TOOL_NAME}/releases/tag/${TAG}).")
+          fi
 
           gh pr merge "$PR_URL" \
             --repo gruntwork-io/homebrew-tap \


### PR DESCRIPTION
## Summary
- Adds a `release: [published]` workflow that automatically updates the Homebrew formula in [`gruntwork-io/homebrew-tap`](https://github.com/gruntwork-io/homebrew-tap) whenever a new GitHub Release is published
- On each release, the workflow downloads the 4 platform binaries, computes SHA256 checksums, generates updated unversioned and versioned formulae, then opens/approves/merges a PR against homebrew-tap

## Setup required
After merging, add these repository secrets (values in 1Password under "Gruntwork Homebrew Tap Updater"):
- `HOMEBREW_TAP_APP_ID`
- `HOMEBREW_TAP_APP_PRIVATE_KEY`

✅ Already done!

## Test plan
- [x] Ran `test-homebrew-workflow.sh beta-v0.5.2 version` locally — generated formulae match the existing `Formula/runbooks.rb` and `Formula/runbooks@0.5.2.rb` in homebrew-tap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated Homebrew release workflow to streamline distribution: it publishes updated formulae for new releases, handles multi-platform binaries with integrity checks, creates or updates pull requests for formula changes, and auto-merges approved updates so Homebrew users receive new versions promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->