### PR TITLE
Add brew install docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,3 +202,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-homebrew:
+    name: Update Homebrew Formula
+    needs: create-release
+    uses: ./.github/workflows/update-homebrew.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit
+

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -185,4 +185,5 @@ jobs:
           gh pr merge "$PR_URL" \
             --repo gruntwork-io/homebrew-tap \
             --auto \
-            --merge
+            --merge \
+            --delete-branch

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -8,8 +8,12 @@
 name: Update Homebrew Formula
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'The release tag (e.g. v1.2.3)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -36,7 +40,7 @@ jobs:
         id: download
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ inputs.tag }}
         run: |
           TOOL_NAME="${GITHUB_REPOSITORY#*/}"
           mkdir -p /tmp/binaries
@@ -66,7 +70,7 @@ jobs:
 
       - name: Generate formulae
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ inputs.tag }}
           TOOL_NAME: ${{ steps.download.outputs.tool_name }}
           SHA_DARWIN_ARM64: ${{ steps.checksums.outputs.sha_darwin_arm64 }}
           SHA_DARWIN_AMD64: ${{ steps.checksums.outputs.sha_darwin_amd64 }}
@@ -137,7 +141,7 @@ jobs:
       - name: Open PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ inputs.tag }}
           TOOL_NAME: ${{ steps.download.outputs.tool_name }}
         run: |
           cd /tmp/homebrew-tap

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -101,7 +101,7 @@ Runbooks ensure your documentation always works because it actually executes. Ex
 
 <CardGrid>
   <Card title="Install Runbooks" icon="setting">
-    Get up and running in minutes. Build from source or use a pre-built binary.
+    Get up and running in minutes. Install via Homebrew, download a pre-built binary, or build from source.
     
     [Installation Guide →](/intro/installation/)
   </Card>

--- a/docs/src/content/docs/intro/installation.mdx
+++ b/docs/src/content/docs/intro/installation.mdx
@@ -6,9 +6,29 @@ sidebar:
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-The quickest way to install Runbooks is to download the pre-built binaries from the [GitHub releases page](https://github.com/gruntwork-io/runbooks/releases).
+### Homebrew (macOS & Linux)
+
+The quickest way to install Runbooks is via [Homebrew](https://brew.sh/):
+
+```bash
+brew install gruntwork-io/tap/runbooks
+```
+
+To install a specific version:
+
+```bash
+brew install gruntwork-io/tap/runbooks@0.5.2
+```
+
+To upgrade to the latest version:
+
+```bash
+brew upgrade gruntwork-io/tap/runbooks
+```
 
 ### Installing pre-built binaries
+
+Alternatively, you can download pre-built binaries from the [GitHub releases page](https://github.com/gruntwork-io/runbooks/releases).
 
 <Tabs>
   <TabItem label="macOS">


### PR DESCRIPTION
I should have handled this in #65 but forgot, so better late than never!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Builds**
   * Brew updates now trigger after releases, not concurrently with releases (fixed a nice race condition here)  

* **Documentation**
  * Added Homebrew installation instructions for macOS/Linux, with versioning and upgrade commands
  * Expanded installation docs to include explicit pre-built binary downloads and preserved curl-based instructions for all platforms
  * Added a reference to GitHub releases for downloading binaries

* **Chores**
  * Automated Homebrew formula update as part of the release process
<!-- end of auto-generated comment: release notes by coderabbit.ai -->