### PR TITLE
split display/validation of PATs vs app tokens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,31 @@ jobs:
           RUNBOOKS_GITHUB_TOKEN: ${{ secrets.RUNBOOKS_GITHUB_TOKEN }}
         run: resources/bin/runbooks-test test testdata/...
 
+  test-runbooks-app-token:
+    name: Runbook Tests (GitHub App Token)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Compile test CLI
+        run: just compile-test-cli
+
+      - name: Run GitHub auth flows with installation token
+        env:
+          # No RUNBOOKS_GITHUB_TOKEN: force the executor's fallback chain
+          # (RUNBOOKS_GITHUB_TOKEN -> GITHUB_TOKEN -> GH_TOKEN) to land on the
+          # ghs_ installation token, exercising validateInstallationToken.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: resources/bin/runbooks-test test testdata/feature-demos/github-auth/...
+
   test-docs:
     name: Documentation Tests
     runs-on: ubuntu-latest
@@ -174,6 +199,7 @@ jobs:
         test-build,
         test-e2e,
         test-runbooks,
+        test-runbooks-app-token,
         test-docs,
       ]
     runs-on: ubuntu-latest
@@ -186,9 +212,10 @@ jobs:
           BUILD_RESULT: ${{ needs.test-build.result }}
           E2E_RESULT: ${{ needs.test-e2e.result }}
           RUNBOOKS_RESULT: ${{ needs.test-runbooks.result }}
+          RUNBOOKS_APP_RESULT: ${{ needs.test-runbooks-app-token.result }}
           DOCS_RESULT: ${{ needs.test-docs.result }}
         run: |
-          for result in "$LINT_RESULT" "$UNIT_RESULT" "$BUILD_RESULT" "$E2E_RESULT" "$RUNBOOKS_RESULT" "$DOCS_RESULT"; do
+          for result in "$LINT_RESULT" "$UNIT_RESULT" "$BUILD_RESULT" "$E2E_RESULT" "$RUNBOOKS_RESULT" "$RUNBOOKS_APP_RESULT" "$DOCS_RESULT"; do
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "CI failed!"
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,11 @@ jobs:
       - name: Ensure Electron binary is installed
         run: node node_modules/electron/install.js
 
+      - name: Fix Electron chrome-sandbox permissions
+        run: |
+          sudo chown root:root node_modules/electron/dist/chrome-sandbox
+          sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
+
       - name: Get Playwright version
         id: pw-version
         run: echo "version=$(bunx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,9 +108,12 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
-          path: playwright-report/
+          name: playwright-results
+          path: |
+            web/test-results/
+            electron/e2e/test-results/
           retention-days: 30
+          if-no-files-found: ignore
 
   test-runbooks:
     name: Runbook Tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage.out
 *.test
 dist/
 testdata/**/output
+testdata/**/empty-repo
 out/
 test-results/
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ generated/*
 coverage.out
 *.test
 dist/
+testdata/**/output
 out/
 test-results/
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -14,7 +14,7 @@ import { initAutoUpdater } from "./updater.ts"
 import { parseCliArgs } from "./cli.ts"
 import { registerAllIpcHandlers } from "./ipc/index.ts"
 import { checkCliInstall, installCli, uninstallCli } from "./cli-install.ts"
-import { runtime, setRunbookConfig, runbookConfig } from "./ipc/runtime.ts"
+import { runtime, setRunbookConfig, runbookConfig, setCliWorkingDir } from "./ipc/runtime.ts"
 import { resolveRemoteRunbook, cleanupTempClones } from "./remote.ts"
 import { isContainedIn } from "../../src/path-validation.ts"
 import { makeLogger } from "./logger.ts"
