### PR TITLE
[Wails] Fix demo2 Playwright flake: bump 2s timeouts to 5s

### DIFF
--- a/web/e2e/test-sample-gruntbooks.spec.ts
+++ b/web/e2e/test-sample-gruntbooks.spec.ts
@@ -88,9 +88,9 @@ test.describe("sample-gruntbooks/demo2", () => {
     const infraLiveElements = page.getByTestId('infra-live-elements-inputs');
     await infraLiveElements.getByRole('textbox', { name: 'Org Name Prefix' }).fill('my_prefix');
     await infraLiveElements.getByRole('button', { name: 'Generate', exact: true }).click();
-    await expect(generated.getTreeItem('subfolder')).toBeVisible({ timeout: 2_000 });
+    await expect(generated.getTreeItem('subfolder')).toBeVisible({ timeout: 5_000 });
     await generated.getTreeItem('subfolder').click();
-    await expect(generated.getTreeItem('sample.hcl')).toBeVisible({ timeout: 2_000 });
+    await expect(generated.getTreeItem('sample.hcl')).toBeVisible({ timeout: 5_000 });
     await generated.getTreeItem('sample.hcl').click();
     await expect(generated.getCodeFile('subfolder/sample.hcl')).toContainText('name_prefix = "my_prefix"');
 
@@ -138,20 +138,20 @@ test.describe("sample-gruntbooks/demo2", () => {
     const genFiles = getFilesPanel(page, 'generated');
 
     // Verify common.hcl contains values from our inputs.
-    await expect(genFiles.getTreeItem('common.hcl')).toBeVisible({ timeout: 2_000 });
+    await expect(genFiles.getTreeItem('common.hcl')).toBeVisible({ timeout: 5_000 });
     await genFiles.getTreeItem('common.hcl').click();
     await expect(genFiles.getCodeFile('common.hcl')).toContainText('name_prefix    = "acme"');
     await expect(genFiles.getCodeFile('common.hcl')).toContainText('default_region = "eu-west-1"');
     await expect(genFiles.getCodeFile('common.hcl')).toContainText('config_s3_bucket_name');
 
     // Verify accounts.yml contains the structured map entry.
-    await expect(genFiles.getTreeItem('accounts.yml')).toBeVisible({ timeout: 2_000 });
+    await expect(genFiles.getTreeItem('accounts.yml')).toBeVisible({ timeout: 5_000 });
     await genFiles.getTreeItem('accounts.yml').click();
     await expect(genFiles.getCodeFile('accounts.yml')).toContainText('dev-account');
     await expect(genFiles.getCodeFile('accounts.yml')).toContainText('111222333444');
 
     // Verify the root terragrunt file uses our custom name.
-    await expect(genFiles.getTreeItem('terragrunt2.hcl')).toBeVisible({ timeout: 2_000 });
+    await expect(genFiles.getTreeItem('terragrunt2.hcl')).toBeVisible({ timeout: 5_000 });
     await genFiles.getTreeItem('terragrunt2.hcl').click();
 
     expectNoConsoleErrors(consoleMessages);


### PR DESCRIPTION
## Summary
- Five `toBeVisible({ timeout: 2_000 })` assertions in `test-sample-gruntbooks.spec.ts` (demo2 tests) wait for generated file-tree items after clicking **Generate**. Under CI load the boilerplate render → fs walk → tree populate path can exceed 2s, producing intermittent failures.
- PR #127 confirmed the flake: the exact same commit produced one passing Playwright run (3m5s) and one failing run (1m38s) at `test-sample-gruntbooks.spec.ts:91`.
- The comparable demo3 test at line 238 uses a 5s timeout for the same "click Generate → assert tree item visible" pattern and passes reliably. Aligning demo2 with that baseline.

## Diff
Five timeouts: `2_000` → `5_000`. No logic changes.

## Test plan
- [ ] Playwright E2E passes on this PR.
- [ ] Rerun Playwright 2–3× on the PR to confirm the flake is gone (pre-fix it was failing ~50%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)