### PR TITLE
feat: Add per-execution timeoutMs override for Command blocks

### DIFF
--- a/docs/src/content/docs/authoring/blocks/Command.mdx
+++ b/docs/src/content/docs/authoring/blocks/Command.mdx
@@ -41,6 +41,7 @@ Command blocks and [Check](/authoring/blocks/check/) blocks share many features 
 - `failMessage` (string) - Message shown when command fails (default: "Failed"). Supports inline markdown.
 - `runningMessage` (string) - Message shown while running (default: "Running..."). Supports inline markdown.
 - `usePty` (boolean) - Whether to use a pseudo-terminal (PTY) for script execution. Defaults to `true`. Set to `false` to use pipes instead, which may be needed for scripts that don't work well with PTY or when simpler output handling is preferred. See [PTY Support](/authoring/blocks/advanced#pseudo-terminal-pty-support) for details.
+- `timeoutMs` (number) - Maximum time, in milliseconds, the script is allowed to run before it is killed and the block is marked as failed. Defaults to `300000` (5 minutes). Use this for scripts that legitimately take longer than the default — for example, `timeoutMs={1800000}` for a 30-minute deployment.
 
 ### Inline content
 

--- a/electron/shared/channels.ts
+++ b/electron/shared/channels.ts
@@ -315,6 +315,8 @@ export interface ExecRequest {
   templateVarValues?: Record<string, unknown>
   envVarsOverride?: Record<string, string>
   usePty?: boolean
+  /** Per-execution timeout in milliseconds. Falls back to the executor's default when omitted. */
+  timeoutMs?: number
 }
 
 export interface BoilerplateConfig {

--- a/src/domain/exec/executor.ts
+++ b/src/domain/exec/executor.ts
@@ -28,8 +28,8 @@ import type { ScriptSetup } from "./script.ts"
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Execution timeout in milliseconds (5 minutes). */
-const EXEC_TIMEOUT_MS = 5 * 60 * 1000
+/** Default execution timeout in milliseconds (5 minutes). Overridable per-request via `ExecRequest.timeoutMs`. */
+const DEFAULT_EXEC_TIMEOUT_MS = 5 * 60 * 1000
 
 // ---------------------------------------------------------------------------
 // Execution Event Types
@@ -148,6 +148,9 @@ export const executeScript = (
       fs.rm(filesDir, { recursive: true, force: true }).pipe(Effect.ignore),
     )
 
+    // Resolve the effective execution timeout: per-request override, falling back to the default.
+    const effectiveTimeoutMs = request.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS
+
     // console.log("[executor] step 4: preparing script")
     // Prepare script for execution (handles interpreter detection, env capture wrapping, temp files)
     const scriptSetup: ScriptSetup = yield* prepareScript(scriptContent, language)
@@ -203,8 +206,8 @@ export const executeScript = (
       // Wait for the process to exit
       const exitResult = yield* process.exitCode.pipe(
         Effect.timeoutFail({
-          duration: EXEC_TIMEOUT_MS,
-          onTimeout: () => new ExecTimeoutError({ timeoutMs: EXEC_TIMEOUT_MS }),
+          duration: effectiveTimeoutMs,
+          onTimeout: () => new ExecTimeoutError({ timeoutMs: effectiveTimeoutMs }),
         }),
         Effect.either,
       )
@@ -225,7 +228,7 @@ export const executeScript = (
         events.push({
           _tag: "log",
           event: {
-            line: `Script execution timed out after ${EXEC_TIMEOUT_MS / 1000 / 60} minutes`,
+            line: `Script execution timed out after ${Math.round(effectiveTimeoutMs / 1000)} seconds`,
             timestamp: new Date().toISOString(),
           },
         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,8 @@ export interface ExecRequest {
   componentId?: string
   templateVarValues?: Record<string, unknown>
   envVarsOverride?: Record<string, string>
+  /** Per-execution timeout in milliseconds. Falls back to the executor's default when omitted. */
+  timeoutMs?: number
 }
 
 export interface ExecLogEvent {

--- a/web/src/components/mdx/Command/Command.tsx
+++ b/web/src/components/mdx/Command/Command.tsx
@@ -29,6 +29,8 @@ interface CommandProps {
   children?: ReactNode // For inline Inputs component
   /** Whether to use PTY (pseudo-terminal) for script execution. Defaults to true. Set to false to use pipes instead, which may be needed for scripts that don't work well with PTY or when simpler output handling is preferred. */
   usePty?: boolean
+  /** Per-execution timeout in milliseconds. When omitted, the executor's default timeout (5 minutes) applies. */
+  timeoutMs?: number
 }
 
 function Command({
@@ -45,6 +47,7 @@ function Command({
   runningMessage = "Running...",
   children,
   usePty,
+  timeoutMs,
 }: CommandProps) {
   // Validate required props
   const validationError = useMemo((): AppError | null => {
@@ -101,6 +104,7 @@ function Command({
     children,
     componentType: 'command',
     usePty,
+    timeoutMs,
   })
   
   // Clone children and add variant="embedded" prop if it's an Inputs component

--- a/web/src/components/mdx/_shared/hooks/useScriptExecution.ts
+++ b/web/src/components/mdx/_shared/hooks/useScriptExecution.ts
@@ -31,6 +31,8 @@ interface UseScriptExecutionProps {
   componentType: ComponentType
   /** Whether to use PTY (pseudo-terminal) for script execution. Defaults to true. Set to false to use pipes instead, which may be needed for scripts that don't work well with PTY. */
   usePty?: boolean
+  /** Per-execution timeout in milliseconds. When omitted, the executor's default timeout applies. */
+  timeoutMs?: number
 }
 
 // Re-export for backwards compatibility
@@ -132,6 +134,7 @@ export function useScriptExecution({
   children,
   componentType,
   usePty,
+  timeoutMs,
 }: UseScriptExecutionProps): UseScriptExecutionReturn {
   // Get executable registry to look up executable ID
   const { getExecutableByComponentId, useExecutableRegistry: execRegistryEnabled } = useExecutableRegistry()
@@ -566,12 +569,12 @@ export function useScriptExecution({
         return
       }
       
-      executeScript(executable.id, processedVariables, mergedAuthEnvVars, usePty)
+      executeScript(executable.id, processedVariables, mergedAuthEnvVars, usePty, timeoutMs)
     } else {
       // Live reload mode: Send component ID directly
-      executeByComponentId(componentId, processedVariables, mergedAuthEnvVars, usePty)
+      executeByComponentId(componentId, processedVariables, mergedAuthEnvVars, usePty, timeoutMs)
     }
-  }, [execRegistryEnabled, executeScript, executeByComponentId, componentId, getExecutableByComponentId, allInputsIds, getTemplateContext, awsAuthEnvVars, githubAuthEnvVars, usePty])
+  }, [execRegistryEnabled, executeScript, executeByComponentId, componentId, getExecutableByComponentId, allInputsIds, getTemplateContext, awsAuthEnvVars, githubAuthEnvVars, usePty, timeoutMs])
 
   // Cleanup on unmount: cancel all pending operations
   useEffect(() => {

--- a/web/src/hooks/useApiExec.test.ts
+++ b/web/src/hooks/useApiExec.test.ts
@@ -106,6 +106,7 @@ describe('useApiExec state machine', () => {
       templateVarValues: { region: 'us-west-2' },
       envVarsOverride: undefined,
       usePty: undefined,
+      timeoutMs: undefined,
     })
 
     // Simulate IPC events from main process

--- a/web/src/hooks/useApiExec.ts
+++ b/web/src/hooks/useApiExec.ts
@@ -67,8 +67,8 @@ export interface UseApiExecOptions {
 
 export interface UseApiExecReturn {
   state: ExecState
-  execute: (executableId: string, variables?: Record<string, unknown>, envVars?: Record<string, string>, usePty?: boolean) => void
-  executeByComponentId: (componentId: string, variables?: Record<string, unknown>, envVars?: Record<string, string>, usePty?: boolean) => void
+  execute: (executableId: string, variables?: Record<string, unknown>, envVars?: Record<string, string>, usePty?: boolean, timeoutMs?: number) => void
+  executeByComponentId: (componentId: string, variables?: Record<string, unknown>, envVars?: Record<string, string>, usePty?: boolean, timeoutMs?: number) => void
   cancel: () => void
   reset: () => void
 }
@@ -142,6 +142,7 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
       templateVarValues: Record<string, unknown>;
       envVarsOverride?: Record<string, string>;
       usePty?: boolean;
+      timeoutMs?: number;
     }
   ) => {
     // Cancel any existing execution and bump generation
@@ -247,12 +248,13 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
 
   // Execute script by executable ID (used in registry mode)
   const execute = useCallback(
-    (executableId: string, templateVarValues: Record<string, unknown> = {}, envVarsOverride?: Record<string, string>, usePty?: boolean) => {
+    (executableId: string, templateVarValues: Record<string, unknown> = {}, envVarsOverride?: Record<string, string>, usePty?: boolean, timeoutMs?: number) => {
       executeScript({
         executableId,
         templateVarValues,
         envVarsOverride,
         usePty,
+        timeoutMs,
       })
     },
     [executeScript]
@@ -265,12 +267,13 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
   // This allows script changes to take effect immediately without restarting the server,
   // but bypasses registry validation (only use with --live-file-reload flag).
   const executeByComponentId = useCallback(
-    (componentId: string, templateVarValues: Record<string, unknown> = {}, envVarsOverride?: Record<string, string>, usePty?: boolean) => {
+    (componentId: string, templateVarValues: Record<string, unknown> = {}, envVarsOverride?: Record<string, string>, usePty?: boolean, timeoutMs?: number) => {
       executeScript({
         componentId,
         templateVarValues,
         envVarsOverride,
         usePty,
+        timeoutMs,
       })
     },
     [executeScript]


### PR DESCRIPTION
## Summary
- Thread a `timeoutMs` option from the `Command` MDX block through `useScriptExecution`, `useApiExec`, the `ExecRequest` IPC channel, and the executor.
- Executor now resolves `request.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS` (5 min unchanged).
- Authors can override per-block for legitimately long-running scripts, e.g. `timeoutMs={1800000}` for a 30-minute deploy.
- Docs updated in `Command.mdx`.

## Test plan
- [ ] Existing Command blocks (no `timeoutMs`) still use the 5-minute default
- [ ] Setting `timeoutMs={10000}` on a `sleep 15` block surfaces the timeout message after ~10s
- [ ] `useApiExec` test passes with new `timeoutMs: undefined` field in the IPC payload

Second of 7 stacked PRs splitting up \`feat/electron-rewrite-render-unstub\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)