### PR TITLE
fix: Align GitClone test executor output names with runtime

### DIFF
--- a/cli/test/executor.ts
+++ b/cli/test/executor.ts
@@ -1211,8 +1211,8 @@ export class TestExecutor {
     // Count files
     const fileCount = this.countFilesRecursive(destPath)
 
-    result.outputs = { CLONE_PATH: destPath, FILE_COUNT: String(fileCount) }
-    if (ref) result.outputs["REF"] = ref
+    result.outputs = { clone_path: destPath, file_count: String(fileCount) }
+    if (ref) result.outputs["ref"] = ref
 
     const outputMap = new Map<string, string>()
     for (const [k, v] of Object.entries(result.outputs)) outputMap.set(k, v)


### PR DESCRIPTION
## Summary
- The CLI test executor emitted uppercase output keys (`CLONE_PATH`, `FILE_COUNT`, `REF`) for `GitClone` blocks, while the Electron runtime (`electron/main/ipc/git.ts:132`), the public docs (`docs/src/content/docs/authoring/blocks/GitClone.mdx`), and existing test assertions all use lowercase (`clone_path`, `file_count`, `ref`).
- Lowercased the three keys in `cli/test/executor.ts` so the CLI test executor matches the runtime contract.
- Resolves the `github-clone-with-auth` failure in `testdata/feature-demos/git-clone/runbook.mdx` (`Block "clone-subdir" has no output "clone_path"`).

## Test plan
- [x] `bun cli/index.ts test testdata/feature-demos/git-clone/runbook.mdx` — all 4 tests pass with `RUNBOOKS_GITHUB_TOKEN` set
- [ ] Full CLI test suite run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)