### PR TITLE
harden: Resolve directory runbook paths

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -7,6 +7,7 @@ if (process.env.ELECTRON_RENDERER_URL) {
 
 import { app, shell, ipcMain, dialog, protocol, net } from "electron"
 import * as path from "path"
+import * as fs from "fs"
 import { createMainWindow, focusOrCreateWindow, getMainWindow } from "./window.ts"
 import { setupApplicationMenu } from "./menu.ts"
 import { initAutoUpdater } from "./updater.ts"
@@ -69,10 +70,29 @@ const cliConfig = parseCliArgs()
 
 // Apply CLI overrides to the shared runtime config.
 // Remote URLs are resolved asynchronously after app.whenReady().
+//
+// If the CLI path is a directory, resolve it to the runbook.mdx inside so that
+// `runbookConfig.localPath` is always a concrete file path. The runbook-asset
+// protocol handler computes the asset directory via `path.dirname(localPath)`;
+// leaving `localPath` as a directory would make `path.dirname` return its
+// *parent*, causing asset 404s on any image request that races ahead of the
+// renderer's `runbook:get` IPC call (which later re-resolves the path).
 if (cliConfig.runbookPath) {
+  let resolvedPath = cliConfig.runbookPath
+  try {
+    if (fs.statSync(resolvedPath).isDirectory()) {
+      const candidate = path.join(resolvedPath, "runbook.mdx")
+      if (fs.existsSync(candidate)) {
+        resolvedPath = candidate
+      }
+    }
+  } catch {
+    // stat may fail (e.g. path doesn't exist yet); leave as-is and let the
+    // renderer's runbook:get call surface the error.
+  }
   setRunbookConfig({
     ...runbookConfig,
-    localPath: cliConfig.runbookPath,
+    localPath: resolvedPath,
     isWatchMode: cliConfig.watch,
   })
 }

--- a/electron/main/window.ts
+++ b/electron/main/window.ts
@@ -42,7 +42,7 @@ export function createMainWindow(): BrowserWindow {
         responseHeaders: {
           ...details.responseHeaders,
           "Content-Security-Policy": [
-            "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: runbook-asset: https://*.githubusercontent.com; media-src 'self' runbook-asset:; font-src 'self' data:",
+            "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: runbook-asset:; media-src 'self' runbook-asset:; font-src 'self' data:",
           ],
         },
       })

--- a/electron/main/window.ts
+++ b/electron/main/window.ts
@@ -42,7 +42,7 @@ export function createMainWindow(): BrowserWindow {
         responseHeaders: {
           ...details.responseHeaders,
           "Content-Security-Policy": [
-            "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: runbook-asset:; media-src 'self' runbook-asset:; font-src 'self' data:",
+            "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: runbook-asset: https://*.githubusercontent.com; media-src 'self' runbook-asset:; font-src 'self' data:",
           ],
         },
       })


### PR DESCRIPTION
## Summary
small Electron main-process fixes:

- **Directory path resolution** (`electron/main/index.ts`): when the CLI path is a directory, resolve it to `runbook.mdx` inside before storing in `runbookConfig.localPath`. The `runbook-asset:` protocol handler derives the asset directory via `path.dirname(localPath)`, so leaving a directory path would point at the *parent* directory and 404 any asset request that races ahead of the renderer's `runbook:get` IPC call.

## Test plan
- [ ] Asset images load when launching with a directory path (e.g. `runbooks testdata/sample-runbooks/markdown-only-full`)
- [ ] No regression when launching with an explicit `.mdx` path

Third of 7 stacked PRs splitting up \`feat/electron-rewrite-render-unstub\`.

