### PR TITLE
[Wails] M0c: Add GitHubClient port, HTTP adapter, fake; migrate HandleGitHubValidate

### DIFF
--- a/adapters/http_github_client.go
+++ b/adapters/http_github_client.go
@@ -1,0 +1,88 @@
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// githubAPIBaseURL is the REST API base. Only github.com is supported —
+// custom GitHub Enterprise base URLs are not currently wired through,
+// and accepting arbitrary ones would be an SSRF vector for a future
+// hosted deployment.
+const githubAPIBaseURL = "https://api.github.com"
+
+// HttpGitHubClient is the production GitHubClient, backed by net/http
+// against api.github.com.
+type HttpGitHubClient struct {
+	// client is exposed for test injection (e.g. httptest.Server-based
+	// integration tests in adapters/). Domain tests should use
+	// fakes.FakeGitHubClient instead.
+	client *http.Client
+	base   string
+}
+
+// NewHttpGitHubClient constructs the production HTTP-backed client using
+// http.DefaultClient against api.github.com.
+func NewHttpGitHubClient() *HttpGitHubClient {
+	return &HttpGitHubClient{client: http.DefaultClient, base: githubAPIBaseURL}
+}
+
+// ValidateToken calls GET /user with the provided bearer token. The
+// returned scopes come from the X-OAuth-Scopes response header, which is
+// GitHub's canonical place to advertise classic PAT / OAuth scopes.
+func (c *HttpGitHubClient) ValidateToken(ctx context.Context, token string) (*ports.GitHubUser, []string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/user", nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to call GitHub API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, nil, fmt.Errorf("invalid or expired token")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var scopes []string
+	if header := resp.Header.Get("X-OAuth-Scopes"); header != "" {
+		for _, s := range strings.Split(header, ",") {
+			if scope := strings.TrimSpace(s); scope != "" {
+				scopes = append(scopes, scope)
+			}
+		}
+	}
+
+	var body struct {
+		Login     string `json:"login"`
+		Name      string `json:"name"`
+		AvatarURL string `json:"avatar_url"`
+		Email     string `json:"email"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse GitHub response: %w", err)
+	}
+
+	return &ports.GitHubUser{
+		Login:     body.Login,
+		Name:      body.Name,
+		AvatarURL: body.AvatarURL,
+		Email:     body.Email,
+	}, scopes, nil
+}

--- a/api/aws_auth_test.go
+++ b/api/aws_auth_test.go
@@ -27,7 +27,8 @@ func setupTestRouter(t *testing.T, sm *SessionManager) *gin.Engine {
 	// Use the real route setup - this is what we're testing
 	tokens := NewTokenResolver(fakes.NewFakeEnvironment(nil), fakes.NewFakeProcessSpawner())
 	awsClient := fakes.NewFakeAwsClient(nil)
-	setupCommonRoutes(r, gruntbookPath, workingDir, outputPath, nil, sm, tokens, awsClient, false)
+	ghClient := fakes.NewFakeGitHubClient(nil)
+	setupCommonRoutes(r, gruntbookPath, workingDir, outputPath, nil, sm, tokens, awsClient, ghClient, false)
 
 	return r
 }

--- a/api/github_auth.go
+++ b/api/github_auth.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
 )
 
 // =============================================================================
@@ -179,7 +181,8 @@ func (r *GitHubCliCredentialsResponse) HasRepoScope() bool {
 // =============================================================================
 
 // HandleGitHubValidate validates a GitHub token by calling the /user endpoint
-func HandleGitHubValidate() gin.HandlerFunc {
+// through the GitHubClient port.
+func HandleGitHubValidate(gh ports.GitHubClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req GitHubValidateRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -201,7 +204,7 @@ func HandleGitHubValidate() gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		user, scopes, err := validateGitHubToken(ctx, req.Token)
+		user, scopes, err := gh.ValidateToken(ctx, req.Token)
 		if err != nil {
 			c.JSON(http.StatusOK, GitHubValidateResponse{
 				Valid: false,
@@ -212,10 +215,25 @@ func HandleGitHubValidate() gin.HandlerFunc {
 
 		c.JSON(http.StatusOK, GitHubValidateResponse{
 			Valid:     true,
-			User:      user,
+			User:      githubUserInfoFromPort(user),
 			Scopes:    scopes,
 			TokenType: detectGitHubTokenType(req.Token),
 		})
+	}
+}
+
+// githubUserInfoFromPort converts a ports.GitHubUser to the
+// JSON-serializable GitHubUserInfo shape the HTTP API returns. Nil maps
+// to nil so the omitempty JSON field stays clean.
+func githubUserInfoFromPort(u *ports.GitHubUser) *GitHubUserInfo {
+	if u == nil {
+		return nil
+	}
+	return &GitHubUserInfo{
+		Login:     u.Login,
+		Name:      u.Name,
+		AvatarURL: u.AvatarURL,
+		Email:     u.Email,
 	}
 }
 

--- a/api/github_validate_test.go
+++ b/api/github_validate_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+	"github.com/gruntwork-io/runbooks/core/ports/fakes"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func githubValidateRequest(t *testing.T, client ports.GitHubClient, body any) (int, GitHubValidateResponse) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/validate", HandleGitHubValidate(client))
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	var resp GitHubValidateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	return w.Code, resp
+}
+
+func TestHandleGitHubValidate_MissingTokenRejected(t *testing.T) {
+	client := fakes.NewFakeGitHubClient(nil)
+
+	code, resp := githubValidateRequest(t, client, GitHubValidateRequest{})
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.False(t, resp.Valid)
+	assert.Equal(t, "Token is required", resp.Error)
+
+	// Handler must reject before calling the port.
+	assert.Empty(t, client.Calls, "no ValidateToken calls expected when token is empty")
+}
+
+func TestHandleGitHubValidate_ValidTokenReturnsUserAndScopes(t *testing.T) {
+	client := fakes.NewFakeGitHubClient(&ports.GitHubUser{
+		Login:     "octocat",
+		Name:      "The Octocat",
+		AvatarURL: "https://avatars.example/oc.png",
+		Email:     "octo@example.test",
+	})
+	client.Scopes = []string{"repo", "read:org"}
+
+	code, resp := githubValidateRequest(t, client, GitHubValidateRequest{
+		Token: "ghp_abc123def456",
+	})
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.True(t, resp.Valid)
+	require.NotNil(t, resp.User)
+	assert.Equal(t, "octocat", resp.User.Login)
+	assert.Equal(t, "The Octocat", resp.User.Name)
+	assert.Equal(t, []string{"repo", "read:org"}, resp.Scopes)
+	assert.Equal(t, GitHubTokenTypeClassicPAT, resp.TokenType, "ghp_ prefix -> classic PAT")
+
+	require.Len(t, client.Calls, 1)
+	assert.Equal(t, "ValidateToken", client.Calls[0].Method)
+	assert.Equal(t, "ghp_abc123def456", client.Calls[0].Token, "handler must pass the token through unchanged")
+}
+
+func TestHandleGitHubValidate_ClientErrorSurfacedAsInvalid(t *testing.T) {
+	client := fakes.NewFakeGitHubClient(nil)
+	client.QueueValidateErr(errors.New("invalid or expired token"))
+
+	code, resp := githubValidateRequest(t, client, GitHubValidateRequest{
+		Token: "ghp_bad",
+	})
+
+	// Bad tokens come back as HTTP 200 with Valid:false — keeps the
+	// frontend flow single-path (bad creds aren't a transport error).
+	assert.Equal(t, http.StatusOK, code)
+	assert.False(t, resp.Valid)
+	assert.Equal(t, "invalid or expired token", resp.Error)
+}
+
+func TestHandleGitHubValidate_TokenTypeDetection(t *testing.T) {
+	tests := []struct {
+		token    string
+		expected GitHubTokenType
+	}{
+		{"github_pat_xyz", GitHubTokenTypeFineGrainedPAT},
+		{"ghp_classic", GitHubTokenTypeClassicPAT},
+		{"gho_oauth", GitHubTokenTypeOAuth},
+		{"ghs_app", GitHubTokenTypeGitHubApp},
+		{"ghu_user", GitHubTokenTypeGitHubApp},
+		{"garbage", GitHubTokenTypeUnknown},
+	}
+
+	client := fakes.NewFakeGitHubClient(&ports.GitHubUser{Login: "user"})
+
+	for _, tc := range tests {
+		t.Run(string(tc.expected), func(t *testing.T) {
+			_, resp := githubValidateRequest(t, client, GitHubValidateRequest{Token: tc.token})
+			assert.True(t, resp.Valid)
+			assert.Equal(t, tc.expected, resp.TokenType)
+		})
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -15,7 +15,7 @@ import (
 )
 
 // setupCommonRoutes sets up the common routes for both server modes
-func setupCommonRoutes(r *gin.Engine, gruntbookPath string, workingDir string, outputPath string, registry *ExecutableRegistry, sessionManager *SessionManager, tokens *TokenResolver, aws ports.AwsClient, useExecutableRegistry bool) {
+func setupCommonRoutes(r *gin.Engine, gruntbookPath string, workingDir string, outputPath string, registry *ExecutableRegistry, sessionManager *SessionManager, tokens *TokenResolver, aws ports.AwsClient, gh ports.GitHubClient, useExecutableRegistry bool) {
 	// If the gruntbook contains AwsAuth blocks, strip AWS credentials from session
 	// at creation time. This ensures users must explicitly confirm which AWS account
 	// they want to use before any scripts can access the credentials.
@@ -141,7 +141,7 @@ func setupCommonRoutes(r *gin.Engine, gruntbookPath string, workingDir string, o
 
 	// GitHub authentication endpoints (no credentials returned)
 	// No token required: these endpoints don't return secrets
-	r.POST("/api/github/validate", HandleGitHubValidate())     // Validates token, returns user info
+	r.POST("/api/github/validate", HandleGitHubValidate(gh))   // Validates token, returns user info
 	r.POST("/api/github/oauth/start", HandleGitHubOAuthStart()) // Device flow: returns device code
 
 	// Serve gruntbook assets (images, PDFs, media files, etc.) from the gruntbook's assets directory
@@ -202,6 +202,7 @@ func StartServer(cfg ServerConfig) error {
 	// adapters here without changing anything downstream.
 	tokens := NewTokenResolver(adapters.NewOsEnvironment(), adapters.NewOsProcessSpawner())
 	awsClient := adapters.NewSdkAwsClient()
+	ghClient := adapters.NewHttpGitHubClient()
 
 	r := newGinEngine(cfg.ReleaseMode)
 	r.SetTrustedProxies(nil)
@@ -232,7 +233,7 @@ func StartServer(cfg ServerConfig) error {
 		r.GET("/api/watch", HandleWatchSSE(fileWatcher))
 	}
 
-	setupCommonRoutes(r, resolvedPath, cfg.WorkingDir, cfg.OutputPath, registry, sessionManager, tokens, awsClient, cfg.UseExecutableRegistry)
+	setupCommonRoutes(r, resolvedPath, cfg.WorkingDir, cfg.OutputPath, registry, sessionManager, tokens, awsClient, ghClient, cfg.UseExecutableRegistry)
 
 	return r.Run(fmt.Sprintf("127.0.0.1:%d", cfg.Port))
 }

--- a/core/ports/fakes/fake_github_client.go
+++ b/core/ports/fakes/fake_github_client.go
@@ -1,0 +1,88 @@
+package fakes
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// FakeGitHubClient is a scripted GitHubClient for tests. Each call pops
+// the next response from ValidateResponses; if the queue is empty, the
+// canned User/Scopes are returned. Errors are queued separately so tests
+// can script (user-hit, transient-error, user-hit) scenarios.
+type FakeGitHubClient struct {
+	mu sync.Mutex
+
+	// Canned default response when no queued response is available.
+	User   *ports.GitHubUser
+	Scopes []string
+
+	// Queued responses (FIFO). Each entry overrides User/Scopes for a
+	// single call.
+	ValidateResponses []FakeGitHubValidate
+
+	// Queued errors (FIFO). Consumed in lock-step with ValidateToken
+	// calls — if an error is queued, it's returned; otherwise the
+	// response/canned value is returned.
+	ValidateErrs []error
+
+	// Call log: records every ValidateToken invocation's token argument.
+	// Tests assert against this to confirm the handler passed the right
+	// token through.
+	Calls []FakeGitHubCall
+}
+
+// FakeGitHubValidate is a single queued response for ValidateToken.
+type FakeGitHubValidate struct {
+	User   *ports.GitHubUser
+	Scopes []string
+}
+
+// FakeGitHubCall records a single invocation on FakeGitHubClient.
+type FakeGitHubCall struct {
+	Method string
+	Token  string
+}
+
+// NewFakeGitHubClient returns a fake with the given canned user (pass
+// nil to start without one). Tests override User/Scopes or queue
+// responses via the exported fields.
+func NewFakeGitHubClient(user *ports.GitHubUser) *FakeGitHubClient {
+	return &FakeGitHubClient{User: user}
+}
+
+func (f *FakeGitHubClient) ValidateToken(ctx context.Context, token string) (*ports.GitHubUser, []string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.Calls = append(f.Calls, FakeGitHubCall{Method: "ValidateToken", Token: token})
+
+	if err := popErr(&f.ValidateErrs); err != nil {
+		return nil, nil, err
+	}
+	if len(f.ValidateResponses) > 0 {
+		resp := f.ValidateResponses[0]
+		f.ValidateResponses = f.ValidateResponses[1:]
+		return resp.User, resp.Scopes, nil
+	}
+	return f.User, f.Scopes, nil
+}
+
+// QueueValidateErr queues an error to be returned by the next
+// ValidateToken call.
+func (f *FakeGitHubClient) QueueValidateErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ValidateErrs = append(f.ValidateErrs, err)
+}
+
+// QueueValidateResponse queues a response for the next ValidateToken
+// call, overriding the canned User/Scopes for that single call.
+func (f *FakeGitHubClient) QueueValidateResponse(user *ports.GitHubUser, scopes []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ValidateResponses = append(f.ValidateResponses, FakeGitHubValidate{User: user, Scopes: scopes})
+}
+
+var _ ports.GitHubClient = (*FakeGitHubClient)(nil)

--- a/core/ports/github.go
+++ b/core/ports/github.go
@@ -1,0 +1,30 @@
+package ports
+
+import "context"
+
+// GitHubUser is the subset of GitHub's /user response the application uses.
+// Missing fields (Name, Email, AvatarURL) simply come back empty — GitHub
+// returns them as JSON null for users who haven't set them, and no
+// application code treats that as an error.
+type GitHubUser struct {
+	Login     string
+	Name      string
+	AvatarURL string
+	Email     string
+}
+
+// GitHubClient is the port for GitHub REST + OAuth operations. Domain code
+// never calls github.com directly; it depends on this port so a hosted
+// deployment can swap in a tenant-scoped client (e.g. a GitHub App
+// installation token scoped to a tenant's org) instead of relying on the
+// user's personal token sitting in env vars or ~/.config/gh/.
+//
+// The interface will grow as more handlers migrate; this initial surface
+// covers what HandleGitHubValidate needs.
+type GitHubClient interface {
+	// ValidateToken calls GET /user with the given bearer token and
+	// returns the user plus the OAuth scopes from X-OAuth-Scopes.
+	// Returns an error for HTTP 401 (invalid/expired token) or any
+	// non-2xx response.
+	ValidateToken(ctx context.Context, token string) (*GitHubUser, []string, error)
+}


### PR DESCRIPTION
Stacked on #127 (M0b). Rebase-target: \`feat/wails-rewrite\` once #126 + #127 land.

## Summary

Third slice of the hexagonal refactor. Defines \`ports.GitHubClient\` with a single method — \`ValidateToken\` — which is exactly what \`HandleGitHubValidate\` needs. Plain-value \`GitHubUser\` keeps the domain free of \`net/http\` imports and of hardcoded \`api.github.com\`. Ships the \`HttpGitHubClient\` adapter (net/http against \`api.github.com\`) and \`FakeGitHubClient\` with scripted responses, an error queue, and a call log.

The interface stays minimal on purpose — I'd rather grow it as more handlers migrate (\`HandleGitHubOAuthPoll\`, \`HandleGitHubEnvCredentials\`, \`HandleGitHubCliCredentials\`, org/repo/refs listing) than over-size it now. The existing in-file \`validateGitHubToken\` helper stays for those handlers until they move.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` (all packages pass)
- [x] Four new tests in \`api/github_validate_test.go\`: missing-token rejection, valid-token happy path (user + scopes + token-type inference), client error surfaced as \`Valid:false\`, token-type detection across all known prefixes. No network hits.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)