### PR TITLE
[Wails] M0a: Extract Environment, FileSystem, ProcessSpawner ports

### DIFF
--- a/adapters/doc.go
+++ b/adapters/doc.go
@@ -1,0 +1,8 @@
+// Package adapters contains OS-coupled implementations of core/ports.
+//
+// Everything that reaches for os, os/exec, syscall, filepath, or other
+// host-specific APIs lives here, not in core/. Domain code in core/
+// receives these adapters as interfaces via constructor injection, so
+// the same domain code can later run against sandboxed or tenant-scoped
+// adapters without modification.
+package adapters

--- a/adapters/os_environment.go
+++ b/adapters/os_environment.go
@@ -1,0 +1,37 @@
+package adapters
+
+import (
+	"os"
+	"strings"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// OsEnvironment implements ports.Environment using the host process's
+// real environment via os.LookupEnv and os.Environ.
+type OsEnvironment struct{}
+
+// NewOsEnvironment returns an Environment backed by the host process.
+func NewOsEnvironment() *OsEnvironment {
+	return &OsEnvironment{}
+}
+
+// Get returns the value of key from the host process environment.
+func (e *OsEnvironment) Get(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+// GetAll returns a snapshot of the host process environment.
+func (e *OsEnvironment) GetAll() map[string]string {
+	entries := os.Environ()
+	out := make(map[string]string, len(entries))
+	for _, kv := range entries {
+		if idx := strings.Index(kv, "="); idx != -1 {
+			out[kv[:idx]] = kv[idx+1:]
+		}
+	}
+	return out
+}
+
+// Compile-time check that OsEnvironment implements the port.
+var _ ports.Environment = (*OsEnvironment)(nil)

--- a/adapters/os_environment_test.go
+++ b/adapters/os_environment_test.go
@@ -1,0 +1,45 @@
+package adapters
+
+import (
+	"testing"
+)
+
+func TestOsEnvironment_Get(t *testing.T) {
+	env := NewOsEnvironment()
+
+	key := "GRUNTBOOKS_OS_ENV_ADAPTER_TEST_KEY"
+	want := "hello-world"
+	t.Setenv(key, want)
+
+	got, ok := env.Get(key)
+	if !ok {
+		t.Fatalf("Get(%q) ok = false, want true", key)
+	}
+	if got != want {
+		t.Errorf("Get(%q) = %q, want %q", key, got, want)
+	}
+
+	if _, ok := env.Get("GRUNTBOOKS_OS_ENV_ADAPTER_TEST_MISSING_KEY"); ok {
+		t.Errorf("Get missing key reported ok = true, want false")
+	}
+}
+
+func TestOsEnvironment_GetAll(t *testing.T) {
+	env := NewOsEnvironment()
+
+	key := "GRUNTBOOKS_OS_ENV_ADAPTER_TEST_GETALL"
+	want := "snapshot-value"
+	t.Setenv(key, want)
+
+	snapshot := env.GetAll()
+	if got := snapshot[key]; got != want {
+		t.Errorf("snapshot[%q] = %q, want %q", key, got, want)
+	}
+
+	// Mutating the returned map must not affect subsequent calls.
+	snapshot[key] = "mutated"
+	second := env.GetAll()
+	if got := second[key]; got != want {
+		t.Errorf("second snapshot[%q] = %q; want %q (map mutations leaked)", key, got, want)
+	}
+}

--- a/adapters/os_filesystem.go
+++ b/adapters/os_filesystem.go
@@ -1,0 +1,52 @@
+package adapters
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// OsFileSystem implements ports.FileSystem using the host filesystem.
+type OsFileSystem struct{}
+
+// NewOsFileSystem returns a FileSystem backed by the host filesystem.
+func NewOsFileSystem() *OsFileSystem {
+	return &OsFileSystem{}
+}
+
+func (f *OsFileSystem) Read(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func (f *OsFileSystem) Write(path string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}
+
+func (f *OsFileSystem) Stat(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (f *OsFileSystem) ReadDir(path string) ([]fs.DirEntry, error) {
+	return os.ReadDir(path)
+}
+
+func (f *OsFileSystem) MkdirAll(path string, perm fs.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (f *OsFileSystem) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (f *OsFileSystem) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (f *OsFileSystem) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return filepath.WalkDir(root, fn)
+}
+
+// Compile-time check that OsFileSystem implements the port.
+var _ ports.FileSystem = (*OsFileSystem)(nil)

--- a/adapters/os_filesystem_test.go
+++ b/adapters/os_filesystem_test.go
@@ -1,0 +1,115 @@
+package adapters
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOsFileSystem_WriteRead(t *testing.T) {
+	fs := NewOsFileSystem()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hello.txt")
+	want := []byte("hello, world")
+
+	if err := fs.Write(path, want, 0o600); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := fs.Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("Read = %q, want %q", got, want)
+	}
+}
+
+func TestOsFileSystem_StatReadDir(t *testing.T) {
+	f := NewOsFileSystem()
+	dir := t.TempDir()
+
+	if err := f.Write(filepath.Join(dir, "a.txt"), []byte("a"), 0o600); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := f.Write(filepath.Join(dir, "b.txt"), []byte("b"), 0o600); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	info, err := f.Stat(filepath.Join(dir, "a.txt"))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() != 1 {
+		t.Errorf("Stat size = %d, want 1", info.Size())
+	}
+
+	entries, err := f.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("ReadDir returned %d entries, want 2", len(entries))
+	}
+}
+
+func TestOsFileSystem_MkdirAllRemoveAll(t *testing.T) {
+	f := NewOsFileSystem()
+	root := t.TempDir()
+
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := f.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if _, err := f.Stat(nested); err != nil {
+		t.Fatalf("Stat nested: %v", err)
+	}
+
+	if err := f.RemoveAll(filepath.Join(root, "a")); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if _, err := f.Stat(filepath.Join(root, "a")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("after RemoveAll, Stat err = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestOsFileSystem_WalkDir(t *testing.T) {
+	f := NewOsFileSystem()
+	root := t.TempDir()
+
+	if err := f.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := f.Write(filepath.Join(root, "top.txt"), []byte("top"), 0o600); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := f.Write(filepath.Join(root, "sub", "inner.txt"), []byte("inner"), 0o600); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var files []string
+	err := f.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			rel, _ := filepath.Rel(root, path)
+			files = append(files, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+
+	wantFiles := map[string]bool{"top.txt": true, "sub/inner.txt": true}
+	if len(files) != len(wantFiles) {
+		t.Fatalf("WalkDir visited %v, want %d files", files, len(wantFiles))
+	}
+	for _, f := range files {
+		if !wantFiles[f] {
+			t.Errorf("unexpected file %q", f)
+		}
+	}
+}

--- a/adapters/os_process_spawner.go
+++ b/adapters/os_process_spawner.go
@@ -1,0 +1,81 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// OsProcessSpawner implements ports.ProcessSpawner using os/exec.
+type OsProcessSpawner struct{}
+
+// NewOsProcessSpawner returns a ProcessSpawner backed by os/exec.
+func NewOsProcessSpawner() *OsProcessSpawner {
+	return &OsProcessSpawner{}
+}
+
+// Run executes the requested process and waits for it to exit. A non-
+// zero exit code surfaces in the result, not as an error; err is non-
+// nil only when the process fails to start or when ctx is cancelled.
+func (s *OsProcessSpawner) Run(ctx context.Context, req ports.ProcessRequest) (ports.ProcessResult, error) {
+	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
+	cmd.Env = req.Env
+	cmd.Dir = req.WorkingDir
+	if req.Stdin != nil {
+		cmd.Stdin = req.Stdin
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	result := ports.ProcessResult{
+		Stdout: stdout.Bytes(),
+		Stderr: stderr.Bytes(),
+	}
+
+	// Exit code is available on the ProcessState after Run, even on
+	// non-zero exit. If the process never started, ProcessState is nil.
+	if cmd.ProcessState != nil {
+		result.ExitCode = cmd.ProcessState.ExitCode()
+	}
+
+	// Context cancellation trumps exit status: a process killed by the
+	// context produces an ExitError, but we want callers to see the
+	// cancellation rather than a misleading "non-zero exit".
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return result, ctxErr
+	}
+
+	// Distinguish "process ran and exited non-zero" (no error, exit code
+	// in result) from "process failed to start" (error).
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return result, nil
+	}
+	if runErr != nil {
+		return result, fmt.Errorf("run %s: %w", req.Name, runErr)
+	}
+	return result, nil
+}
+
+// LookPath resolves name via the host PATH.
+func (s *OsProcessSpawner) LookPath(name string) (string, error) {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", fmt.Errorf("%s: %w", name, ports.ErrExecutableNotFound)
+		}
+		return "", err
+	}
+	return path, nil
+}
+
+// Compile-time check that OsProcessSpawner implements the port.
+var _ ports.ProcessSpawner = (*OsProcessSpawner)(nil)

--- a/adapters/os_process_spawner_test.go
+++ b/adapters/os_process_spawner_test.go
@@ -1,0 +1,106 @@
+package adapters
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+func TestOsProcessSpawner_RunSuccess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("echo semantics differ on Windows; adapter behavior is the same but this test uses POSIX /bin/echo")
+	}
+
+	spawner := NewOsProcessSpawner()
+	ctx := context.Background()
+
+	result, err := spawner.Run(ctx, ports.ProcessRequest{
+		Name: "/bin/echo",
+		Args: []string{"hello"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if got := strings.TrimSpace(string(result.Stdout)); got != "hello" {
+		t.Errorf("Stdout = %q, want %q", got, "hello")
+	}
+}
+
+func TestOsProcessSpawner_RunNonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX /bin/sh")
+	}
+
+	spawner := NewOsProcessSpawner()
+	ctx := context.Background()
+
+	// A non-zero exit is NOT an error; it's reflected in ExitCode.
+	result, err := spawner.Run(ctx, ports.ProcessRequest{
+		Name: "/bin/sh",
+		Args: []string{"-c", "exit 7"},
+	})
+	if err != nil {
+		t.Fatalf("Run returned err for non-zero exit: %v", err)
+	}
+	if result.ExitCode != 7 {
+		t.Errorf("ExitCode = %d, want 7", result.ExitCode)
+	}
+}
+
+func TestOsProcessSpawner_RunFailsToStart(t *testing.T) {
+	spawner := NewOsProcessSpawner()
+	ctx := context.Background()
+
+	_, err := spawner.Run(ctx, ports.ProcessRequest{
+		Name: "/definitely/not/a/real/binary-xyz",
+	})
+	if err == nil {
+		t.Fatal("Run: want err for missing binary, got nil")
+	}
+}
+
+func TestOsProcessSpawner_RunContextCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX /bin/sh sleep")
+	}
+
+	spawner := NewOsProcessSpawner()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := spawner.Run(ctx, ports.ProcessRequest{
+		Name: "/bin/sh",
+		Args: []string{"-c", "sleep 5"},
+	})
+	if err == nil {
+		t.Fatal("Run: want err from cancelled context, got nil")
+	}
+}
+
+func TestOsProcessSpawner_LookPath(t *testing.T) {
+	spawner := NewOsProcessSpawner()
+
+	// sh is present on all POSIX systems we target.
+	if runtime.GOOS != "windows" {
+		path, err := spawner.LookPath("sh")
+		if err != nil {
+			t.Fatalf("LookPath(sh): %v", err)
+		}
+		if path == "" {
+			t.Error("LookPath(sh) returned empty path")
+		}
+	}
+
+	_, err := spawner.LookPath("definitely-not-a-real-binary-xyz-" + t.Name())
+	if !errors.Is(err, ports.ErrExecutableNotFound) {
+		t.Errorf("LookPath missing binary: err = %v, want ErrExecutableNotFound", err)
+	}
+}

