### PR TITLE
Update GitClone working directory to be based on what runbook opens with

### DIFF
--- a/api/git_clone.go
+++ b/api/git_clone.go
@@ -262,18 +262,19 @@ func HandleGitClone(sm *SessionManager, workingDir string) gin.HandlerFunc {
 			return
 		}
 
-		// Get session context for working directory
+		// Verify session is valid
 		execCtx := GetSessionExecContext(c)
 		if execCtx == nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Session context not found"})
 			return
 		}
 
-		// Determine the effective working directory
-		effectiveWorkDir := execCtx.WorkDir
-		if effectiveWorkDir == "" {
-			effectiveWorkDir = workingDir
-		}
+		// Always resolve clone paths relative to the initial working directory
+		// (the --working-dir passed at server start), NOT the session's current
+		// working directory. The session WorkDir can drift when <Command> blocks
+		// execute scripts that change directory (e.g. `cd infra-catalog`), which
+		// would cause a second <GitClone> to nest inside the first clone's tree.
+		effectiveWorkDir := workingDir
 
 		absolutePath, relativePath := ResolveClonePaths(req.LocalPath, req.URL, effectiveWorkDir)
 
@@ -993,6 +994,11 @@ func isValidGitURL(rawURL string) bool {
 
 	// git:// protocol
 	if strings.HasPrefix(rawURL, "git://") {
+		return true
+	}
+
+	// file:// protocol (local repos)
+	if strings.HasPrefix(rawURL, "file://") {
 		return true
 	}
 

--- a/api/git_clone_test.go
+++ b/api/git_clone_test.go
@@ -1,7 +1,17 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInjectGitToken(t *testing.T) {
@@ -193,4 +203,78 @@ func TestIsValidGitHubRepoName(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGitCloneUsesInitialWorkDir verifies that HandleGitClone resolves clone
+// paths relative to the initial working directory (passed at server start),
+// NOT the session's current working directory. This prevents the second
+// GitClone from nesting inside the first clone when a Command block changes
+// the session's working directory in between (issue #94).
+func TestGitCloneUsesInitialWorkDir(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Create the initial working directory and a subdirectory that simulates
+	// the result of a previous clone + cd.
+	initialWorkDir := t.TempDir()
+	subDir := filepath.Join(initialWorkDir, "repo-a")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+
+	// Set up session with initial working directory
+	sm := NewSessionManager()
+	sessionResp, err := sm.CreateSession(initialWorkDir)
+	require.NoError(t, err)
+
+	// Simulate a Command block changing the session's working directory
+	// (this is what happens when a script does `cd repo-a`)
+	err = sm.UpdateSessionEnv(map[string]string{}, subDir)
+	require.NoError(t, err)
+
+	// Verify session WorkDir has drifted
+	session, ok := sm.GetSession()
+	require.True(t, ok)
+	assert.Equal(t, subDir, session.WorkingDir, "session WorkDir should have drifted to subDir")
+
+	// Set up a router with the clone handler using the INITIAL working directory
+	router := gin.New()
+	router.POST("/api/git/clone", SessionAuthMiddleware(sm), HandleGitClone(sm, initialWorkDir))
+
+	// Send a clone request — the URL is invalid on purpose (we only care about
+	// the path resolution, not whether the clone actually succeeds). The handler
+	// will attempt the clone and fail, but we can check the 409 "directory_exists"
+	// behavior to verify path resolution.
+
+	// Create a directory at initialWorkDir/repo-b to trigger the 409 response,
+	// which reveals the resolved absolute path in the response body.
+	repoBDir := filepath.Join(initialWorkDir, "repo-b")
+	require.NoError(t, os.MkdirAll(repoBDir, 0o755))
+
+	body := GitCloneRequest{
+		URL: "https://github.com/example/repo-b.git",
+	}
+	jsonBody, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/git/clone", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+sessionResp.Token)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// We should get a 409 because repo-b exists in the INITIAL working directory.
+	// If the bug were still present, the handler would look for repo-b inside
+	// the drifted subDir (repo-a/repo-b), which doesn't exist, and would proceed
+	// to clone — returning 200 with an SSE stream instead of 409.
+	assert.Equal(t, http.StatusConflict, w.Code,
+		"clone should resolve relative to initial workDir, not drifted session WorkDir. Body: %s", w.Body.String())
+
+	var respBody map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &respBody)
+	require.NoError(t, err)
+	assert.Equal(t, "directory_exists", respBody["error"])
+
+	// Verify the absolute path in the response points to initialWorkDir/repo-b
+	// (NOT subDir/repo-b)
+	assert.Equal(t, repoBDir, respBody["absolutePath"],
+		"absolutePath should be relative to initial workDir")
 }

--- a/testdata/sample-runbooks/dual-clone/runbook.mdx
+++ b/testdata/sample-runbooks/dual-clone/runbook.mdx
@@ -1,0 +1,35 @@
+# Working Directory Behavior Test
+
+This runbook tests that working directory behaves correctly across different
+block types and scenarios.
+
+## Scenario 1: Command blocks inherit and propagate CWD
+
+A Command block that changes directory should affect subsequent Command blocks.
+
+<Command
+    id="cd-subdir"
+    command="mkdir -p subdir && cd subdir && pwd"
+    title="Change directory to subdir"
+    description="Creates ./subdir and cd's into it"
+/>
+
+<Command
+    id="verify-cwd"
+    command="pwd"
+    title="Verify CWD"
+    description="Should show that we're now inside subdir"
+/>
+
+## Scenario 2: GitClone resolves relative to the initial working directory
+
+Even though the Command above changed the session CWD to `subdir/`,
+a GitClone block should still resolve paths relative to the *initial*
+working directory (where the runbook server was started).
+
+<GitClone
+    id="clone-after-cd"
+    title="Clone after cd"
+    description="Enter a git URL to clone"
+    usePty={false}
+/>

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -1,5 +1,5 @@
 import { test as base, expect, type ConsoleMessage } from "@playwright/test";
-import { type ChildProcess, spawn } from "child_process";
+import { type ChildProcess, execSync, spawn } from "child_process";
 import fs from "fs";
 import net from "net";
 import os from "os";
@@ -131,6 +131,8 @@ type RunbookServerFixture = {
   serverPort: number;
   /** Console messages collected from the page during the test. */
   consoleMessages: ConsoleMessage[];
+  /** The temporary working directory used by the server. */
+  workDir: string;
 };
 
 /**
@@ -151,9 +153,14 @@ export const test = base.extend<RunbookServerFixture>({
     await use(await findFreePort());
   }, { scope: "test" }],
 
-  serveRunbook: async ({ page, consoleMessages, serverPort }, use, testInfo) => {
+  workDir: [async ({}, use, testInfo) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `runbooks-e2e-${testInfo.workerIndex}-`));
+    await use(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }, { scope: "test" }],
+
+  serveRunbook: async ({ page, consoleMessages, serverPort, workDir }, use) => {
     let serverProcess: ChildProcess | null = null;
-    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), `runbooks-e2e-${testInfo.workerIndex}-`));
 
     page.on("console", (msg) => consoleMessages.push(msg));
 
@@ -208,7 +215,6 @@ export const test = base.extend<RunbookServerFixture>({
     if (serverProcess) {
       await killProcess(serverProcess);
     }
-    fs.rmSync(workDir, { recursive: true, force: true });
   },
 });
 
@@ -302,4 +308,30 @@ export function expectNoConsoleErrors(messages: ConsoleMessage[]) {
       .join("\n\n");
     expect.soft(unexpected, `Browser console errors:\n\n${summary}\n`).toHaveLength(0);
   }
+}
+
+/**
+ * Create a local bare git repo with one commit, suitable for cloning
+ * in tests without needing GitHub credentials or network access.
+ *
+ * Returns the absolute path to the bare repo (use as a `file://` URL).
+ */
+export function createLocalBareRepo(parentDir: string, name = "bare-test-repo"): string {
+  const bareRepoPath = path.join(parentDir, `${name}.git`);
+  execSync(`git init --bare "${bareRepoPath}"`, { stdio: "ignore" });
+
+  const seedDir = path.join(parentDir, `_seed-${name}`);
+  execSync([
+    `git init "${seedDir}"`,
+    `cd "${seedDir}"`,
+    `git checkout -b main`,
+    `echo "hello" > README.md`,
+    `git add .`,
+    `git -c user.name=test -c user.email=test@test.com commit -m "init"`,
+    `git remote add origin "${bareRepoPath}"`,
+    `git push origin main`,
+  ].join(" && "), { stdio: "ignore" });
+  fs.rmSync(seedDir, { recursive: true, force: true });
+
+  return bareRepoPath;
 }

--- a/web/e2e/test-sample-runbooks.spec.ts
+++ b/web/e2e/test-sample-runbooks.spec.ts
@@ -1,5 +1,7 @@
 import { execSync } from "child_process";
-import { test, expect, expectNoConsoleErrors, trustRunbook, deleteFilesIfPrompted, getFilesPanel } from "./fixtures";
+import fs from "fs";
+import path from "path";
+import { test, expect, expectNoConsoleErrors, trustRunbook, deleteFilesIfPrompted, getFilesPanel, createLocalBareRepo } from "./fixtures";
 
 /**
  * End-to-end tests for the sample runbooks in testdata/sample-runbooks/.
@@ -571,6 +573,79 @@ test.describe("sample-runbooks/next-app", () => {
     // Files go to the worktree (target="worktree"), so they appear in the changed files panel.
     const changed = getFilesPanel(page, "changed");
     await expect(changed.getTreeItem("WelcomeCard.tsx")).toBeVisible({ timeout: 10_000 });
+
+    expectNoConsoleErrors(consoleMessages);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: dual-clone (issue #94 regression test)
+// Working directory behavior across block types.
+// ---------------------------------------------------------------------------
+test.describe("sample-runbooks/dual-clone", () => {
+  test("Command blocks propagate CWD to subsequent commands", async ({ page, serveRunbook, serverPort, consoleMessages }) => {
+    await serveRunbook("testdata/sample-runbooks/dual-clone");
+    await page.goto(`http://localhost:${serverPort}/`);
+
+    const markdownBody = page.getByTestId("runbook-content");
+    await expect(markdownBody).toBeVisible({ timeout: 15_000 });
+    await trustRunbook(page);
+
+    // Run the first Command that cd's into subdir.
+    const cdBlock = page.getByTestId("cd-subdir");
+    await expect(cdBlock.getByRole("button", { name: "Run" })).toBeEnabled({ timeout: 5_000 });
+    await cdBlock.getByRole("button", { name: "Run" }).click();
+    await expect(cdBlock.getByText("Success")).toBeVisible({ timeout: 15_000 });
+
+    // Run the second Command that just prints pwd.
+    // It should inherit the changed CWD and print "<workDir>/subdir".
+    const pwdBlock = page.getByTestId("verify-cwd");
+    await expect(pwdBlock.getByRole("button", { name: "Run" })).toBeEnabled({ timeout: 5_000 });
+    await pwdBlock.getByRole("button", { name: "Run" }).click();
+    await expect(pwdBlock.getByText("Success")).toBeVisible({ timeout: 15_000 });
+
+    // Verify the pwd output contains "subdir" (the CWD propagated)
+    await pwdBlock.getByText("View Logs").click();
+    await expect(pwdBlock.getByText(/subdir/)).toBeVisible();
+
+    expectNoConsoleErrors(consoleMessages);
+  });
+
+  test("GitClone resolves paths relative to initial workDir after cd (issue #94)", async ({ page, serveRunbook, serverPort, workDir, consoleMessages }) => {
+    // Create a local bare git repo so we can clone without GitHub credentials.
+    const bareRepoPath = createLocalBareRepo(workDir);
+
+    await serveRunbook("testdata/sample-runbooks/dual-clone");
+    await page.goto(`http://localhost:${serverPort}/`);
+
+    const markdownBody = page.getByTestId("runbook-content");
+    await expect(markdownBody).toBeVisible({ timeout: 15_000 });
+    await trustRunbook(page);
+
+    // Run the Command block that cd's into subdir — this drifts the session CWD.
+    const cdBlock = page.getByTestId("cd-subdir");
+    await expect(cdBlock.getByRole("button", { name: "Run" })).toBeEnabled({ timeout: 5_000 });
+    await cdBlock.getByRole("button", { name: "Run" }).click();
+    await expect(cdBlock.getByText("Success")).toBeVisible({ timeout: 15_000 });
+
+    // Now use the GitClone block to clone the local bare repo via the UI.
+    const cloneBlock = page.getByTestId("clone-after-cd");
+    const urlInput = cloneBlock.getByRole("textbox").first();
+    await urlInput.fill(`file://${bareRepoPath}`);
+    // Set an explicit local path so the clone destination is predictable
+    // (file:// URLs don't parse into a clean repo name).
+    await cloneBlock.getByText("Additional Settings").click();
+    const localPathInput = cloneBlock.getByPlaceholder("Defaults to repo name");
+    await localPathInput.fill("cloned-repo");
+    await cloneBlock.getByRole("button", { name: "Clone" }).click();
+    await expect(cloneBlock.getByText("Clone complete", { exact: true })).toBeVisible({ timeout: 15_000 });
+
+    // The repo should be cloned as a sibling to subdir (in the initial workDir),
+    // NOT nested inside subdir. This is the core assertion for issue #94.
+    const correctPath = path.join(workDir, "cloned-repo");
+    const buggyPath = path.join(workDir, "subdir", "cloned-repo");
+    expect(fs.existsSync(correctPath), `expected clone at ${correctPath}`).toBe(true);
+    expect(fs.existsSync(buggyPath), `clone should NOT be nested inside subdir`).toBe(false);
 
     expectNoConsoleErrors(consoleMessages);
   });


### PR DESCRIPTION
## Summary

   - `HandleGitClone` now resolves clone paths relative to the initial `--working-dir` instead of the session's current working directory, which drifts when `<Command>` blocks run scripts that `cd`
   - Added `file://` as a valid git URL scheme in `isValidGitURL`
   - Added `createLocalBareRepo()` test helper for cloning in e2e tests without GitHub credentials

   ## Test plan

   - [x] Go unit test: simulates drifted session CWD, verifies clone resolves to initial workDir
   - [x] Playwright e2e: runs a Command that `cd`s, then clones via the UI, asserts the repo lands as a sibling (not nested)
   - [x] Playwright e2e: verifies Command CWD propagation still works between Command blocks
   - [x] Full test suite passes (14 e2e + all Go tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed git clone destination paths being incorrectly nested when session working directory changes during command execution. Clone paths now consistently resolve based on the initial server working directory.

* **New Features**
  * Extended Git URL validation to support `file://` protocol in clone operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->