### PR TITLE
Add REPO_OWNER and REPO_NAME outputs to GitClone block

### DIFF
--- a/api/git_clone.go
+++ b/api/git_clone.go
@@ -377,6 +377,10 @@ func HandleGitClone(sm *SessionManager, workingDir string) gin.HandlerFunc {
 		if req.Ref != "" {
 			outputs["REF"] = req.Ref
 		}
+		if owner, repo := parseOwnerRepoFromURL(req.URL); owner != "" {
+			outputs["REPO_OWNER"] = owner
+			outputs["REPO_NAME"] = repo
+		}
 		sse.outputs(outputs)
 		sse.status("success", 0)
 		sse.done()

--- a/api/git_clone.go
+++ b/api/git_clone.go
@@ -371,15 +371,16 @@ func HandleGitClone(sm *SessionManager, workingDir string) gin.HandlerFunc {
 
 		// Send outputs event so the block can register outputs in RunbookContext
 		outputs := map[string]string{
-			"CLONE_PATH": absolutePath,
-			"FILE_COUNT": fmt.Sprintf("%d", fileCount),
+			"clone_path": absolutePath,
+			"file_count": fmt.Sprintf("%d", fileCount),
+			"repo_url":   req.URL,
 		}
 		if req.Ref != "" {
-			outputs["REF"] = req.Ref
+			outputs["ref"] = req.Ref
 		}
 		if owner, repo := parseOwnerRepoFromURL(req.URL); owner != "" {
-			outputs["REPO_OWNER"] = owner
-			outputs["REPO_NAME"] = repo
+			outputs["repo_owner"] = owner
+			outputs["repo_name"] = repo
 		}
 		sse.outputs(outputs)
 		sse.status("success", 0)

--- a/api/testing/executor.go
+++ b/api/testing/executor.go
@@ -1494,10 +1494,10 @@ func (e *TestExecutor) executeGitClone(block api.ParsedComponent, step TestStep,
 	fileCount := api.CountFiles(absolutePath)
 
 	// Store outputs
-	result.Outputs["CLONE_PATH"] = absolutePath
-	result.Outputs["FILE_COUNT"] = fmt.Sprintf("%d", fileCount)
+	result.Outputs["clone_path"] = absolutePath
+	result.Outputs["file_count"] = fmt.Sprintf("%d", fileCount)
 	if ref != "" {
-		result.Outputs["REF"] = ref
+		result.Outputs["ref"] = ref
 	}
 
 	// Store in block outputs for downstream access

--- a/api/testing/executor_test.go
+++ b/api/testing/executor_test.go
@@ -731,11 +731,11 @@ func TestExecuteGitClone_Success(t *testing.T) {
 	require.NotNil(t, cloneResult, "should have a step result for clone-test")
 	assert.True(t, cloneResult.Passed)
 	assert.Equal(t, "success", cloneResult.ActualStatus)
-	assert.NotEmpty(t, cloneResult.Outputs["CLONE_PATH"])
-	assert.Equal(t, "2", cloneResult.Outputs["FILE_COUNT"]) // README.md + src/main.go
+	assert.NotEmpty(t, cloneResult.Outputs["clone_path"])
+	assert.Equal(t, "2", cloneResult.Outputs["file_count"]) // README.md + src/main.go
 
 	// Verify cloned files exist on disk
-	clonePath := cloneResult.Outputs["CLONE_PATH"]
+	clonePath := cloneResult.Outputs["clone_path"]
 	_, err = os.Stat(filepath.Join(clonePath, "README.md"))
 	assert.NoError(t, err, "README.md should exist in clone")
 	_, err = os.Stat(filepath.Join(clonePath, "src/main.go"))
@@ -799,11 +799,11 @@ func TestExecuteGitClone_WithRef(t *testing.T) {
 	}
 	require.NotNil(t, cloneResult)
 	assert.True(t, cloneResult.Passed)
-	assert.Equal(t, "feature", cloneResult.Outputs["REF"])
-	assert.Equal(t, "2", cloneResult.Outputs["FILE_COUNT"]) // main.txt + feature.txt
+	assert.Equal(t, "feature", cloneResult.Outputs["ref"])
+	assert.Equal(t, "2", cloneResult.Outputs["file_count"]) // main.txt + feature.txt
 
 	// Verify the feature branch file exists
-	clonePath := cloneResult.Outputs["CLONE_PATH"]
+	clonePath := cloneResult.Outputs["clone_path"]
 	_, err = os.Stat(filepath.Join(clonePath, "feature.txt"))
 	assert.NoError(t, err, "feature.txt should exist when cloning the feature branch")
 }
@@ -847,7 +847,7 @@ func TestExecuteGitClone_SparseCheckout(t *testing.T) {
 	require.NotNil(t, cloneResult)
 	assert.True(t, cloneResult.Passed)
 
-	clonePath := cloneResult.Outputs["CLONE_PATH"]
+	clonePath := cloneResult.Outputs["clone_path"]
 	// Sparse checkout should have docs/ files
 	_, err = os.Stat(filepath.Join(clonePath, "docs/README.md"))
 	assert.NoError(t, err, "docs/README.md should exist in sparse checkout")

--- a/docs/src/content/docs/authoring/blocks/DirPicker.mdx
+++ b/docs/src/content/docs/authoring/blocks/DirPicker.mdx
@@ -123,7 +123,7 @@ The `outputPath` resolves `{{ .outputs.*.* }}` expressions client-side using blo
 
 ### How It Works
 
-1. DirPicker resolves its root directory from `rootDir` (if set) or by reading the `CLONE_PATH` output of the referenced `<GitClone>` block once the clone completes.
+1. DirPicker resolves its root directory from `rootDir` (if set) or by reading the `clone_path` output of the referenced `<GitClone>` block once the clone completes.
 2. It fetches the immediate subdirectories via `GET /api/workspace/dirs`.
 3. Each dropdown selection triggers a fetch for the next level's subdirectories, building a cascading drill-down.
 4. An editable text input below the dropdowns shows the composed path. Users can edit this directly for full control.

--- a/docs/src/content/docs/authoring/blocks/GitClone.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitClone.mdx
@@ -159,9 +159,12 @@ After a successful clone, the GitClone block produces outputs that can be refere
 
 | Output | Description | Example |
 |--------|-------------|---------|
-| `CLONE_PATH` | Absolute path where files were cloned | `/Users/josh/Code/my-repo` |
-| `FILE_COUNT` | Number of files downloaded (excluding `.git`) | `127` |
-| `REF` | The ref (branch/tag) that was cloned, if specified | `v1.2.0` |
+| `clone_path` | Absolute path where files were cloned | `/Users/josh/Code/my-repo` |
+| `file_count` | Number of files downloaded (excluding `.git`) | `127` |
+| `ref` | The ref (branch/tag) that was cloned, if specified | `v1.2.0` |
+| `repo_owner` | The GitHub organization or user that owns the repo | `acme-corp` |
+| `repo_name` | The repository name | `infrastructure-live` |
+| `repo_url` | The full URL of the cloned repository | `https://github.com/acme-corp/infrastructure-live` |
 
 Reference outputs in downstream blocks using template variables:
 
@@ -169,7 +172,7 @@ Reference outputs in downstream blocks using template variables:
 <Command
   id="list-files"
   title="List Cloned Files"
-  command="ls -la {{ .outputs.clone_repo.CLONE_PATH }}"
+  command="ls -la {{ .outputs.clone_repo.clone_path }}"
 />
 ```
 
@@ -203,6 +206,6 @@ The GitClone block includes a collapsible "View Logs" section (identical to the 
   id="apply-changes"
   githubAuthId="gh-auth"
   title="Apply OpenTofu Changes"
-  command="cd {{ .outputs.clone_infra.CLONE_PATH }} && tofu apply -auto-approve"
+  command="cd {{ .outputs.clone_infra.clone_path }} && tofu apply -auto-approve"
 />
 ```

--- a/testdata/feature-demos/git-clone/runbook_test.yml
+++ b/testdata/feature-demos/git-clone/runbook_test.yml
@@ -15,10 +15,10 @@ tests:
     assertions:
       - type: output_exists
         block: clone-subdir
-        output: FILE_COUNT
+        output: file_count
       - type: output_exists
         block: clone-subdir
-        output: CLONE_PATH
+        output: clone_path
       - type: dir_exists
         path: "../runbooks-docs"
 

--- a/testdata/sample-runbooks/openclaw/scripts/release-catalog.sh
+++ b/testdata/sample-runbooks/openclaw/scripts/release-catalog.sh
@@ -9,7 +9,7 @@ set -e
 DRY_RUN="${RUNBOOK_DRY_RUN:-false}"
 
 MODULE_NAME="{{ .inputs.ModuleName }}"
-CATALOG_DIR="{{ .outputs.clone_catalog.CLONE_PATH }}"
+CATALOG_DIR="{{ .outputs.clone_catalog.clone_path }}"
 RELEASE_TAG="{{ .inputs.ReleaseTag }}"
 
 if [[ "$DRY_RUN" == "true" ]]; then

--- a/web/src/components/mdx/DirPicker/hooks/useDirPicker.ts
+++ b/web/src/components/mdx/DirPicker/hooks/useDirPicker.ts
@@ -39,7 +39,7 @@ export function useDirPicker({ id, rootDir, gitCloneId, maxLevels }: UseDirPicke
     if (!gitCloneId) return null
     const normalizedId = normalizeBlockId(gitCloneId)
     const blockData = allOutputs[normalizedId]
-    return blockData?.values?.CLONE_PATH ?? null
+    return blockData?.values?.clone_path ?? null
   }, [rootDir, gitCloneId, allOutputs])
 
   // Whether the root directory is available (immediately if rootDir is set, otherwise when GitClone completes)

--- a/web/src/components/mdx/GitClone/GitClone.tsx
+++ b/web/src/components/mdx/GitClone/GitClone.tsx
@@ -604,7 +604,7 @@ function GitClone({
         <div className="mt-4 space-y-2">
           <ViewOutputs
             outputs={registeredOutputs}
-            autoOpen={registeredOutputs !== null && Object.keys(registeredOutputs).length > 0}
+            autoOpen={false}
           />
         </div>
       )}

--- a/web/src/components/mdx/GitClone/GitClone.tsx
+++ b/web/src/components/mdx/GitClone/GitClone.tsx
@@ -2,12 +2,13 @@ import { GitBranch, CheckCircle, XCircle, Loader2, AlertTriangle, Info, Copy, Ch
 import { useState, useEffect, useMemo, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { ViewLogs, InlineMarkdown, BlockIdLabel } from "@/components/mdx/_shared"
+import { ViewLogs, ViewOutputs, InlineMarkdown, BlockIdLabel } from "@/components/mdx/_shared"
 import { copyTextToClipboard } from "@/lib/utils"
 import { useComponentIdRegistry } from "@/contexts/ComponentIdRegistry"
 import { useErrorReporting } from "@/contexts/useErrorReporting"
 import { useTelemetry } from "@/contexts/useTelemetry"
 import { useGitWorkTree } from "@/contexts/useGitWorkTree"
+import { useOutputs } from "@/contexts/useRunbook"
 import { useGitClone } from "./hooks/useGitClone"
 import { GitHubBrowser } from "./components/GitHubBrowser"
 import { CloneResultDisplay } from "./components/CloneResult"
@@ -136,6 +137,13 @@ function GitClone({
     fetchRepos,
     fetchRefs,
   } = useGitClone({ id, gitHubAuthId })
+
+  // Get registered outputs for this block
+  const outputValues = useOutputs(id)
+  const registeredOutputs = useMemo(() => {
+    if (!outputValues || outputValues.length === 0) return null
+    return Object.fromEntries(outputValues.map(o => [o.name, o.value]))
+  }, [outputValues])
 
   // Form state — initialized from resolved values
   const [gitUrl, setGitUrl] = useState(resolvedUrl)
@@ -587,6 +595,16 @@ function GitClone({
             status={cloneStatus === 'running' ? 'running' : cloneStatus === 'success' ? 'success' : cloneStatus === 'fail' ? 'fail' : 'pending'}
             autoOpen={cloneStatus === 'running'}
             blockId={id}
+          />
+        </div>
+      )}
+
+      {/* View Outputs - below logs */}
+      {cloneStatus === 'success' && (
+        <div className="mt-4 space-y-2">
+          <ViewOutputs
+            outputs={registeredOutputs}
+            autoOpen={registeredOutputs !== null && Object.keys(registeredOutputs).length > 0}
           />
         </div>
       )}

--- a/web/src/components/mdx/_shared/components/ViewOutputs.tsx
+++ b/web/src/components/mdx/_shared/components/ViewOutputs.tsx
@@ -100,7 +100,7 @@ export function ViewOutputs({
 
       {/* Outputs Table */}
       {showOutputs && (
-        <div className="border-t border-gray-200 p-3 bg-gray-50 max-h-64 overflow-y-auto">
+        <div className="border-t border-gray-200 p-3 bg-gray-50 max-h-96 overflow-y-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-200">


### PR DESCRIPTION
## Summary
- Display GitClone block outputs in the runbook UI using the same `ViewOutputs` component as Command blocks
- Rename all GitClone output keys from `SCREAMING_CASE` to `snake_case` (`clone_path`, `file_count`, `ref`, `repo_owner`, `repo_name`) to match the convention used by script-authored outputs
- Add new `repo_url` output with the full clone URL
- Increase `ViewOutputs` max height from 256px to 384px so typical output counts aren't clipped

## Test plan
- [x] Verified outputs render correctly after a successful clone
- [x] Updated all references in Go code, tests, docs, DirPicker, and sample runbooks
- [x] `runbook_test.yml` assertions updated and passing