--- a/api/aws_auth_test.go
+++ b/api/aws_auth_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gruntwork-io/runbooks/core/ports/fakes"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -23,7 +25,8 @@ func setupTestRouter(t *testing.T, sm *SessionManager) *gin.Engine {
 	outputPath := workingDir + "/output"
 
 	// Use the real route setup - this is what we're testing
-	setupCommonRoutes(r, gruntbookPath, workingDir, outputPath, nil, sm, false)
+	tokens := NewTokenResolver(fakes.NewFakeEnvironment(nil), fakes.NewFakeProcessSpawner())
+	setupCommonRoutes(r, gruntbookPath, workingDir, outputPath, nil, sm, tokens, false)
 
 	return r
 }

--- a/api/git_clone.go
+++ b/api/git_clone.go
@@ -243,7 +243,7 @@ func (w *sseWriter) fail(msg string)  { w.log(msg); w.status("fail", 1); w.done(
 // HandleGitClone performs a git clone operation with real-time SSE streaming.
 // POST /api/git/clone
 // Requires SessionAuthMiddleware.
-func HandleGitClone(sm *SessionManager, workingDir string) gin.HandlerFunc {
+func HandleGitClone(sm *SessionManager, workingDir string, tokens *TokenResolver) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req GitCloneRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -318,7 +318,7 @@ func HandleGitClone(sm *SessionManager, workingDir string) gin.HandlerFunc {
 		// Inject a git auth token if one is available for this host
 		cloneURL := req.URL
 		if parsed, err := url.Parse(req.URL); err == nil {
-			if token := GetTokenForHost(parsed.Hostname()); token != "" {
+			if token := tokens.TokenForHost(parsed.Hostname()); token != "" {
 				cloneURL = InjectGitToken(req.URL, token)
 			}
 		}

--- a/api/git_clone_test.go
+++ b/api/git_clone_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/runbooks/core/ports/fakes"
+
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -236,7 +238,10 @@ func TestGitCloneUsesInitialWorkDir(t *testing.T) {
 
 	// Set up a router with the clone handler using the INITIAL working directory
 	router := gin.New()
-	router.POST("/api/git/clone", SessionAuthMiddleware(sm), HandleGitClone(sm, initialWorkDir))
+	// The test supplies no remote URL tokens; a nil-friendly fake resolver
+	// keeps the handler's nil guard unnecessary.
+	tokens := NewTokenResolver(fakes.NewFakeEnvironment(nil), fakes.NewFakeProcessSpawner())
+	router.POST("/api/git/clone", SessionAuthMiddleware(sm), HandleGitClone(sm, initialWorkDir, tokens))
 
 	// Send a clone request — the URL is invalid on purpose (we only care about
 	// the path resolution, not whether the clone actually succeeds). The handler

--- a/api/remote_token.go
+++ b/api/remote_token.go
@@ -2,55 +2,117 @@ package api
 
 import (
 	"context"
-	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
 )
 
-// GetTokenForHost returns an auth token for the given git host.
-// For github.com: checks GITHUB_TOKEN → GH_TOKEN → `gh auth token` (5s timeout)
-// For gitlab.com: checks GITLAB_TOKEN → `glab auth token` (5s timeout)
-// Returns empty string if no token is found (not an error — repo may be public).
+// TokenResolver looks up auth tokens for git hosts, consulting environment
+// variables first and then falling back to host-specific CLI tools
+// (`gh auth token`, `glab auth token`). Results are cached per-resolver so
+// repeated lookups for the same CLI don't re-spawn the process.
 //
-// The token is only used in-memory for authenticating git operations.
-// It is never written to disk, logged, or included in error messages.
-func GetTokenForHost(host string) string {
+// The resolver depends on the Environment and ProcessSpawner ports so the
+// same logic works against the real host environment (desktop) and against
+// tenant-scoped adapters (future hosted service) without modification.
+type TokenResolver struct {
+	env     ports.Environment
+	spawner ports.ProcessSpawner
+
+	mu    sync.Mutex
+	cache map[string]string
+}
+
+// NewTokenResolver returns a TokenResolver backed by the given ports.
+func NewTokenResolver(env ports.Environment, spawner ports.ProcessSpawner) *TokenResolver {
+	return &TokenResolver{
+		env:     env,
+		spawner: spawner,
+		cache:   make(map[string]string),
+	}
+}
+
+// TokenForHost returns an auth token for the given git host.
+//
+//	github.com → GITHUB_TOKEN → GH_TOKEN → `gh auth token` (5s timeout)
+//	gitlab.com → GITLAB_TOKEN → `glab auth token` (5s timeout)
+//
+// Returns "" if no token is found (not an error — the repo may be public).
+// The returned token is only used in-memory for authenticating git
+// operations; it is never written to disk, logged, or included in error
+// messages.
+func (r *TokenResolver) TokenForHost(host string) string {
 	switch strings.ToLower(host) {
 	case "github.com":
-		return getGitHubTokenFromEnv()
+		return r.githubTokenFromEnv()
 	case "gitlab.com":
-		return getGitLabTokenFromEnv()
+		return r.gitlabTokenFromEnv()
 	default:
 		return ""
 	}
 }
 
-// getGitHubTokenFromEnv checks GITHUB_TOKEN, GH_TOKEN env vars,
-// then falls back to `gh auth token` CLI.
-func getGitHubTokenFromEnv() string {
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+func (r *TokenResolver) githubTokenFromEnv() string {
+	if token, ok := r.env.Get("GITHUB_TOKEN"); ok && token != "" {
 		return token
 	}
-	if token := os.Getenv("GH_TOKEN"); token != "" {
+	if token, ok := r.env.Get("GH_TOKEN"); ok && token != "" {
 		return token
 	}
-	return tokenFromCLI("gh", "auth", "token")
+	return r.tokenFromCLI("gh", "auth", "token")
 }
 
-// getGitLabTokenFromEnv checks GITLAB_TOKEN env var,
-// then falls back to `glab auth token` CLI.
-func getGitLabTokenFromEnv() string {
-	if token := os.Getenv("GITLAB_TOKEN"); token != "" {
+func (r *TokenResolver) gitlabTokenFromEnv() string {
+	if token, ok := r.env.Get("GITLAB_TOKEN"); ok && token != "" {
 		return token
 	}
-	return tokenFromCLI("glab", "auth", "token")
+	return r.tokenFromCLI("glab", "auth", "token")
+}
+
+// tokenFromCLI runs a CLI command via the ProcessSpawner port and returns
+// the trimmed stdout output. Results are cached per-resolver. Returns ""
+// if the command is not found, fails, or returns empty output.
+func (r *TokenResolver) tokenFromCLI(name string, args ...string) string {
+	key := name + " " + strings.Join(args, " ")
+
+	r.mu.Lock()
+	if cached, ok := r.cache[key]; ok {
+		r.mu.Unlock()
+		return cached
+	}
+	r.mu.Unlock()
+
+	path, err := r.spawner.LookPath(name)
+	if err != nil {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := r.spawner.Run(ctx, ports.ProcessRequest{
+		Name: path,
+		Args: args,
+	})
+	if err != nil || result.ExitCode != 0 {
+		return ""
+	}
+
+	token := strings.TrimSpace(string(result.Stdout))
+
+	r.mu.Lock()
+	r.cache[key] = token
+	r.mu.Unlock()
+
+	return token
 }
 
 // AuthHintForHost returns the environment variable name and CLI command
 // that a user should use to authenticate with the given git host.
-// Returns empty strings for unknown hosts.
+// Returns empty strings for unknown hosts. This is pure metadata and
+// doesn't need any ports.
 func AuthHintForHost(host string) (tokenVar, cliCmd string) {
 	switch strings.ToLower(host) {
 	case "github.com":
@@ -60,45 +122,4 @@ func AuthHintForHost(host string) (tokenVar, cliCmd string) {
 	default:
 		return "", ""
 	}
-}
-
-var (
-	cliTokenCache   = make(map[string]string)
-	cliTokenCacheMu sync.Mutex
-)
-
-// tokenFromCLI runs a CLI command and returns the trimmed stdout output.
-// Results are cached so repeated calls for the same command don't re-spawn processes.
-// Returns empty string if the command is not found, fails, or returns empty output.
-func tokenFromCLI(name string, args ...string) string {
-	key := name + " " + strings.Join(args, " ")
-
-	cliTokenCacheMu.Lock()
-	if cached, ok := cliTokenCache[key]; ok {
-		cliTokenCacheMu.Unlock()
-		return cached
-	}
-	cliTokenCacheMu.Unlock()
-
-	path, err := exec.LookPath(name)
-	if err != nil {
-		return ""
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, path, args...)
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	token := strings.TrimSpace(string(output))
-
-	cliTokenCacheMu.Lock()
-	cliTokenCache[key] = token
-	cliTokenCacheMu.Unlock()
-
-	return token
 }

--- a/api/remote_token_test.go
+++ b/api/remote_token_test.go
@@ -3,54 +3,78 @@ package api
 import (
 	"testing"
 
+	"github.com/gruntwork-io/runbooks/core/ports"
+	"github.com/gruntwork-io/runbooks/core/ports/fakes"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetTokenForHost_GitHubEnvVars(t *testing.T) {
+func newTestResolver(env map[string]string) *TokenResolver {
+	return NewTokenResolver(fakes.NewFakeEnvironment(env), fakes.NewFakeProcessSpawner())
+}
+
+func TestTokenResolver_GitHubEnvVars(t *testing.T) {
 	// GITHUB_TOKEN takes precedence over GH_TOKEN
-	t.Setenv("GITHUB_TOKEN", "gh-token-1")
-	t.Setenv("GH_TOKEN", "gh-token-2")
+	r := newTestResolver(map[string]string{
+		"GITHUB_TOKEN": "gh-token-1",
+		"GH_TOKEN":     "gh-token-2",
+	})
 
-	token := GetTokenForHost("github.com")
-	assert.Equal(t, "gh-token-1", token)
+	assert.Equal(t, "gh-token-1", r.TokenForHost("github.com"))
 }
 
-func TestGetTokenForHost_GitHubFallsBackToGHToken(t *testing.T) {
-	// When GITHUB_TOKEN is not set, GH_TOKEN is used
-	t.Setenv("GITHUB_TOKEN", "")
-	t.Setenv("GH_TOKEN", "gh-token-2")
+func TestTokenResolver_GitHubFallsBackToGHToken(t *testing.T) {
+	// When GITHUB_TOKEN is unset or empty, GH_TOKEN is used
+	r := newTestResolver(map[string]string{
+		"GH_TOKEN": "gh-token-2",
+	})
 
-	token := GetTokenForHost("github.com")
-	assert.Equal(t, "gh-token-2", token)
+	assert.Equal(t, "gh-token-2", r.TokenForHost("github.com"))
 }
 
-func TestGetTokenForHost_GitLabEnvVar(t *testing.T) {
-	t.Setenv("GITLAB_TOKEN", "gl-token-1")
+func TestTokenResolver_GitLabEnvVar(t *testing.T) {
+	r := newTestResolver(map[string]string{
+		"GITLAB_TOKEN": "gl-token-1",
+	})
 
-	token := GetTokenForHost("gitlab.com")
-	assert.Equal(t, "gl-token-1", token)
+	assert.Equal(t, "gl-token-1", r.TokenForHost("gitlab.com"))
 }
 
-func TestGetTokenForHost_CaseInsensitive(t *testing.T) {
-	t.Setenv("GITHUB_TOKEN", "gh-token")
-	t.Setenv("GITLAB_TOKEN", "gl-token")
+func TestTokenResolver_CaseInsensitive(t *testing.T) {
+	r := newTestResolver(map[string]string{
+		"GITHUB_TOKEN": "gh-token",
+		"GITLAB_TOKEN": "gl-token",
+	})
 
-	assert.Equal(t, "gh-token", GetTokenForHost("GitHub.com"))
-	assert.Equal(t, "gh-token", GetTokenForHost("GITHUB.COM"))
-	assert.Equal(t, "gl-token", GetTokenForHost("GitLab.com"))
-	assert.Equal(t, "gl-token", GetTokenForHost("GITLAB.COM"))
+	assert.Equal(t, "gh-token", r.TokenForHost("GitHub.com"))
+	assert.Equal(t, "gh-token", r.TokenForHost("GITHUB.COM"))
+	assert.Equal(t, "gl-token", r.TokenForHost("GitLab.com"))
+	assert.Equal(t, "gl-token", r.TokenForHost("GITLAB.COM"))
 }
 
-func TestGetTokenForHost_UnknownHost(t *testing.T) {
-	token := GetTokenForHost("bitbucket.org")
-	assert.Equal(t, "", token)
+func TestTokenResolver_UnknownHost(t *testing.T) {
+	r := newTestResolver(nil)
+
+	assert.Equal(t, "", r.TokenForHost("bitbucket.org"))
 }
 
-func TestGetTokenForHost_GitLabNoTokenSet(t *testing.T) {
-	t.Setenv("GITLAB_TOKEN", "")
+func TestTokenResolver_FallsBackToCLIWhenEnvMissing(t *testing.T) {
+	env := fakes.NewFakeEnvironment(nil)
+	spawner := fakes.NewFakeProcessSpawner()
+	spawner.SetLookPath("gh", "/usr/local/bin/gh")
+	spawner.QueueRun(ports.ProcessResult{Stdout: []byte("gh-cli-token\n")}, nil)
 
-	token := GetTokenForHost("gitlab.com")
-	// glab CLI may or may not be installed; if not, token is empty.
-	// Either way, verify the env var path returns empty.
-	assert.Empty(t, token)
+	r := NewTokenResolver(env, spawner)
+
+	assert.Equal(t, "gh-cli-token", r.TokenForHost("github.com"))
+
+	// Second call should hit the cache (no new scripted response queued).
+	assert.Equal(t, "gh-cli-token", r.TokenForHost("github.com"))
+}
+
+func TestTokenResolver_EmptyWhenCLINotFoundAndNoEnv(t *testing.T) {
+	r := newTestResolver(nil) // spawner has no LookPath entries, so gh is "not found"
+
+	assert.Empty(t, r.TokenForHost("github.com"))
+	assert.Empty(t, r.TokenForHost("gitlab.com"))
 }

--- a/api/server.go
+++ b/api/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gruntwork-io/runbooks/adapters"
 	"github.com/gruntwork-io/runbooks/api/telemetry"
 	"github.com/gruntwork-io/runbooks/web"
 
@@ -13,7 +14,7 @@ import (
 )
 
 // setupCommonRoutes sets up the common routes for both server modes
-func setupCommonRoutes(r *gin.Engine, gruntbookPath string, workingDir string, outputPath string, registry *ExecutableRegistry, sessionManager *SessionManager, useExecutableRegistry bool) {
+func setupCommonRoutes(r *gin.Engine, gruntbookPath string, workingDir string, outputPath string, registry *ExecutableRegistry, sessionManager *SessionManager, tokens *TokenResolver, useExecutableRegistry bool) {
 	// If the gruntbook contains AwsAuth blocks, strip AWS credentials from session
 	// at creation time. This ensures users must explicitly confirm which AWS account
 	// they want to use before any scripts can access the credentials.
@@ -107,14 +108,14 @@ func setupCommonRoutes(r *gin.Engine, gruntbookPath string, workingDir string, o
 		protectedAPI.GET("/github/repos", HandleGitHubListRepos(sessionManager))
 		protectedAPI.GET("/github/refs", HandleGitHubListRefs(sessionManager))
 		// Git clone endpoint (SSE streaming)
-		protectedAPI.POST("/git/clone", HandleGitClone(sessionManager, workingDir))
+		protectedAPI.POST("/git/clone", HandleGitClone(sessionManager, workingDir, tokens))
 		// GitHub pull request endpoints
 		protectedAPI.GET("/github/labels", HandleGitHubListLabels(sessionManager))
 		protectedAPI.POST("/git/pull-request", HandleGitPullRequest(sessionManager))
 		protectedAPI.POST("/git/push", HandleGitPush(sessionManager))
 		protectedAPI.DELETE("/git/branch", HandleGitDeleteBranch())
 		// OpenTofu module parsing (reads local files and may clone remote repos with user tokens)
-		protectedAPI.POST("/tf/parse", HandleTfModuleParse(gruntbookPath))
+		protectedAPI.POST("/tf/parse", HandleTfModuleParse(gruntbookPath, tokens))
 		// Workspace endpoints for file tree, file content, and git changes
 		protectedAPI.GET("/workspace/tree", HandleWorkspaceTree())
 		protectedAPI.GET("/workspace/dirs", HandleWorkspaceDirs())
@@ -195,6 +196,11 @@ func StartServer(cfg ServerConfig) error {
 
 	sessionManager := NewSessionManager()
 
+	// Host-backed adapters for the ports consumed by handlers built in
+	// setupCommonRoutes. A hosted build would swap in tenant-scoped
+	// adapters here without changing anything downstream.
+	tokens := NewTokenResolver(adapters.NewOsEnvironment(), adapters.NewOsProcessSpawner())
+
 	r := newGinEngine(cfg.ReleaseMode)
 	r.SetTrustedProxies(nil)
 
@@ -224,7 +230,7 @@ func StartServer(cfg ServerConfig) error {
 		r.GET("/api/watch", HandleWatchSSE(fileWatcher))
 	}
 
-	setupCommonRoutes(r, resolvedPath, cfg.WorkingDir, cfg.OutputPath, registry, sessionManager, cfg.UseExecutableRegistry)
+	setupCommonRoutes(r, resolvedPath, cfg.WorkingDir, cfg.OutputPath, registry, sessionManager, tokens, cfg.UseExecutableRegistry)
 
 	return r.Run(fmt.Sprintf("127.0.0.1:%d", cfg.Port))
 }

--- a/api/tf_parse_handler.go
+++ b/api/tf_parse_handler.go
@@ -36,7 +36,7 @@ type TfParseResponse struct {
 // with additional module metadata (folder name, README title, outputs, resources).
 // The source can be a local path (resolved relative to the gruntbook directory) or a remote
 // git URL (cloned to a temp directory, parsed, then cleaned up).
-func HandleTfModuleParse(gruntbookPath string) gin.HandlerFunc {
+func HandleTfModuleParse(gruntbookPath string, tokens *TokenResolver) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req TfParseRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -49,7 +49,7 @@ func HandleTfModuleParse(gruntbookPath string) gin.HandlerFunc {
 		}
 
 		// Determine if this is a remote URL or a local path
-		modulePath, cleanup, err := resolveModuleSource(req.Source, gruntbookPath)
+		modulePath, cleanup, err := resolveModuleSource(req.Source, gruntbookPath, tokens)
 		if err != nil {
 			slog.Error("Failed to resolve module source", "source", req.Source, "error", err)
 			c.JSON(http.StatusBadRequest, gin.H{
@@ -110,7 +110,10 @@ func HandleTfModuleParse(gruntbookPath string) gin.HandlerFunc {
 // resolveModuleSource resolves a module source string to a local filesystem path.
 // For local paths, resolves relative to the gruntbook directory.
 // For remote URLs, clones to a temp directory and returns a cleanup function.
-func resolveModuleSource(source string, gruntbookPath string) (localPath string, cleanup func(), err error) {
+//
+// tokens may be nil for callers that never pass remote URLs (e.g., unit
+// tests covering only the local-path branches).
+func resolveModuleSource(source string, gruntbookPath string, tokens *TokenResolver) (localPath string, cleanup func(), err error) {
 	parsed, err := ParseRemoteSource(source)
 	if err != nil {
 		return "", nil, fmt.Errorf("invalid module source %q: %w", source, err)
@@ -137,7 +140,10 @@ func resolveModuleSource(source string, gruntbookPath string) (localPath string,
 	}
 	releaseSem := func() { <-tfRemoteCloneSem }
 
-	token := GetTokenForHost(parsed.Host)
+	var token string
+	if tokens != nil {
+		token = tokens.TokenForHost(parsed.Host)
+	}
 	if err := parsed.Resolve(token); err != nil {
 		releaseSem()
 		return "", nil, fmt.Errorf("failed to resolve remote ref: %w", err)

--- a/api/tf_parse_handler_test.go
+++ b/api/tf_parse_handler_test.go
@@ -17,7 +17,9 @@ import (
 // tfParseRequest is a test helper that fires a POST /api/tf/parse with the given body.
 func tfParseRequest(t *testing.T, gruntbookPath string, body interface{}) (int, []byte) {
 	t.Helper()
-	return postJSON(t, "/api/tf/parse", HandleTfModuleParse(gruntbookPath), body)
+	// These tests exercise only local-path resolution, so a nil resolver is
+	// safe: resolveModuleSource only touches tokens on the remote-URL branch.
+	return postJSON(t, "/api/tf/parse", HandleTfModuleParse(gruntbookPath, nil), body)
 }
 
 func TestHandleTfModuleParse_LocalPath(t *testing.T) {
@@ -85,7 +87,7 @@ func TestHandleTfModuleParse_DotPath(t *testing.T) {
 func TestHandleTfModuleParse_InvalidJSON(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.POST("/api/tf/parse", HandleTfModuleParse("/fake/gruntbook.mdx"))
+	router.POST("/api/tf/parse", HandleTfModuleParse("/fake/gruntbook.mdx", nil))
 
 	req, err := http.NewRequest("POST", "/api/tf/parse", bytes.NewBufferString("not json"))
 	require.NoError(t, err)
@@ -203,7 +205,7 @@ func TestHandleTfModuleParse_ModuleWithOutputsAndResources(t *testing.T) {
 func TestResolveModuleSource_AbsolutePath(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	localPath, cleanup, err := resolveModuleSource(tmpDir, "/some/gruntbook.mdx")
+	localPath, cleanup, err := resolveModuleSource(tmpDir, "/some/gruntbook.mdx", nil)
 	require.NoError(t, err)
 	assert.Nil(t, cleanup)
 	assert.Equal(t, tmpDir, localPath, "absolute paths should be returned as-is")
@@ -213,7 +215,7 @@ func TestResolveModuleSource_RelativePath(t *testing.T) {
 	gruntbookDir := t.TempDir()
 	gruntbookPath := filepath.Join(gruntbookDir, "gruntbook.mdx")
 
-	localPath, cleanup, err := resolveModuleSource("../modules/vpc", gruntbookPath)
+	localPath, cleanup, err := resolveModuleSource("../modules/vpc", gruntbookPath, nil)
 	require.NoError(t, err)
 	assert.Nil(t, cleanup)
 
@@ -225,7 +227,7 @@ func TestResolveModuleSource_DotPath(t *testing.T) {
 	gruntbookDir := t.TempDir()
 	gruntbookPath := filepath.Join(gruntbookDir, "gruntbook.mdx")
 
-	localPath, cleanup, err := resolveModuleSource(".", gruntbookPath)
+	localPath, cleanup, err := resolveModuleSource(".", gruntbookPath, nil)
 	require.NoError(t, err)
 	assert.Nil(t, cleanup)
 	assert.Equal(t, gruntbookDir, localPath, "'.' should resolve to the gruntbook directory")
@@ -235,7 +237,7 @@ func TestResolveModuleSource_NestedRelativePath(t *testing.T) {
 	gruntbookDir := t.TempDir()
 	gruntbookPath := filepath.Join(gruntbookDir, "gruntbook.mdx")
 
-	localPath, cleanup, err := resolveModuleSource("modules/vpc", gruntbookPath)
+	localPath, cleanup, err := resolveModuleSource("modules/vpc", gruntbookPath, nil)
 	require.NoError(t, err)
 	assert.Nil(t, cleanup)
 

--- a/cmd/remote_open.go
+++ b/cmd/remote_open.go
@@ -10,10 +10,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gruntwork-io/runbooks/adapters"
 	"github.com/gruntwork-io/runbooks/api"
 
 	"github.com/spf13/cobra"
 )
+
+// cmdTokenResolver returns a TokenResolver backed by the host process's
+// real environment and process spawner. CLI commands that download
+// remote sources use this to authenticate against private git hosts.
+//
+// A new resolver is created per call so the per-resolver CLI cache
+// doesn't outlive the command. Commands that make many lookups in one
+// invocation should hold the returned resolver instead of calling this
+// repeatedly.
+func cmdTokenResolver() *api.TokenResolver {
+	return api.NewTokenResolver(adapters.NewOsEnvironment(), adapters.NewOsProcessSpawner())
+}
 
 // validateSourceArg is a Cobra Args validator that provides a clear error when GRUNTBOOK_SOURCE is missing.
 func validateSourceArg(cmd *cobra.Command, args []string) error {
@@ -54,7 +67,7 @@ func downloadRemoteSource(parsed *api.ParsedRemoteSource) (string, func(), error
 	}
 
 	// Resolve the remote ref
-	token := api.GetTokenForHost(parsed.Host)
+	token := cmdTokenResolver().TokenForHost(parsed.Host)
 	if err := parsed.Resolve(token); err != nil {
 		return "", nil, err
 	}

--- a/core/ports/doc.go
+++ b/core/ports/doc.go
@@ -1,0 +1,14 @@
+// Package ports defines the interfaces that domain code depends on.
+//
+// Domain code in core/ must import only from core/ports/ and standard
+// library packages that are not OS-coupled (no os, os/exec, syscall,
+// net/http, etc.). OS-coupled implementations live in the adapters
+// package.
+//
+// Each entry point (desktop, CLI, future hosted service) composes a
+// set of adapters that satisfy these ports. This lets the same domain
+// code run in a desktop app reading the user's real environment and,
+// later, in a multi-tenant service with env vars scoped per tenant,
+// filesystem calls confined to a per-tenant directory, and process
+// spawning routed through a sandbox.
+package ports

--- a/core/ports/environment.go
+++ b/core/ports/environment.go
@@ -1,0 +1,24 @@
+package ports
+
+// Environment is a read-only view of environment variables.
+//
+// Domain code reads env vars exclusively through this port. The desktop
+// adapter reads from os.Environ(). A hosted adapter would read from a
+// tenant-scoped allowlist, preventing domain code from probing env vars
+// it has no business seeing.
+//
+// The port is intentionally read-only. Mutating the host process
+// environment is never a domain concern — environments passed to child
+// processes are built explicitly by the Session and handed to the
+// ProcessSpawner.
+type Environment interface {
+	// Get returns the value of key and whether it was set. An empty string
+	// with ok=true means the var was set to the empty string, which is
+	// distinct from unset (ok=false).
+	Get(key string) (value string, ok bool)
+
+	// GetAll returns a snapshot of all environment variables as a map.
+	// The returned map is owned by the caller; mutating it does not
+	// affect the underlying environment.
+	GetAll() map[string]string
+}

--- a/core/ports/fakes/fake_environment.go
+++ b/core/ports/fakes/fake_environment.go
@@ -1,0 +1,60 @@
+// Package fakes provides in-memory implementations of core/ports interfaces
+// for use in tests. Fakes are safe to use in unit tests without touching the
+// host filesystem, environment, or process table.
+package fakes
+
+import (
+	"sync"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// FakeEnvironment is an in-memory Environment backed by a map.
+type FakeEnvironment struct {
+	mu   sync.RWMutex
+	vars map[string]string
+}
+
+// NewFakeEnvironment returns a FakeEnvironment seeded with the given vars.
+// Pass nil to start with an empty environment.
+func NewFakeEnvironment(vars map[string]string) *FakeEnvironment {
+	env := &FakeEnvironment{vars: make(map[string]string, len(vars))}
+	for k, v := range vars {
+		env.vars[k] = v
+	}
+	return env
+}
+
+// Set records a variable in the fake environment (test helper; not part of
+// the Environment port).
+func (e *FakeEnvironment) Set(key, value string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.vars[key] = value
+}
+
+// Unset removes a variable from the fake environment (test helper).
+func (e *FakeEnvironment) Unset(key string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.vars, key)
+}
+
+func (e *FakeEnvironment) Get(key string) (string, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	v, ok := e.vars[key]
+	return v, ok
+}
+
+func (e *FakeEnvironment) GetAll() map[string]string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make(map[string]string, len(e.vars))
+	for k, v := range e.vars {
+		out[k] = v
+	}
+	return out
+}
+
+var _ ports.Environment = (*FakeEnvironment)(nil)

--- a/core/ports/fakes/fake_process_spawner.go
+++ b/core/ports/fakes/fake_process_spawner.go
@@ -1,0 +1,91 @@
+package fakes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// FakeProcessSpawner is a scripted ProcessSpawner for tests. Each call to
+// Run consumes one programmed response; calls beyond the programmed set
+// return an error. LookPath consults a configurable map of executable
+// names to resolved paths.
+type FakeProcessSpawner struct {
+	mu        sync.Mutex
+	responses []FakeProcessResponse
+	calls     []FakeProcessCall
+	paths     map[string]string
+}
+
+// FakeProcessResponse is a scripted outcome for a single Run call.
+type FakeProcessResponse struct {
+	Result ports.ProcessResult
+	Err    error
+}
+
+// FakeProcessCall records the request that was made to Run, so tests can
+// assert on what the caller asked for.
+type FakeProcessCall struct {
+	Request ports.ProcessRequest
+}
+
+// NewFakeProcessSpawner returns a FakeProcessSpawner with no programmed
+// responses and no path mappings.
+func NewFakeProcessSpawner() *FakeProcessSpawner {
+	return &FakeProcessSpawner{paths: make(map[string]string)}
+}
+
+// QueueRun adds a scripted response for the next Run call.
+func (s *FakeProcessSpawner) QueueRun(result ports.ProcessResult, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.responses = append(s.responses, FakeProcessResponse{Result: result, Err: err})
+}
+
+// SetLookPath configures LookPath to return resolved for name. Passing an
+// empty resolved causes LookPath to return ErrExecutableNotFound.
+func (s *FakeProcessSpawner) SetLookPath(name, resolved string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.paths[name] = resolved
+}
+
+// Calls returns all Run calls recorded since construction.
+func (s *FakeProcessSpawner) Calls() []FakeProcessCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]FakeProcessCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func (s *FakeProcessSpawner) Run(ctx context.Context, req ports.ProcessRequest) (ports.ProcessResult, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, FakeProcessCall{Request: req})
+	if len(s.responses) == 0 {
+		s.mu.Unlock()
+		return ports.ProcessResult{}, fmt.Errorf("fake process spawner: no response queued for %s", req.Name)
+	}
+	resp := s.responses[0]
+	s.responses = s.responses[1:]
+	s.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return ports.ProcessResult{}, err
+	}
+	return resp.Result, resp.Err
+}
+
+func (s *FakeProcessSpawner) LookPath(name string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	resolved, ok := s.paths[name]
+	if !ok || resolved == "" {
+		return "", fmt.Errorf("%s: %w", name, ports.ErrExecutableNotFound)
+	}
+	return resolved, nil
+}
+
+var _ ports.ProcessSpawner = (*FakeProcessSpawner)(nil)

--- a/core/ports/filesystem.go
+++ b/core/ports/filesystem.go
@@ -1,0 +1,43 @@
+package ports
+
+import "io/fs"
+
+// FileSystem abstracts filesystem access for domain code.
+//
+// Paths are interpreted by the adapter. The desktop adapter treats them
+// as absolute or relative paths on the host filesystem. A hosted adapter
+// could confine all paths to a per-tenant root directory, rejecting
+// path traversal attempts before they reach the host.
+//
+// This port uses io/fs types (FileInfo, DirEntry, FileMode, WalkDirFunc)
+// so the ports package itself imports nothing from os.
+type FileSystem interface {
+	// Read returns the contents of the file at path.
+	Read(path string) ([]byte, error)
+
+	// Write writes data to the file at path, creating it (with perm) if
+	// it doesn't exist or truncating it if it does.
+	Write(path string, data []byte, perm fs.FileMode) error
+
+	// Stat returns file info for the given path.
+	Stat(path string) (fs.FileInfo, error)
+
+	// ReadDir returns the entries in the directory at path, sorted by
+	// filename.
+	ReadDir(path string) ([]fs.DirEntry, error)
+
+	// MkdirAll creates the directory at path along with any necessary
+	// parents. Returns nil if the directory already exists.
+	MkdirAll(path string, perm fs.FileMode) error
+
+	// Remove removes the file or empty directory at path.
+	Remove(path string) error
+
+	// RemoveAll removes path and any children it contains. Returns nil
+	// if the path does not exist.
+	RemoveAll(path string) error
+
+	// WalkDir walks the file tree rooted at root, calling fn for each
+	// file or directory. The walk follows the io/fs.WalkDir contract.
+	WalkDir(root string, fn fs.WalkDirFunc) error
+}

--- a/core/ports/process.go
+++ b/core/ports/process.go
@@ -1,0 +1,64 @@
+package ports
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// ErrExecutableNotFound is returned by LookPath when an executable cannot be
+// located on PATH. Adapters should wrap this so callers can detect it with
+// errors.Is without depending on os/exec.
+var ErrExecutableNotFound = errors.New("executable not found")
+
+// ProcessRequest describes a process to be spawned.
+type ProcessRequest struct {
+	// Name is the executable name (resolved via PATH) or absolute path.
+	Name string
+
+	// Args are passed to the process (not including Name as argv[0]).
+	Args []string
+
+	// Env is the environment for the child process as KEY=VALUE pairs.
+	// If nil, the adapter may use an empty environment; domain code
+	// should always build this explicitly so behavior is deterministic.
+	Env []string
+
+	// WorkingDir is the child process's working directory. If empty,
+	// the adapter's behavior is implementation-defined.
+	WorkingDir string
+
+	// Stdin, if non-nil, is copied to the child process's standard input.
+	Stdin io.Reader
+}
+
+// ProcessResult holds the completed process's output and exit status.
+type ProcessResult struct {
+	Stdout   []byte
+	Stderr   []byte
+	ExitCode int
+}
+
+// ProcessSpawner runs child processes.
+//
+// The desktop adapter wraps os/exec. A hosted adapter would route
+// spawning through a sandbox (gVisor, Firecracker, K8s job) so that
+// untrusted runbook scripts run with resource limits and isolation.
+//
+// This port covers one-shot commands (git, gh, auth CLIs). The long-
+// running, streaming, PTY-based exec path used by <Command> blocks
+// will be introduced as a separate port in a later milestone so its
+// richer surface (streaming output, signal forwarding, PTY resize) can
+// be shaped deliberately.
+type ProcessSpawner interface {
+	// Run starts the process, waits for it to exit, and returns its
+	// captured output. A non-zero exit code is returned in the result
+	// (not as an error); err is non-nil only for failures to start the
+	// process or for context cancellation.
+	Run(ctx context.Context, req ProcessRequest) (ProcessResult, error)
+
+	// LookPath resolves an executable name to an absolute path using
+	// the spawner's view of PATH. Returns ErrExecutableNotFound if the
+	// executable is not found.
+	LookPath(name string) (string, error)
+}


### PR DESCRIPTION
## Summary

First slice of the hexagonal refactor for the Wails rewrite. Defines three infrastructure ports (Environment, FileSystem, ProcessSpawner) and ships OS-backed adapters plus in-memory fakes for testing.

- **`core/ports/`** — port interfaces (no OS imports; FileSystem uses `io/fs` types so core stays infrastructure-free)
- **`adapters/`** — `OsEnvironment`, `OsFileSystem`, `OsProcessSpawner` wrapping the stdlib
- **`core/ports/fakes/`** — `FakeEnvironment`, `FakeProcessSpawner` (scripted responses, `LookPath` control, call recording)

Migrates the first consumer — the git-host token resolver — from free functions that called `os.LookupEnv` and `exec.Command` directly to a `TokenResolver` struct that takes its dependencies via constructor. Handlers (`git_clone`, `tf_parse_handler`) and the `cmd/` entrypoints now receive the resolver; tests use fake-backed resolvers instead of `t.Setenv` and the real `gh` CLI.

Remaining `api/` consumers (aws, github, exec, git clone) migrate to ports in M0b/M0c.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)