@@ -67,6 +67,7 @@ if (!gotLock) {
 // ---------------------------------------------------------------------------
 
 const cliConfig = parseCliArgs()
+setCliWorkingDir(cliConfig.workingDir)
 
 // Apply CLI overrides to the shared runtime config.
 // Remote URLs are resolved asynchronously after app.whenReady().

--- a/electron/main/ipc/git.ts
+++ b/electron/main/ipc/git.ts
@@ -5,7 +5,7 @@
  * event.sender.send(). Pull request creation and branch deletion are
  * simple request-response handlers.
  */
-import { Effect, Stream } from "effect"
+import { Cause, Effect, Exit, Stream } from "effect"
 import { ipcMain } from "electron"
 import { runtime, sessionManager } from "./runtime.ts"
 import { ProcessSpawner } from "../../../src/services/ProcessSpawner.ts"
@@ -23,6 +23,38 @@ import { isContainedIn } from "../../../src/path-validation.ts"
 import { PathTraversalError, GitError } from "../../../src/errors/index.ts"
 import { validateSessionPath } from "./path-guard.ts"
 
+/**
+ * Run an Effect program and surface typed failures as plain Errors whose
+ * message carries the real failure detail (e.g. git stderr).
+ *
+ * Effect's TaggedError inherits from Error but leaves `.message` empty, so
+ * across the IPC boundary the renderer would otherwise only see "An error
+ * has occurred". Unwrapping the Cause here and rethrowing a regular Error
+ * keeps the real message flowing through Electron's IPC serialization.
+ */
+async function runAndUnwrap<A, E extends { _tag: string }>(
+  program: Effect.Effect<A, E, never>,
+): Promise<A> {
+  const exit = await runtime.runPromiseExit(program)
+  if (Exit.isSuccess(exit)) return exit.value
+
+  const failure = Cause.failureOption(exit.cause)
+  if (failure._tag === "Some") {
+    const err = failure.value as GitError | PathTraversalError | { _tag: string }
+    if (err._tag === "GitError") {
+      const gitErr = err as GitError
+      throw new Error(
+        gitErr.stderr || `git ${gitErr.command} failed (exit ${gitErr.exitCode})`,
+      )
+    }
+    if (err._tag === "PathTraversalError") {
+      throw new Error((err as PathTraversalError).message)
+    }
+    throw new Error(String(err))
+  }
+  throw new Error(Cause.pretty(exit.cause))
+}
+
 export function registerGitHandlers(): void {
   ipcMain.handle(
     "git:clone",
@@ -35,7 +67,7 @@ export function registerGitHandlers(): void {
         credentials?: { token: string }
       },
     ) => {
-      return runtime.runPromise(
+      return runAndUnwrap(
         Effect.scoped(
         Effect.gen(function* () {
           // Validate the clone URL before any other processing
@@ -89,8 +121,10 @@ export function registerGitHandlers(): void {
           const proc = yield* spawner.spawn("git", cloneArgs, {})
 
           // debugLog("[git:clone] draining output stream...")
+          const stderrLines: string[] = []
           yield* Stream.runForEach(proc.output, (line) =>
             Effect.sync(() => {
+              if (line.source === "stderr") stderrLines.push(line.line)
               event.sender.send("git:clone-progress", {
                 line: line.line,
                 timestamp: new Date().toISOString(),
@@ -102,10 +136,11 @@ export function registerGitHandlers(): void {
           const exitCode = yield* proc.exitCode
           // debugLog("[git:clone] exit code: " + exitCode)
           if (exitCode !== 0) {
+            const stderr = stderrLines.join("\n").trim()
             return yield* Effect.fail(
               new GitError({
                 command: "git clone",
-                stderr: `clone to ${paths.absolutePath} failed`,
+                stderr: stderr || `clone to ${paths.absolutePath} failed (exit ${exitCode})`,
                 exitCode,
               }),
             )
@@ -150,7 +185,7 @@ export function registerGitHandlers(): void {
         setUpstream?: boolean
       },
     ) => {
-      return runtime.runPromise(
+      return runAndUnwrap(
         Effect.gen(function* () {
           yield* validateSessionPath(params.worktreePath)
 
@@ -189,14 +224,14 @@ export function registerGitHandlers(): void {
       params: { token: string } & CreatePullRequestParams,
     ) => {
       const { token, ...prParams } = params
-      return runtime.runPromise(createPullRequest(token, prParams))
+      return runAndUnwrap(createPullRequest(token, prParams))
     },
   )
 
   ipcMain.handle(
     "git:delete-branch",
     async (_event, params: { worktreePath: string; branch: string }) => {
-      return runtime.runPromise(
+      return runAndUnwrap(
         Effect.gen(function* () {
           yield* validateSessionPath(params.worktreePath)
           return yield* deleteBranch(params.worktreePath, params.branch)

--- a/electron/main/ipc/github.ts
+++ b/electron/main/ipc/github.ts
@@ -4,6 +4,7 @@
  * Bridges Electron ipcMain to the GitHub auth domain module, providing token
  * validation, OAuth device flow, credential detection, and repository queries.
  */
+import { Effect } from "effect"
 import { ipcMain } from "electron"
 import { runtime, sessionManager } from "./runtime.ts"
 import {
@@ -19,6 +20,22 @@ import {
   listLabels,
   DEFAULT_GITHUB_OAUTH_CLIENT_ID,
 } from "../../../src/domain/github/auth.ts"
+
+/**
+ * Resolve the GitHub token from the current session's environment. The env
+ * is populated by github:env-credentials / github:cli-credentials / user
+ * paste, and is the single source of truth for "which token do API calls
+ * use" — the renderer never sees the token directly.
+ */
+const getSessionToken = () =>
+  Effect.gen(function* () {
+    const session = yield* sessionManager.getSession()
+    const token = session.env.get("GITHUB_TOKEN")
+    if (!token) {
+      return yield* Effect.fail(new Error("No GitHub token available in session"))
+    }
+    return token
+  })
 
 export function registerGitHubHandlers(): void {
   ipcMain.handle(
@@ -115,18 +132,23 @@ export function registerGitHubHandlers(): void {
     }
   })
 
-  ipcMain.handle(
-    "github:orgs",
-    async (_event, params: { token: string }) => {
-      return runtime.runPromise(listOrgs(params.token))
-    },
-  )
+  ipcMain.handle("github:orgs", async () => {
+    return runtime.runPromise(
+      Effect.gen(function* () {
+        const token = yield* getSessionToken()
+        return yield* listOrgs(token)
+      }),
+    )
+  })
 
   ipcMain.handle(
     "github:repos",
-    async (_event, params: { token: string; org: string; query?: string }) => {
+    async (_event, params: { org: string; query?: string }) => {
       return runtime.runPromise(
-        listRepos(params.token, params.org, params.query),
+        Effect.gen(function* () {
+          const token = yield* getSessionToken()
+          return yield* listRepos(token, params.org, params.query)
+        }),
       )
     },
   )
@@ -135,22 +157,25 @@ export function registerGitHubHandlers(): void {
     "github:refs",
     async (
       _event,
-      params: { token: string; owner: string; repo: string; query?: string },
+      params: { owner: string; repo: string; query?: string },
     ) => {
       return runtime.runPromise(
-        listRefs(params.token, params.owner, params.repo, params.query),
+        Effect.gen(function* () {
+          const token = yield* getSessionToken()
+          return yield* listRefs(token, params.owner, params.repo, params.query)
+        }),
       )
     },
   )
 
   ipcMain.handle(
     "github:labels",
-    async (
-      _event,
-      params: { token: string; owner: string; repo: string },
-    ) => {
+    async (_event, params: { owner: string; repo: string }) => {
       return runtime.runPromise(
-        listLabels(params.token, params.owner, params.repo),
+        Effect.gen(function* () {
+          const token = yield* getSessionToken()
+          return yield* listLabels(token, params.owner, params.repo)
+        }),
       )
     },
   )

--- a/electron/main/ipc/runbook.ts
+++ b/electron/main/ipc/runbook.ts
@@ -13,6 +13,7 @@ import {
   sessionManager,
   setExecutableRegistry,
   setRunbookConfig,
+  cliWorkingDir,
 } from "./runtime.ts"
 import { ExecutableRegistry } from "../../../src/domain/registry/executable.ts"
 import { readFileMetadata, resolveRunbookPath, getContentType, isAllowedAssetExtension } from "../../../src/domain/workspace/file.ts"
@@ -54,9 +55,12 @@ export function registerRunbookHandlers(): void {
 
       // Update the session's working directory to the runbook's parent dir.
       // The session may have been created with '.' before the runbook path
-      // was known.
-      const runbookDir = path.dirname(runbookPath)
-      sessionManager.setWorkingDir(runbookDir)
+      // was known. Skip when --working-dir was explicitly supplied on the CLI,
+      // so E2E tests can pin the session to an isolated temp dir.
+      if (!cliWorkingDir) {
+        const runbookDir = path.dirname(runbookPath)
+        sessionManager.setWorkingDir(runbookDir)
+      }
 
       // Read the runbook file content
       const fileData = await runtime.runPromise(readFileMetadata(runbookPath))

--- a/electron/main/ipc/runtime.ts
+++ b/electron/main/ipc/runtime.ts
@@ -46,6 +46,18 @@ export function setRunbookConfig(config: RunbookConfig): void {
   runbookConfig = config
 }
 
+/**
+ * Working directory explicitly supplied on the command line via --working-dir.
+ * When set, it pins the session's workingDir and prevents the runbook loader
+ * from overriding it with the runbook's parent directory. Used by E2E tests
+ * to isolate generated files in a temp dir.
+ */
+export let cliWorkingDir: string | null = null
+
+export function setCliWorkingDir(dir: string | null): void {
+  cliWorkingDir = dir
+}
+
 /** Active file watcher stream -- non-null when watch mode is active. */
 export let fileWatcher: Stream.Stream<FileChangeEvent, FileWatchError> | null = null
 

--- a/electron/main/ipc/session.ts
+++ b/electron/main/ipc/session.ts
@@ -4,15 +4,28 @@
  * Bridges Electron ipcMain to the SessionManager domain module.
  * All handlers are process-local and trusted -- no token validation needed.
  */
+import fs from "fs"
 import path from "path"
 import { ipcMain } from "electron"
-import { runtime, sessionManager } from "./runtime.ts"
+import { runtime, sessionManager, cliWorkingDir } from "./runtime.ts"
 
 export function registerSessionHandlers(): void {
   ipcMain.handle(
     "session:create",
     async (_event, params: { workingDir: string }) => {
-      const resolved = path.resolve(params.workingDir)
+      // --working-dir on the CLI overrides the renderer-supplied value so that
+      // E2E tests can isolate generated files in a temp dir.
+      const input = cliWorkingDir ?? params.workingDir
+      // Resolve symlinks so session.workingDir matches paths returned by
+      // fs.realpath elsewhere in the pipeline (macOS /var -> /private/var).
+      // Without this, template outputs under os.tmpdir() fail containment
+      // checks because one side is realpath'd and the other isn't.
+      let resolved = path.resolve(input)
+      try {
+        resolved = fs.realpathSync(resolved)
+      } catch {
+        // Path may not exist yet — fall back to the lexical resolution.
+      }
       if (resolved === path.parse(resolved).root) {
         throw new Error("workingDir must not be a filesystem root")
       }

--- a/electron/main/window.ts
+++ b/electron/main/window.ts
@@ -42,7 +42,7 @@ export function createMainWindow(): BrowserWindow {
         responseHeaders: {
           ...details.responseHeaders,
           "Content-Security-Policy": [
-            "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: runbook-asset:; media-src 'self' runbook-asset:; font-src 'self' data:",
+            "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: runbook-asset: https://avatars.githubusercontent.com; media-src 'self' runbook-asset:; font-src 'self' data:",
           ],
         },
       })

--- a/src/domain/github/auth.test.ts
+++ b/src/domain/github/auth.test.ts
@@ -18,8 +18,12 @@ describe("detectTokenType", () => {
     expect(detectTokenType("gho_abc123")).toBe("oauth")
   })
 
-  it("identifies GitHub App token", () => {
+  it("identifies GitHub App installation token", () => {
     expect(detectTokenType("ghs_abc123")).toBe("github_app")
+  })
+
+  it("identifies GitHub App user-to-server token", () => {
+    expect(detectTokenType("ghu_abc123")).toBe("github_app")
   })
 
   it("returns unknown for unrecognized prefix", () => {

--- a/src/domain/github/auth.ts
+++ b/src/domain/github/auth.ts
@@ -41,14 +41,14 @@ export const validateToken = (token: string) =>
  *   ghp_        -> classic_pat
  *   github_pat_ -> fine_grained_pat
  *   gho_        -> oauth
- *   ghs_        -> github_app
+ *   ghs_, ghu_  -> github_app  (installation token / user-to-server)
  *   (other)     -> unknown
  */
 export const detectTokenType = (token: string): GitHubTokenType => {
   if (token.startsWith("ghp_")) return "classic_pat"
   if (token.startsWith("github_pat_")) return "fine_grained_pat"
   if (token.startsWith("gho_")) return "oauth"
-  if (token.startsWith("ghs_")) return "github_app"
+  if (token.startsWith("ghs_") || token.startsWith("ghu_")) return "github_app"
   return "unknown"
 }
 

--- a/src/layers/GitCliClient.ts
+++ b/src/layers/GitCliClient.ts
@@ -275,7 +275,7 @@ function makeGitClient(spawner: ProcessSpawner["Type"]): GitClientShape {
 
     status: (repoPath: string) =>
       Effect.gen(function* () {
-        const lines = yield* runGit(spawner, ["status", "--porcelain"], repoPath)
+        const lines = yield* runGit(spawner, ["status", "--porcelain", "--untracked-files=all"], repoPath)
         return lines
           .filter((l) => l.trim().length > 0)
           .map((line): StatusEntry => ({
@@ -292,7 +292,7 @@ function makeGitClient(spawner: ProcessSpawner["Type"]): GitClientShape {
 
     hasChanges: (repoPath: string) =>
       Effect.gen(function* () {
-        const lines = yield* runGit(spawner, ["status", "--porcelain"], repoPath)
+        const lines = yield* runGit(spawner, ["status", "--porcelain", "--untracked-files=all"], repoPath)
         return lines.some((l) => l.trim().length > 0)
       }),
 

--- a/src/layers/GitHubHttpClient.ts
+++ b/src/layers/GitHubHttpClient.ts
@@ -70,41 +70,79 @@ async function paginateAll<T>(
   return results
 }
 
+// GitHub App installation tokens (ghs_) can't call /user — GitHub returns
+// 403 "Resource not accessible by integration" because the token has no user
+// context. Probe /installation/repositories instead and synthesize an
+// identity from the installation owner.
+async function validateInstallationToken(
+  token: string,
+): Promise<GitHubTokenValidation> {
+  const resp = await githubFetch(
+    `${API_BASE}/installation/repositories?per_page=1`,
+    { token },
+  )
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "")
+    throw new GitHubApiError({
+      status: resp.status,
+      message: body || resp.statusText,
+    })
+  }
+  const data = (await resp.json()) as {
+    total_count: number
+    repositories: Array<{ owner?: { login?: string } }>
+  }
+  const ownerLogin = data.repositories[0]?.owner?.login
+  return {
+    user: {
+      login: ownerLogin ? `${ownerLogin}[bot]` : "github-app[bot]",
+      name: "GitHub App Installation",
+    },
+  }
+}
+
+async function validateUserToken(
+  token: string,
+): Promise<GitHubTokenValidation> {
+  const resp = await githubFetch(`${API_BASE}/user`, { token })
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "")
+    throw new GitHubApiError({
+      status: resp.status,
+      message: body || resp.statusText,
+    })
+  }
+  const data = (await resp.json()) as {
+    login: string
+    name?: string
+    avatar_url?: string
+    email?: string
+  }
+  const scopeHeader = resp.headers.get("x-oauth-scopes")
+  const scopes = scopeHeader
+    ? scopeHeader
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    : undefined
+  return {
+    user: {
+      login: data.login,
+      name: data.name,
+      avatarUrl: data.avatar_url,
+      email: data.email,
+    },
+    scopes,
+  }
+}
+
 const impl: GitHubClientShape = {
   validateToken: (token: string) =>
     Effect.tryPromise({
-      try: async (): Promise<GitHubTokenValidation> => {
-        const resp = await githubFetch(`${API_BASE}/user`, { token })
-        if (!resp.ok) {
-          const body = await resp.text().catch(() => "")
-          throw new GitHubApiError({
-            status: resp.status,
-            message: body || resp.statusText,
-          })
-        }
-        const data = (await resp.json()) as {
-          login: string
-          name?: string
-          avatar_url?: string
-          email?: string
-        }
-        const scopeHeader = resp.headers.get("x-oauth-scopes")
-        const scopes = scopeHeader
-          ? scopeHeader
-              .split(",")
-              .map((s) => s.trim())
-              .filter((s) => s.length > 0)
-          : undefined
-        return {
-          user: {
-            login: data.login,
-            name: data.name,
-            avatarUrl: data.avatar_url,
-            email: data.email,
-          },
-          scopes,
-        }
-      },
+      try: async (): Promise<GitHubTokenValidation> =>
+        token.startsWith("ghs_")
+          ? validateInstallationToken(token)
+          : validateUserToken(token),
       catch: (err) =>
         err instanceof GitHubApiError
           ? err

--- a/testdata/feature-demos/github-auth/runbook_test.yml
+++ b/testdata/feature-demos/github-auth/runbook_test.yml
@@ -16,40 +16,34 @@ settings:
 
 tests:
   - name: happy-path
-    description: Standard successful execution
+    description: Authenticate and verify against the GitHub API using whichever
+      token is in the env (user PAT via RUNBOOKS_GITHUB_TOKEN, or a ghs_
+      installation token via GITHUB_TOKEN). verify-auth.sh branches on the
+      token prefix to hit the correct endpoint.
 
     inputs:
-      # repo_url: string - the repository to clone
       repo-config.repo_url: "https://github.com/gruntwork-io/runbooks-test.git"
-      # clone_path: string - relative path within temp working directory
       repo-config.clone_path: "./cloned-repo"
 
     steps:
-      # Note: Order matters! Blocks that produce outputs must run before
-      # blocks that consume them via {{ .outputs.x.y }}
-      # All blocks below are commented out, so this test runs all blocks
-      # in document order. Uncomment specific blocks to run only those.
+      - block: gh-auth
+        expect: success
 
-      # - block: gh-auth
-      #   # Set expect: skip if not testing GitHub auth
-      #   # Or set RUNBOOKS_GITHUB_TOKEN env var
-      #   expect: skip
+      - block: verify-auth
+        expect: success
 
-      # - block: verify-auth
-      #   expect: success
+      # clone-repo is intentionally not exercised here: runbooks-test is a
+      # private fixture only the user PAT can reach. GitClone coverage with
+      # both token types belongs in the git-clone demo.
 
-      # - block: clone-repo
-      #   expect: success
-
-    assertions:
-      # TemplateInline blocks automatically validate their output dependencies.
-      # Add additional assertions to validate test results:
-      # - type: file_exists
-      #   path: generated/README.md
-      # - type: file_contains
-      #   path: generated/README.md
-      #   contains: "expected content"
-
-    # cleanup:
-    #   - command: rm -rf /tmp/test-resources
-    #   - path: cleanup/teardown.sh
+  - name: skip-without-credentials
+    description: With no token in the env, gh-auth skips and dependents skip too.
+    env:
+      GITHUB_TOKEN: ""
+      GH_TOKEN: ""
+      RUNBOOKS_GITHUB_TOKEN: ""
+    steps:
+      - block: gh-auth
+        expect: skip
+      - block: verify-auth
+        expect: skip

--- a/testdata/feature-demos/github-auth/scripts/verify-auth.sh
+++ b/testdata/feature-demos/github-auth/scripts/verify-auth.sh
@@ -1,14 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Verify GITHUB_TOKEN is set
 if [ -z "${GITHUB_TOKEN:-}" ]; then
   echo "ERROR: GITHUB_TOKEN not set"
   exit 1
 fi
 
-# Call GitHub API to verify token
-response=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user)
+# GitHub App installation tokens (ghs_) have no associated user, so /user
+# returns 403. Use /installation/repositories instead — same endpoint the
+# GitHubHttpClient.validateInstallationToken code path uses.
+if [[ "$GITHUB_TOKEN" == ghs_* ]]; then
+  response=$(curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    https://api.github.com/installation/repositories)
+
+  repo_count=$(echo "$response" | jq -r '.total_count // "null"')
+  if [ "$repo_count" = "null" ]; then
+    echo "ERROR: Invalid installation token - could not list installation repositories"
+    echo "Response: $response"
+    exit 1
+  fi
+
+  echo "SUCCESS: Authenticated as GitHub App installation ($repo_count repo(s) accessible)"
+  echo "RUNBOOK_OUTPUT:installation_repo_count=$repo_count"
+  exit 0
+fi
+
+response=$(curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user)
 
 username=$(echo "$response" | jq -r '.login')
 if [ "$username" = "null" ]; then

--- a/web/src/components/mdx/GitHubAuth/components/AuthSuccess.tsx
+++ b/web/src/components/mdx/GitHubAuth/components/AuthSuccess.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { AlertTriangle, ChevronDown, ChevronRight, ExternalLink, Shield } from "lucide-react"
+import { AlertTriangle, Bot, ChevronDown, ChevronRight, ExternalLink, Shield } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { GitHubUserInfo, GitHubDetectionSource, GitHubTokenType } from "../types"
 
@@ -69,9 +69,9 @@ const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'workflow': 'Update GitHub Actions workflows',
 }
 
-export function AuthSuccess({ 
-  userInfo, 
-  detectionSource, 
+export function AuthSuccess({
+  userInfo,
+  detectionSource,
   detectedScopes,
   detectedTokenType,
   scopeWarning,
@@ -80,7 +80,65 @@ export function AuthSuccess({
 }: AuthSuccessProps) {
   const [showPermissions, setShowPermissions] = useState(false)
   const isFineGrainedPat = detectedTokenType === 'fine_grained_pat'
-  
+  // ghs_ installation tokens have no user context — /user returns 403 — so
+  // validateToken synthesizes a user without an avatar. ghu_ tokens also
+  // detect as 'github_app' but hit /user successfully and have a real avatar,
+  // so they fall through to the normal user card.
+  const isAppInstallation = detectedTokenType === 'github_app' && !userInfo.avatarUrl
+
+  if (isAppInstallation) {
+    return (
+      <div className="mb-4">
+        <div className="text-green-700 font-semibold text-sm mb-2 flex items-center gap-2">
+          <span>✓ Authenticated as GitHub App</span>
+          {detectionSource && (
+            <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded font-normal">
+              {detectionSource === 'env' && 'From Environment'}
+              {detectionSource === 'cli' && 'Via GitHub CLI'}
+              {detectionSource === 'block' && 'From Command'}
+            </span>
+          )}
+        </div>
+        <div className="bg-green-100/50 rounded p-3 text-sm">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full border border-green-200 bg-white flex items-center justify-center">
+              <Bot className="size-5 text-gray-600" />
+            </div>
+            <div>
+              <div className="text-gray-700 font-medium">
+                {userInfo.name || 'GitHub App Installation'}
+              </div>
+              <div className="text-gray-500 text-xs">
+                @{userInfo.login}
+              </div>
+              <div className="text-gray-400 text-xs mt-1 flex items-center gap-1">
+                <Shield className="size-3" />
+                <span>GitHub App Token</span>
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 pt-3 border-t border-green-200 text-gray-500 text-xs">
+            GitHub Apps use installation-level permission grants instead of OAuth scopes.
+            Access is scoped to the repositories the app is installed on.
+          </div>
+          {sessionEnvWarning && (
+            <div className="mt-3 pt-3 border-t border-green-200 flex items-start gap-2 text-amber-600 text-xs">
+              <AlertTriangle className="size-4 flex-shrink-0 mt-0.5" />
+              <div>{sessionEnvWarning}</div>
+            </div>
+          )}
+        </div>
+        {onReAuthenticate && (
+          <div className="mt-3">
+            <Button variant="outline" size="sm" onClick={onReAuthenticate}>
+              Use a different token
+            </Button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="mb-4">
       <div className="text-green-700 font-semibold text-sm mb-2 flex items-center gap-2">


### PR DESCRIPTION
Users with oauth tokens or PATs vs app tokens have different endpoints/scopes available to them. We were using the user endpoint which may not be true if we want to use an app to run runbooks automagically.