### PR TITLE
Fix long lines being truncated in code viewer

### DIFF
--- a/web/src/components/artifacts/code/CodeFile.tsx
+++ b/web/src/components/artifacts/code/CodeFile.tsx
@@ -55,7 +55,8 @@ export const CodeFile = ({
           fontSize: '12px',
           border: '1px solid #ddd',
           borderRadius: '2px',
-          padding: '14px 0px'
+          padding: '14px 0px',
+          overflowX: 'auto'
         }}
         lineNumberStyle={{
           color: '#999',

--- a/web/src/components/artifacts/code/CodeFileCollection.tsx
+++ b/web/src/components/artifacts/code/CodeFileCollection.tsx
@@ -408,7 +408,8 @@ const CollapsibleCodeFile = forwardRef<HTMLDivElement, CollapsibleCodeFileProps>
                 margin: 0,
                 borderRadius: 0,
                 border: 'none',
-                padding: '14px 0px'
+                padding: '14px 0px',
+                overflowX: 'auto'
               }}
               lineNumberStyle={{
                 color: '#999',


### PR DESCRIPTION
## Summary
- Adds `overflowX: 'auto'` to the `SyntaxHighlighter` `customStyle` in `CodeFile` and `CodeFileCollection` components
- Long lines (e.g., Terraform `source =` paths with full module URLs) now show a horizontal scrollbar instead of being silently clipped

Closes #104

## Test plan
- [ ] Open a runbook that generates files with long lines (e.g., the bootstrap runbook from gruntwork-io/infrastructure-live-root-template#25)
- [ ] Verify that the code viewer shows a horizontal scrollbar for lines that exceed the container width
- [ ] Verify that short lines display normally without a scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code display by enabling horizontal scrolling for long lines of code that exceed the container width. Previously, wide code lines were clipped or caused unwanted overflow, making them difficult to read in full. Users can now scroll horizontally to view complete code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->