### PR TITLE
Fix stale UI state after deleting generated files

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,7 +56,7 @@ function App() {
   useWatchMode(handleFileChange, getRunbookResult.data?.isWatchMode ?? false);
   
   // Get file tree state to detect when files are generated
-  const { fileTree } = useFileTree()
+  const { fileTree, setFileTree } = useFileTree()
   const hasFiles = hasGeneratedFiles(fileTree)
   
   // Get git worktree state to detect when a repo is cloned
@@ -141,8 +141,7 @@ function App() {
   const handleFilesDeleted = () => {
     setShowGeneratedFilesAlert(false);
     setAlertDismissedThisSession(true);
-    // Optionally refetch the file tree to clear it from the UI
-    // The file tree context doesn't expose a clear method, so we'll just close the alert
+    setFileTree(null);
   };
 
   return (

--- a/web/src/components/layout/GeneratedFilesAlert/GeneratedFilesAlert.tsx
+++ b/web/src/components/layout/GeneratedFilesAlert/GeneratedFilesAlert.tsx
@@ -51,10 +51,9 @@ export function GeneratedFilesAlert({
   };
 
   const handleDeleteFiles = async () => {
-    await deleteFiles();
-    
-    // Check if deletion was successful
-    if (!deleteError) {
+    const success = await deleteFiles();
+
+    if (success) {
       if (dontAskAgain) {
         dismissGeneratedFilesAlert();
       }

--- a/web/src/hooks/useApiGeneratedFilesDelete.ts
+++ b/web/src/hooks/useApiGeneratedFilesDelete.ts
@@ -13,7 +13,7 @@ export interface GeneratedFilesDeleteResult {
  * Return type for the delete hook
  */
 export interface UseApiGeneratedFilesDeleteReturn {
-  deleteFiles: () => Promise<void>;
+  deleteFiles: () => Promise<boolean>;
   isDeleting: boolean;
   deleteError: { message: string; details?: string } | null;
   deleteSuccess: GeneratedFilesDeleteResult | null;
@@ -27,7 +27,7 @@ export function useApiGeneratedFilesDelete(): UseApiGeneratedFilesDeleteReturn {
   const [deleteError, setDeleteError] = useState<{ message: string; details?: string } | null>(null);
   const [deleteSuccess, setDeleteSuccess] = useState<GeneratedFilesDeleteResult | null>(null);
 
-  const deleteFiles = useCallback(async () => {
+  const deleteFiles = useCallback(async (): Promise<boolean> => {
     setIsDeleting(true);
     setDeleteError(null);
     setDeleteSuccess(null);
@@ -44,18 +44,20 @@ export function useApiGeneratedFilesDelete(): UseApiGeneratedFilesDeleteReturn {
           details: errorData?.details,
         });
         setIsDeleting(false);
-        return;
+        return false;
       }
 
       const data: GeneratedFilesDeleteResult = await response.json();
       setDeleteSuccess(data);
       setIsDeleting(false);
+      return true;
     } catch (err) {
       setDeleteError({
         message: 'Failed to delete files',
         details: err instanceof Error ? err.message : 'Unknown error',
       });
       setIsDeleting(false);
+      return false;
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the generated files deletion flow:

- **Stale file tree**: After clicking "Delete Files" in the alert dialog, `handleFilesDeleted` never cleared the file tree state, leaving deleted files visible in the artifacts panel. Now calls `setFileTree(null)` to clear them.
- **Stale closure on error check**: `handleDeleteFiles` checked the closure-captured `deleteError` (always `null`) instead of the actual API result, so the alert would silently dismiss even when deletion failed. `deleteFiles()` now returns `Promise<boolean>` so callers can reliably detect success without reading stale React state.

Supersedes #70 — that PR addressed these same two bugs but also included unnecessary changes (a `renderingEnabled` context mechanism for a race condition that doesn't exist in practice, and backend tests that just verify Go stdlib behavior). This PR extracts only the legitimate fixes.

## Test plan

- [ ] Load a runbook that has existing generated files in the output directory
- [ ] Verify the "Existing Generated Files Detected" alert appears
- [ ] Click "Delete Files" and verify the file tree panel clears
- [ ] Simulate a network error during deletion and verify the error dialog appears (not silently dismissed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * File tree now correctly clears when generated files are deleted.
  * Improved file deletion process with more reliable success tracking to better indicate when operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->