### PR TITLE
Add collapsible sections to Inputs block

### DIFF
--- a/api/boilerplate_config.go
+++ b/api/boilerplate_config.go
@@ -253,6 +253,7 @@ type rawXVariable struct {
 	Schema              map[string]string `yaml:"x-schema"`
 	SchemaInstanceLabel string            `yaml:"x-schema-instance-label"`
 	Section             string            `yaml:"x-section"`
+	Collapsed           *bool             `yaml:"x-collapsed"`
 }
 
 // parseRawXVariables parses the raw YAML once and returns the x-extension fields.
@@ -313,9 +314,26 @@ func extractSchemaInstanceLabelsFromYAML(yamlContent string) map[string]string {
 // Variables without a section use "" (empty string) as the section name.
 // The unnamed section ("") is always placed first if it exists.
 func extractSectionGroupings(rawVars []rawXVariable) []Section {
-	return groupIntoSections(rawVars, func(v rawXVariable) (string, string) {
+	sections := groupIntoSections(rawVars, func(v rawXVariable) (string, string) {
 		return v.Name, v.Section
 	})
+
+	// Apply x-collapsed flags: use the first x-collapsed value found for each section.
+	collapsedBySection := make(map[string]bool)
+	for _, v := range rawVars {
+		if v.Collapsed != nil {
+			if _, exists := collapsedBySection[v.Section]; !exists {
+				collapsedBySection[v.Section] = *v.Collapsed
+			}
+		}
+	}
+	for i := range sections {
+		if collapsed, ok := collapsedBySection[sections[i].Name]; ok {
+			sections[i].Collapsed = collapsed
+		}
+	}
+
+	return sections
 }
 
 // groupIntoSections collects items into ordered sections, with the unnamed

--- a/api/boilerplate_config_test.go
+++ b/api/boilerplate_config_test.go
@@ -657,6 +657,32 @@ func TestExtractSectionGroupings(t *testing.T) {
 			yaml:             `variables: []`,
 			expectedSections: []Section{},
 		},
+		{
+			name: "x-collapsed on section",
+			yaml: `variables:
+  - name: Var1
+    type: string
+    x-section: Basic
+  - name: Var2
+    type: string
+    x-section: Advanced
+    x-collapsed: true`,
+			expectedSections: []Section{
+				{Name: "Basic", Variables: []string{"Var1"}},
+				{Name: "Advanced", Variables: []string{"Var2"}, Collapsed: true},
+			},
+		},
+		{
+			name: "x-collapsed false is explicit",
+			yaml: `variables:
+  - name: Var1
+    type: string
+    x-section: Open Section
+    x-collapsed: false`,
+			expectedSections: []Section{
+				{Name: "Open Section", Variables: []string{"Var1"}, Collapsed: false},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/api/types.go
+++ b/api/types.go
@@ -260,6 +260,7 @@ type ValidationRule struct {
 type Section struct {
 	Name      string   `json:"name"`      // Section name ("" for unnamed/default section)
 	Variables []string `json:"variables"` // Variable names in this section (in declaration order)
+	Collapsed bool     `json:"collapsed"` // Whether the section should be initially collapsed in the UI
 }
 
 // OutputDependency represents a reference to another block's output in a template.

--- a/web/src/components/mdx/_shared/components/BoilerplateInputsForm.tsx
+++ b/web/src/components/mdx/_shared/components/BoilerplateInputsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react'
+import React, { useMemo, useState, useEffect, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
 import type { BoilerplateVariable } from '@/types/boilerplateVariable'
 import type { BoilerplateConfig } from '@/types/boilerplateConfig'
@@ -10,6 +10,7 @@ import { FormStatus } from './FormStatus'
 import { UnmetDependenciesWarning } from './UnmetDependenciesWarning'
 import { BlockIdLabel } from './BlockIdLabel'
 import type { BlockOutput } from '@/lib/templateUtils'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 
 /**
  * Main form component for rendering a webform to initialize boilerplate variables
@@ -181,6 +182,25 @@ export const BoilerplateInputsForm: React.FC<BoilerplateInputsFormProps> = ({
   // Determine if we should use section-based rendering
   const hasSections = boilerplateConfig?.sections && boilerplateConfig.sections.length > 0
 
+  // Track collapsed state per section, initialized from the API's collapsed flag
+  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>(() => {
+    if (!boilerplateConfig?.sections) return {}
+    const initial: Record<string, boolean> = {}
+    for (const section of boilerplateConfig.sections) {
+      if (section.name) {
+        initial[section.name] = section.collapsed ?? false
+      }
+    }
+    return initial
+  })
+
+  const toggleSection = useCallback((sectionName: string) => {
+    setCollapsedSections(prev => ({
+      ...prev,
+      [sectionName]: !prev[sectionName]
+    }))
+  }, [])
+
   /**
    * Handles form input changes
    * @param variableName - Name of the variable being changed
@@ -263,15 +283,29 @@ export const BoilerplateInputsForm: React.FC<BoilerplateInputsFormProps> = ({
         )
       }
 
-      // For named sections, render with a header
+      // For named sections, render with a collapsible header
+      const isCollapsed = collapsedSections[section.name] ?? false
       return (
         <div key={section.name} className="space-y-4">
-          <h3 className="text-lg font-semibold text-gray-800 pt-5 pb-1 border-b border-gray-400">
-            {section.name}
-          </h3>
-          <div className="space-y-5">
-            {renderSectionVariables(section.variables)}
-          </div>
+          <button
+            type="button"
+            onClick={() => toggleSection(section.name)}
+            className="flex items-center gap-2 w-full pt-5 pb-1 border-b border-gray-400 cursor-pointer hover:border-gray-600 transition-colors"
+          >
+            {isCollapsed ? (
+              <ChevronRight className="size-4 text-gray-500 shrink-0" />
+            ) : (
+              <ChevronDown className="size-4 text-gray-500 shrink-0" />
+            )}
+            <span className="text-lg font-semibold text-gray-800">
+              {section.name}
+            </span>
+          </button>
+          {!isCollapsed && (
+            <div className="space-y-5">
+              {renderSectionVariables(section.variables)}
+            </div>
+          )}
         </div>
       )
     })

--- a/web/src/types/boilerplateConfig.ts
+++ b/web/src/types/boilerplateConfig.ts
@@ -7,6 +7,7 @@ import type { BoilerplateVariable } from './boilerplateVariable';
 export interface Section {
   name: string;        // Section name ("" for unnamed/default section)
   variables: string[]; // Variable names in this section (in declaration order)
+  collapsed: boolean;  // Whether the section should be initially collapsed in the UI
 }
 
 // OutputDependency represents a reference to another block's output found in a template file.


### PR DESCRIPTION
## Summary
- Sections in the Inputs form can now be collapsed/expanded by clicking the section header chevron
- New `x-collapsed: true` YAML property on variables controls whether a section starts collapsed
- Backend parses `x-collapsed` and propagates it via the `Section.Collapsed` JSON field
- Frontend replaces static `<h3>` section headers with clickable chevron toggles

### Usage

```yaml
variables:
  - name: FunctionName
    type: string
    x-section: Basic Configuration

  - name: MemorySize
    type: int
    x-section: Advanced Settings
    x-collapsed: true  # This section starts collapsed
```

## Test plan
- [x] Go tests pass (`TestExtractSectionGroupings` with new `x-collapsed` cases)
- [x] TypeScript type-checks clean
- [ ] Manual: verify sections toggle open/closed on click
- [ ] Manual: verify `x-collapsed: true` sections render collapsed initially
- [ ] Manual: verify sections without `x-collapsed` default to expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sections can now be configured to start in a collapsed or expanded state through YAML configuration settings.
  * Added interactive collapsible section headers with visual chevron icons that allow users to dynamically expand or collapse individual sections, improving usability and interface organization when working with complex boilerplate input configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->