### PR TITLE
[Wails] M0e+f: Remaining ports, composition root, core-import lint

### DIFF
--- a/adapters/log_emitter.go
+++ b/adapters/log_emitter.go
@@ -1,0 +1,21 @@
+package adapters
+
+import (
+	"log/slog"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// LogEmitter writes emissions to slog at Debug level. Useful in CLI
+// debugging and for integration tests that want to see what domain
+// code is emitting without wiring up a real transport.
+type LogEmitter struct{}
+
+func NewLogEmitter() LogEmitter { return LogEmitter{} }
+
+func (LogEmitter) Emit(topic string, payload any) error {
+	slog.Debug("emit", "topic", topic, "payload", payload)
+	return nil
+}
+
+var _ ports.Emitter = LogEmitter{}

--- a/adapters/noop_audit_log.go
+++ b/adapters/noop_audit_log.go
@@ -1,0 +1,21 @@
+package adapters
+
+import (
+	"context"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// NoopAuditLog discards audit events. Desktop mode uses this because
+// a single-user local context has limited value for an audit trail.
+// Hosted deployments swap in a database- or SIEM-backed adapter at
+// the composition root.
+type NoopAuditLog struct{}
+
+func NewNoopAuditLog() NoopAuditLog { return NoopAuditLog{} }
+
+func (NoopAuditLog) Record(ctx context.Context, event ports.AuditEvent) error {
+	return nil
+}
+
+var _ ports.AuditLog = NoopAuditLog{}

--- a/adapters/noop_authorizer.go
+++ b/adapters/noop_authorizer.go
@@ -1,0 +1,21 @@
+package adapters
+
+import (
+	"context"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// NoopAuthorizer allows every action. Desktop mode uses this because
+// the actor is always the single local user — there is no other
+// principal to authorize against. Hosted deployments swap this for
+// an OIDC- or RBAC-backed implementation at the composition root.
+type NoopAuthorizer struct{}
+
+func NewNoopAuthorizer() NoopAuthorizer { return NoopAuthorizer{} }
+
+func (NoopAuthorizer) Check(ctx context.Context, subject ports.Subject, action, resource string) error {
+	return nil
+}
+
+var _ ports.Authorizer = NoopAuthorizer{}

--- a/adapters/noop_emitter.go
+++ b/adapters/noop_emitter.go
@@ -1,0 +1,14 @@
+package adapters
+
+import "github.com/gruntwork-io/runbooks/core/ports"
+
+// NoopEmitter discards every emission. Used in CLI subcommands that
+// don't have a transport to push events to (e.g. `gruntbooks test`),
+// and as a safe default at composition roots still being wired up.
+type NoopEmitter struct{}
+
+func NewNoopEmitter() NoopEmitter { return NoopEmitter{} }
+
+func (NoopEmitter) Emit(topic string, payload any) error { return nil }
+
+var _ ports.Emitter = NoopEmitter{}

--- a/adapters/system_clock.go
+++ b/adapters/system_clock.go
@@ -1,0 +1,21 @@
+package adapters
+
+import (
+	"time"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// SystemClock reads the host's wall clock. Used everywhere except
+// tests (which use fakes.FakeClock) and hosted deployments that
+// need a controlled clock.
+type SystemClock struct{}
+
+// NewSystemClock returns a SystemClock instance. The struct is
+// empty so the constructor is a convenience; the value type is
+// also safe to use directly.
+func NewSystemClock() SystemClock { return SystemClock{} }
+
+func (SystemClock) Now() time.Time { return time.Now() }
+
+var _ ports.Clock = SystemClock{}

--- a/api/aws_auth.go
+++ b/api/aws_auth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gopkg.in/ini.v1"
 
+	coreaws "github.com/gruntwork-io/runbooks/core/aws"
 	"github.com/gruntwork-io/runbooks/core/ports"
 )
 
@@ -246,10 +247,10 @@ const (
 // Handlers
 // =============================================================================
 
-// HandleAwsValidate validates AWS credentials by calling STS GetCallerIdentity
-// through the AwsClient port. If the user's selected region differs from the
-// validation region, the handler also checks region opt-in status and surfaces
-// a warning.
+// HandleAwsValidate validates AWS credentials. The HTTP handler is a
+// thin adapter: it parses JSON, calls coreaws.Validate, and shapes
+// the result into the JSON response. All credential-handling logic
+// lives in core/aws.
 func HandleAwsValidate(aws ports.AwsClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req ValidateCredentialsRequest
@@ -261,68 +262,24 @@ func HandleAwsValidate(aws ports.AwsClient) gin.HandlerFunc {
 			return
 		}
 
-		if req.AccessKeyID == "" || req.SecretAccessKey == "" {
-			c.JSON(http.StatusOK, ValidateCredentialsResponse{
-				Valid: false,
-				Error: "Access Key ID and Secret Access Key are required",
-			})
-			return
-		}
-
-		// Always use us-east-1 for validation — this region is always
-		// enabled. The user's selected default region may be an opt-in
-		// region (e.g. af-south-1) that isn't enabled for their account,
-		// which would make validation fail even with valid credentials.
-		validationRegion := "us-east-1"
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 		defer cancel()
 
-		validationCreds := ports.AwsCredentials{
+		result := coreaws.Validate(ctx, aws, coreaws.ValidateRequest{
 			AccessKeyID:     req.AccessKeyID,
 			SecretAccessKey: req.SecretAccessKey,
 			SessionToken:    req.SessionToken,
-			Region:          validationRegion,
-		}
-		identity, err := aws.ValidateStaticCredentials(ctx, validationCreds)
-		if err != nil {
-			c.JSON(http.StatusOK, ValidateCredentialsResponse{
-				Valid: false,
-				Error: fmt.Sprintf("Invalid credentials: %v", err),
-			})
-			return
-		}
-
-		var warning string
-		if req.Region != "" && req.Region != validationRegion {
-			status, _ := aws.CheckRegionOptInStatus(ctx, validationCreds, req.Region)
-			warning = regionOptInWarning(status, req.Region)
-		}
+			Region:          req.Region,
+		})
 
 		c.JSON(http.StatusOK, ValidateCredentialsResponse{
-			Valid:       true,
-			AccountID:   identity.AccountID,
-			AccountName: identity.AccountName,
-			Arn:         identity.Arn,
-			Warning:     warning,
+			Valid:       result.Valid,
+			AccountID:   result.AccountID,
+			AccountName: result.AccountName,
+			Arn:         result.Arn,
+			Warning:     result.Warning,
+			Error:       result.Error,
 		})
-	}
-}
-
-// regionOptInWarning formats a user-visible warning for a non-enabled
-// region. Returns empty string when the region is enabled or the opt-in
-// status could not be determined (AwsRegionOptInUnknown), mirroring the
-// old SDK-coupled helper's behavior.
-func regionOptInWarning(status ports.AwsRegionOptInStatus, region string) string {
-	switch status {
-	case ports.AwsRegionOptInDisabled:
-		return fmt.Sprintf("The region %s is not enabled for your AWS account. Enable it in the AWS Console under Account Settings > AWS Regions, or choose a different default region.", region)
-	case ports.AwsRegionOptInDisabling:
-		return fmt.Sprintf("The region %s is currently being disabled for your AWS account.", region)
-	case ports.AwsRegionOptInEnabling:
-		return fmt.Sprintf("The region %s is currently being enabled for your AWS account. Please wait a few minutes and try again.", region)
-	default:
-		return ""
 	}
 }
 

--- a/api/github_auth.go
+++ b/api/github_auth.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	coregithub "github.com/gruntwork-io/runbooks/core/github"
 	"github.com/gruntwork-io/runbooks/core/ports"
 )
 
@@ -71,20 +72,11 @@ const (
 	GitHubTokenTypeUnknown        GitHubTokenType = "unknown"
 )
 
-// detectGitHubTokenType determines the type of GitHub token by its prefix
+// detectGitHubTokenType is a thin adapter over the domain function in
+// core/github. The api/ alias exists because GitHubTokenType is part
+// of the JSON response shape; the core/ type is the source of truth.
 func detectGitHubTokenType(token string) GitHubTokenType {
-	switch {
-	case strings.HasPrefix(token, "github_pat_"):
-		return GitHubTokenTypeFineGrainedPAT
-	case strings.HasPrefix(token, "ghp_"):
-		return GitHubTokenTypeClassicPAT
-	case strings.HasPrefix(token, "gho_"):
-		return GitHubTokenTypeOAuth
-	case strings.HasPrefix(token, "ghs_"), strings.HasPrefix(token, "ghu_"):
-		return GitHubTokenTypeGitHubApp
-	default:
-		return GitHubTokenTypeUnknown
-	}
+	return GitHubTokenType(coregithub.DetectTokenType(token))
 }
 
 // GitHubValidateResponse represents the response from token validation
@@ -180,8 +172,12 @@ func (r *GitHubCliCredentialsResponse) HasRepoScope() bool {
 // Handlers
 // =============================================================================
 
-// HandleGitHubValidate validates a GitHub token by calling the /user endpoint
-// through the GitHubClient port.
+// HandleGitHubValidate validates a GitHub token. The HTTP handler is
+// a thin adapter: it parses JSON, delegates to coregithub.Validate,
+// and shapes the domain result into the JSON response. Empty tokens
+// return HTTP 400 (the only path that isn't 200) because the UI
+// distinguishes "user forgot to fill in the field" from "GitHub
+// rejected the token."
 func HandleGitHubValidate(gh ports.GitHubClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req GitHubValidateRequest
@@ -201,23 +197,17 @@ func HandleGitHubValidate(gh ports.GitHubClient) gin.HandlerFunc {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 		defer cancel()
 
-		user, scopes, err := gh.ValidateToken(ctx, req.Token)
-		if err != nil {
-			c.JSON(http.StatusOK, GitHubValidateResponse{
-				Valid: false,
-				Error: err.Error(),
-			})
-			return
-		}
+		result := coregithub.Validate(ctx, gh, req.Token)
 
 		c.JSON(http.StatusOK, GitHubValidateResponse{
-			Valid:     true,
-			User:      githubUserInfoFromPort(user),
-			Scopes:    scopes,
-			TokenType: detectGitHubTokenType(req.Token),
+			Valid:     result.Valid,
+			User:      githubUserInfoFromPort(result.User),
+			Scopes:    result.Scopes,
+			TokenType: GitHubTokenType(result.TokenType),
+			Error:     result.Error,
 		})
 	}
 }

--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -1,0 +1,108 @@
+package core_test
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCoreHasNoForbiddenImports enforces the hostability invariant
+// from the Wails rewrite plan: nothing under core/ may import
+// OS-coupled packages. Adapters live in /adapters; domain code
+// depends only on core/ports interfaces plus pure-stdlib packages.
+//
+// The check is implemented as a plain Go test — no golangci-lint,
+// no depguard config — so the rule is self-contained and runs
+// wherever `go test ./...` runs. When the M0 refactor brings more
+// domain code under core/, this test is the backstop that prevents
+// someone from "just this once" calling os.Getenv directly.
+//
+// _test.go files under core/ are exempt (tests can use anything);
+// non-test files under core/ports/fakes/ are exempt because fakes
+// are test support rather than shippable domain code.
+func TestCoreHasNoForbiddenImports(t *testing.T) {
+	// Note: net/url is intentionally NOT forbidden — it's pure string
+	// parsing with no OS coupling. path/filepath is likewise permitted
+	// for domain code that manipulates paths as strings (no I/O).
+	forbidden := map[string]bool{
+		"os":                              true,
+		"os/exec":                         true,
+		"os/user":                         true,
+		"syscall":                         true,
+		"net":                             true,
+		"net/http":                        true,
+		"github.com/gin-gonic/gin":        true,
+		"github.com/creack/pty":           true,
+		"github.com/fsnotify/fsnotify":    true,
+		"github.com/mixpanel/mixpanel-go": true,
+	}
+	forbiddenPrefixes := []string{
+		"github.com/aws/aws-sdk-go-v2/",
+		"github.com/gin-contrib/",
+	}
+
+	// Resolve the core/ directory regardless of the test's working
+	// directory (go test chdirs into the package under test).
+	coreDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve core dir: %v", err)
+	}
+	// core_test runs from core/, so "." is already core/.
+
+	fset := token.NewFileSet()
+
+	var violations []string
+	walkErr := filepath.Walk(coreDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			// Fakes are test support; they may pull in anything a fake needs.
+			if filepath.Base(path) == "fakes" && filepath.Base(filepath.Dir(path)) == "ports" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, imp := range file.Imports {
+			// imp.Path.Value is a quoted string literal; strip the quotes.
+			importPath := strings.Trim(imp.Path.Value, `"`)
+			if forbidden[importPath] {
+				rel, _ := filepath.Rel(coreDir, path)
+				violations = append(violations, rel+": imports "+importPath)
+				continue
+			}
+			for _, prefix := range forbiddenPrefixes {
+				if strings.HasPrefix(importPath, prefix) {
+					rel, _ := filepath.Rel(coreDir, path)
+					violations = append(violations, rel+": imports "+importPath)
+					break
+				}
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk core/: %v", walkErr)
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("forbidden OS-coupled imports under core/:\n\t%s\n\n"+
+			"Domain code must depend only on core/ports interfaces and pure-stdlib\n"+
+			"packages. Move OS-coupled code to /adapters and depend on a port.",
+			strings.Join(violations, "\n\t"))
+	}
+}

--- a/core/aws/validate.go
+++ b/core/aws/validate.go
@@ -1,0 +1,112 @@
+// Package aws contains AWS-related domain logic. All operations
+// depend on core/ports interfaces — no direct aws-sdk-go-v2 imports.
+// The OS-coupled SDK implementation lives in adapters/SdkAwsClient.
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// ValidationRegion is the region used for STS GetCallerIdentity
+// calls during credential validation. us-east-1 is always enabled on
+// every AWS account; the user's selected default region may be an
+// opt-in region (e.g. af-south-1) that isn't enabled for their
+// account, which would make validation fail even with valid
+// credentials.
+const ValidationRegion = "us-east-1"
+
+// ValidateRequest is the domain-level input for credential
+// validation: a credential triple plus the user's target region.
+// Region is optional — when empty or equal to ValidationRegion, the
+// domain function skips the opt-in check.
+type ValidateRequest struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+	Region          string
+}
+
+// ValidateResult is the domain-level outcome: either a validated
+// identity (Valid=true) or an error message suitable for surfacing
+// to users. Warning is non-empty when the user's target region is
+// not currently enabled for the account.
+//
+// Non-nil Error only appears alongside Valid=false. The shape is
+// chosen so HTTP handlers can map it directly to the existing JSON
+// response without reshaping.
+type ValidateResult struct {
+	Valid       bool
+	AccountID   string
+	AccountName string
+	Arn         string
+	Warning     string
+	Error       string
+}
+
+// Validate checks a set of credentials against STS and (when the
+// user's target region differs from ValidationRegion) the Account
+// API's region opt-in status. Returns a ValidateResult describing
+// the outcome; never returns a Go error — all failure modes are
+// surfaced as Valid=false + Error so callers don't need branching
+// error handling.
+//
+// Timeout and cancellation are the caller's responsibility: pass a
+// context with whatever deadline fits the transport (HTTP handlers
+// currently use 10 seconds).
+func Validate(ctx context.Context, client ports.AwsClient, req ValidateRequest) ValidateResult {
+	if req.AccessKeyID == "" || req.SecretAccessKey == "" {
+		return ValidateResult{
+			Valid: false,
+			Error: "Access Key ID and Secret Access Key are required",
+		}
+	}
+
+	validationCreds := ports.AwsCredentials{
+		AccessKeyID:     req.AccessKeyID,
+		SecretAccessKey: req.SecretAccessKey,
+		SessionToken:    req.SessionToken,
+		Region:          ValidationRegion,
+	}
+	identity, err := client.ValidateStaticCredentials(ctx, validationCreds)
+	if err != nil {
+		return ValidateResult{
+			Valid: false,
+			Error: fmt.Sprintf("Invalid credentials: %v", err),
+		}
+	}
+
+	var warning string
+	if req.Region != "" && req.Region != ValidationRegion {
+		status, _ := client.CheckRegionOptInStatus(ctx, validationCreds, req.Region)
+		warning = regionOptInWarning(status, req.Region)
+	}
+
+	return ValidateResult{
+		Valid:       true,
+		AccountID:   identity.AccountID,
+		AccountName: identity.AccountName,
+		Arn:         identity.Arn,
+		Warning:     warning,
+	}
+}
+
+// regionOptInWarning formats a user-visible warning for a region
+// that is not currently fully enabled. Returns "" for enabled or
+// unknown status. Unknown is treated as "assume enabled" so a
+// missing account:GetRegionOptStatus permission doesn't produce a
+// spurious warning.
+func regionOptInWarning(status ports.AwsRegionOptInStatus, region string) string {
+	switch status {
+	case ports.AwsRegionOptInDisabled:
+		return fmt.Sprintf("The region %s is not enabled for your AWS account. Enable it in the AWS Console under Account Settings > AWS Regions, or choose a different default region.", region)
+	case ports.AwsRegionOptInDisabling:
+		return fmt.Sprintf("The region %s is currently being disabled for your AWS account.", region)
+	case ports.AwsRegionOptInEnabling:
+		return fmt.Sprintf("The region %s is currently being enabled for your AWS account. Please wait a few minutes and try again.", region)
+	default:
+		return ""
+	}
+}

--- a/core/aws/validate_test.go
+++ b/core/aws/validate_test.go
@@ -1,0 +1,111 @@
+package aws_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	coreaws "github.com/gruntwork-io/runbooks/core/aws"
+	"github.com/gruntwork-io/runbooks/core/ports"
+	"github.com/gruntwork-io/runbooks/core/ports/fakes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate_MissingCredentialsRejectedBeforeCallingPort(t *testing.T) {
+	client := fakes.NewFakeAwsClient(nil)
+
+	result := coreaws.Validate(context.Background(), client, coreaws.ValidateRequest{
+		AccessKeyID: "only-the-id",
+	})
+
+	assert.False(t, result.Valid)
+	assert.Contains(t, result.Error, "Access Key ID and Secret Access Key are required")
+	assert.Empty(t, client.Calls, "no AwsClient calls expected when creds are missing")
+}
+
+func TestValidate_ValidCredentialsReturnsIdentity(t *testing.T) {
+	client := fakes.NewFakeAwsClient(&ports.AwsCallerIdentity{
+		AccountID:   "123456789012",
+		AccountName: "my-acct",
+		Arn:         "arn:aws:iam::123456789012:user/alice",
+	})
+
+	result := coreaws.Validate(context.Background(), client, coreaws.ValidateRequest{
+		AccessKeyID:     "AKIA...",
+		SecretAccessKey: "secret",
+		Region:          "us-east-1",
+	})
+
+	assert.True(t, result.Valid)
+	assert.Equal(t, "123456789012", result.AccountID)
+	assert.Equal(t, "my-acct", result.AccountName)
+	assert.Equal(t, "arn:aws:iam::123456789012:user/alice", result.Arn)
+	assert.Empty(t, result.Warning, "no warning expected when target region matches validation region")
+
+	require.Len(t, client.Calls, 1)
+	assert.Equal(t, "ValidateStaticCredentials", client.Calls[0].Method)
+	assert.Equal(t, coreaws.ValidationRegion, client.Calls[0].Creds.Region)
+}
+
+func TestValidate_InvalidCredentialsSurfacesError(t *testing.T) {
+	client := fakes.NewFakeAwsClient(nil)
+	client.QueueValidateErr(errors.New("InvalidClientTokenId: bad"))
+
+	result := coreaws.Validate(context.Background(), client, coreaws.ValidateRequest{
+		AccessKeyID:     "bad",
+		SecretAccessKey: "bad",
+	})
+
+	assert.False(t, result.Valid)
+	assert.Contains(t, result.Error, "Invalid credentials")
+	assert.Contains(t, result.Error, "InvalidClientTokenId")
+}
+
+func TestValidate_DifferentRegionTriggersOptInCheck(t *testing.T) {
+	client := fakes.NewFakeAwsClient(&ports.AwsCallerIdentity{AccountID: "1"})
+	client.OptIn = ports.AwsRegionOptInDisabled
+
+	result := coreaws.Validate(context.Background(), client, coreaws.ValidateRequest{
+		AccessKeyID:     "AKIA...",
+		SecretAccessKey: "secret",
+		Region:          "af-south-1",
+	})
+
+	assert.True(t, result.Valid)
+	assert.Contains(t, result.Warning, "af-south-1")
+	assert.Contains(t, result.Warning, "not enabled")
+
+	require.Len(t, client.Calls, 2)
+	assert.Equal(t, "CheckRegionOptInStatus", client.Calls[1].Method)
+	assert.Equal(t, "af-south-1", client.Calls[1].Region)
+}
+
+func TestValidate_UnknownOptInStatusOmitsWarning(t *testing.T) {
+	client := fakes.NewFakeAwsClient(&ports.AwsCallerIdentity{AccountID: "1"})
+	client.OptIn = ports.AwsRegionOptInUnknown
+
+	result := coreaws.Validate(context.Background(), client, coreaws.ValidateRequest{
+		AccessKeyID:     "AKIA...",
+		SecretAccessKey: "secret",
+		Region:          "af-south-1",
+	})
+
+	assert.True(t, result.Valid)
+	assert.Empty(t, result.Warning)
+}
+
+func TestValidate_EnablingRegionShowsTransientWarning(t *testing.T) {
+	client := fakes.NewFakeAwsClient(&ports.AwsCallerIdentity{AccountID: "1"})
+	client.OptIn = ports.AwsRegionOptInEnabling
+
+	result := coreaws.Validate(context.Background(), client, coreaws.ValidateRequest{
+		AccessKeyID:     "AKIA...",
+		SecretAccessKey: "secret",
+		Region:          "af-south-1",
+	})
+
+	assert.True(t, result.Valid)
+	assert.Contains(t, result.Warning, "currently being enabled")
+}

--- a/core/container.go
+++ b/core/container.go
@@ -1,0 +1,29 @@
+// Package core is the composition root for domain packages. The
+// Container bundles together the set of ports that domain code
+// depends on so entry points (CLI, desktop, future hosted service)
+// assemble one Container and hand the individual ports to whichever
+// services need them.
+//
+// This is the explicit alternative to a DI framework. Plain struct
+// injection keeps the adapter graph visible at the composition root
+// and keeps wire-up readable at a glance.
+package core
+
+import "github.com/gruntwork-io/runbooks/core/ports"
+
+// Container holds the ports a domain package may need. Not every
+// service uses every port — services declare only the fields they
+// depend on. The container is the single place entry points build
+// to see the full set of adapters in one view.
+type Container struct {
+	Env     ports.Environment
+	FS      ports.FileSystem
+	Spawner ports.ProcessSpawner
+	AWS     ports.AwsClient
+	GitHub  ports.GitHubClient
+	Git     ports.GitClient
+	Emitter ports.Emitter
+	Authz   ports.Authorizer
+	Audit   ports.AuditLog
+	Clock   ports.Clock
+}

--- a/core/github/validate.go
+++ b/core/github/validate.go
@@ -63,8 +63,9 @@ type ValidateResult struct {
 func Validate(ctx context.Context, client ports.GitHubClient, token string) ValidateResult {
 	if token == "" {
 		return ValidateResult{
-			Valid: false,
-			Error: "Token is required",
+			Valid:     false,
+			TokenType: TokenTypeUnknown,
+			Error:     "Token is required",
 		}
 	}
 

--- a/core/github/validate.go
+++ b/core/github/validate.go
@@ -1,0 +1,86 @@
+// Package github contains GitHub-related domain logic. All
+// operations depend on core/ports interfaces — no direct GitHub
+// REST client imports. The HTTP adapter lives in
+// adapters/HttpGitHubClient.
+package github
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// TokenType identifies what kind of GitHub credential a token
+// represents. Detected purely from the token's prefix — no network
+// calls — so it's cheap to include in every validation response.
+type TokenType string
+
+const (
+	TokenTypeClassicPAT     TokenType = "classic_pat"
+	TokenTypeFineGrainedPAT TokenType = "fine_grained_pat"
+	TokenTypeOAuth          TokenType = "oauth"
+	TokenTypeGitHubApp      TokenType = "github_app"
+	TokenTypeUnknown        TokenType = "unknown"
+)
+
+// DetectTokenType classifies a GitHub token by its documented
+// prefix. Returns TokenTypeUnknown for tokens with no recognized
+// prefix (legacy 40-char hex tokens, invalid strings, etc).
+func DetectTokenType(token string) TokenType {
+	switch {
+	case strings.HasPrefix(token, "github_pat_"):
+		return TokenTypeFineGrainedPAT
+	case strings.HasPrefix(token, "ghp_"):
+		return TokenTypeClassicPAT
+	case strings.HasPrefix(token, "gho_"):
+		return TokenTypeOAuth
+	case strings.HasPrefix(token, "ghs_"), strings.HasPrefix(token, "ghu_"):
+		return TokenTypeGitHubApp
+	default:
+		return TokenTypeUnknown
+	}
+}
+
+// ValidateResult is the domain-level outcome of token validation.
+// Invalid is encoded via Valid=false + Error rather than a Go error
+// so HTTP handlers can map directly to JSON without branching.
+type ValidateResult struct {
+	Valid     bool
+	User      *ports.GitHubUser
+	Scopes    []string
+	TokenType TokenType
+	Error     string
+}
+
+// Validate calls the GitHub user endpoint through the provided
+// client and returns a domain-level result. TokenType is always
+// populated (even on failure) since it's derived locally from the
+// token string. Empty tokens return Valid=false with a descriptive
+// error; the port is not called.
+//
+// The caller owns the context and therefore the timeout.
+func Validate(ctx context.Context, client ports.GitHubClient, token string) ValidateResult {
+	if token == "" {
+		return ValidateResult{
+			Valid: false,
+			Error: "Token is required",
+		}
+	}
+
+	user, scopes, err := client.ValidateToken(ctx, token)
+	if err != nil {
+		return ValidateResult{
+			Valid:     false,
+			TokenType: DetectTokenType(token),
+			Error:     err.Error(),
+		}
+	}
+
+	return ValidateResult{
+		Valid:     true,
+		User:      user,
+		Scopes:    scopes,
+		TokenType: DetectTokenType(token),
+	}
+}

--- a/core/github/validate_test.go
+++ b/core/github/validate_test.go
@@ -1,0 +1,76 @@
+package github_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	coregithub "github.com/gruntwork-io/runbooks/core/github"
+	"github.com/gruntwork-io/runbooks/core/ports"
+	"github.com/gruntwork-io/runbooks/core/ports/fakes"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectTokenType(t *testing.T) {
+	tests := []struct {
+		token    string
+		expected coregithub.TokenType
+	}{
+		{"github_pat_abc", coregithub.TokenTypeFineGrainedPAT},
+		{"ghp_abc", coregithub.TokenTypeClassicPAT},
+		{"gho_abc", coregithub.TokenTypeOAuth},
+		{"ghs_abc", coregithub.TokenTypeGitHubApp},
+		{"ghu_abc", coregithub.TokenTypeGitHubApp},
+		{"deadbeef", coregithub.TokenTypeUnknown},
+		{"", coregithub.TokenTypeUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.expected)+"/"+tt.token, func(t *testing.T) {
+			assert.Equal(t, tt.expected, coregithub.DetectTokenType(tt.token))
+		})
+	}
+}
+
+func TestValidate_EmptyTokenRejectedBeforeCallingPort(t *testing.T) {
+	client := fakes.NewFakeGitHubClient(nil)
+
+	result := coregithub.Validate(context.Background(), client, "")
+
+	assert.False(t, result.Valid)
+	assert.Contains(t, result.Error, "Token is required")
+	assert.Empty(t, client.Calls, "no GitHubClient calls expected when token is empty")
+}
+
+func TestValidate_ValidTokenReturnsUserAndScopes(t *testing.T) {
+	client := fakes.NewFakeGitHubClient(nil)
+	client.QueueValidateResponse(
+		&ports.GitHubUser{Login: "alice", Name: "Alice A."},
+		[]string{"repo", "user"},
+	)
+
+	result := coregithub.Validate(context.Background(), client, "ghp_sometoken")
+
+	assert.True(t, result.Valid)
+	require.NotNil(t, result.User)
+	assert.Equal(t, "alice", result.User.Login)
+	assert.Equal(t, []string{"repo", "user"}, result.Scopes)
+	assert.Equal(t, coregithub.TokenTypeClassicPAT, result.TokenType)
+
+	require.Len(t, client.Calls, 1)
+	assert.Equal(t, "ghp_sometoken", client.Calls[0].Token)
+}
+
+func TestValidate_ClientErrorSurfacedAsInvalid(t *testing.T) {
+	client := fakes.NewFakeGitHubClient(nil)
+	client.QueueValidateErr(errors.New("bad credentials"))
+
+	result := coregithub.Validate(context.Background(), client, "ghp_expired")
+
+	assert.False(t, result.Valid)
+	assert.Contains(t, result.Error, "bad credentials")
+	// Token type is detected even on failure — callers use it to render
+	// a token-type-specific hint in the UI.
+	assert.Equal(t, coregithub.TokenTypeClassicPAT, result.TokenType)
+}

--- a/core/ports/audit.go
+++ b/core/ports/audit.go
@@ -1,0 +1,45 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+// AuditOutcome is a small enum for whether the audited action
+// succeeded, failed on its own merits, or was denied by policy.
+// Strings are used (not ints) so JSON-serialized audit logs stay
+// human-readable without a lookup table.
+type AuditOutcome string
+
+const (
+	AuditOutcomeSuccess AuditOutcome = "success"
+	AuditOutcomeFailure AuditOutcome = "failure"
+	AuditOutcomeDenied  AuditOutcome = "denied"
+)
+
+// AuditEvent is a single record of a mutating action. Domain code
+// constructs these with no knowledge of where they'll be persisted;
+// adapters choose between stderr, a local JSON file, or a hosted
+// database.
+//
+// Details is intentionally open-shape so subsystem-specific context
+// (script fingerprint, target region, repo URL) can ride along
+// without requiring a schema change for every new action.
+type AuditEvent struct {
+	Time     time.Time
+	Subject  Subject
+	Action   string
+	Resource string
+	Outcome  AuditOutcome
+	Details  map[string]any
+}
+
+// AuditLog is the port for recording that a mutating action
+// happened. Called for every exec, credential use, file write, and
+// clone so a hosted deployment has the trail it needs for compliance
+// and forensics. Desktop uses NoopAuditLog (or a local-file adapter
+// when the user wants an on-disk trail) — the call sites in domain
+// code are identical regardless.
+type AuditLog interface {
+	Record(ctx context.Context, event AuditEvent) error
+}

--- a/core/ports/authorizer.go
+++ b/core/ports/authorizer.go
@@ -1,0 +1,31 @@
+package ports
+
+import "context"
+
+// Subject identifies the actor on whose behalf a request is being
+// made. Desktop mode has a single local actor so Subject is mostly a
+// placeholder, but the type exists from day one so every service
+// entrypoint threads it through — hosted deployments then use Tenant
+// and UserID to route authorization decisions per tenant without
+// touching domain code.
+type Subject struct {
+	Tenant string
+	UserID string
+}
+
+// Authorizer is the port for access-control checks. Every service
+// entrypoint that performs a privileged action (executing a script,
+// writing a file, using credentials, cloning a repo) calls Check so
+// the call site exists regardless of deployment mode. Desktop ships
+// NoopAuthorizer; hosted deployments swap in an OIDC/RBAC
+// implementation at the composition root.
+//
+// Action is a short verb identifier (e.g. "exec.run",
+// "credentials.use", "file.write"). Resource is a stable identifier
+// for the thing being acted on (e.g. a script's content fingerprint,
+// a file path, a credential profile name). An authorizer that denies
+// a request returns a non-nil error; domain code propagates that
+// error without interpretation.
+type Authorizer interface {
+	Check(ctx context.Context, subject Subject, action, resource string) error
+}

--- a/core/ports/clock.go
+++ b/core/ports/clock.go
@@ -1,0 +1,11 @@
+package ports
+
+import "time"
+
+// Clock is the port for reading wall-clock time. Domain code takes a
+// Clock so tests can assert on timestamps without depending on the
+// host system clock, and so a future hosted deployment can swap in a
+// clock that respects tenant-configured time zones or test overrides.
+type Clock interface {
+	Now() time.Time
+}

--- a/core/ports/emitter.go
+++ b/core/ports/emitter.go
@@ -1,0 +1,19 @@
+package ports
+
+// Emitter is the port for pushing streaming events out of core/ to
+// whichever transport the caller chose. Domain code never writes
+// streaming output to stdout/stderr directly; it calls Emit and the
+// adapter decides where the event goes.
+//
+// Adapters: the desktop adapter (future) wraps application.Event.Emit;
+// a hosted adapter would wrap SSE or a WebSocket; the CLI uses a
+// slog-based adapter; tests use FakeEmitter to record events for
+// assertion.
+//
+// Topic strings are namespaced by subsystem and correlation ID — e.g.
+// "exec:<runID>:log", "exec:<runID>:status", "git:<cloneID>:progress".
+// Payloads are any JSON-serializable value; the adapter handles
+// serialization for its transport.
+type Emitter interface {
+	Emit(topic string, payload any) error
+}

--- a/core/ports/fakes/fake_audit_log.go
+++ b/core/ports/fakes/fake_audit_log.go
@@ -1,0 +1,38 @@
+package fakes
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// FakeAuditLog records every Record call so tests can assert that
+// mutating operations audit with the expected action, resource, and
+// outcome.
+type FakeAuditLog struct {
+	mu     sync.Mutex
+	Events []ports.AuditEvent
+	// Queued errors in FIFO order.
+	Errs []error
+}
+
+// NewFakeAuditLog returns a recorder that accepts every event and
+// returns nil until errors are queued.
+func NewFakeAuditLog() *FakeAuditLog { return &FakeAuditLog{} }
+
+func (f *FakeAuditLog) Record(ctx context.Context, event ports.AuditEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Events = append(f.Events, event)
+	return popErr(&f.Errs)
+}
+
+// QueueErr queues an error for the next Record call.
+func (f *FakeAuditLog) QueueErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Errs = append(f.Errs, err)
+}
+
+var _ ports.AuditLog = (*FakeAuditLog)(nil)

--- a/core/ports/fakes/fake_authorizer.go
+++ b/core/ports/fakes/fake_authorizer.go
@@ -1,0 +1,47 @@
+package fakes
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// FakeAuthorizeCall records a single Check invocation.
+type FakeAuthorizeCall struct {
+	Subject  ports.Subject
+	Action   string
+	Resource string
+}
+
+// FakeAuthorizer records every Check call and either allows (default)
+// or returns a queued error. Tests assert against Calls to verify
+// that domain code calls Check at the right boundaries with the
+// right (action, resource) pair.
+type FakeAuthorizer struct {
+	mu    sync.Mutex
+	Calls []FakeAuthorizeCall
+	// Queued errors in FIFO order. Empty queue = allow.
+	Errs []error
+}
+
+// NewFakeAuthorizer returns an authorizer that allows every call
+// and records each invocation. Queue errors via QueueErr to
+// exercise denial paths.
+func NewFakeAuthorizer() *FakeAuthorizer { return &FakeAuthorizer{} }
+
+func (f *FakeAuthorizer) Check(ctx context.Context, subject ports.Subject, action, resource string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Calls = append(f.Calls, FakeAuthorizeCall{Subject: subject, Action: action, Resource: resource})
+	return popErr(&f.Errs)
+}
+
+// QueueErr queues an error for the next Check call.
+func (f *FakeAuthorizer) QueueErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Errs = append(f.Errs, err)
+}
+
+var _ ports.Authorizer = (*FakeAuthorizer)(nil)

--- a/core/ports/fakes/fake_clock.go
+++ b/core/ports/fakes/fake_clock.go
@@ -1,0 +1,42 @@
+package fakes
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// FakeClock returns a fixed time, advanceable via Advance or
+// repositionable via SetTime. Tests that assert on timestamps use
+// this so results are deterministic without freezing the host clock.
+type FakeClock struct {
+	mu      sync.Mutex
+	current time.Time
+}
+
+// NewFakeClock returns a clock whose Now returns t until SetTime or
+// Advance is called.
+func NewFakeClock(t time.Time) *FakeClock { return &FakeClock{current: t} }
+
+func (f *FakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.current
+}
+
+// SetTime resets the clock to t.
+func (f *FakeClock) SetTime(t time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.current = t
+}
+
+// Advance moves the clock forward by d.
+func (f *FakeClock) Advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.current = f.current.Add(d)
+}
+
+var _ ports.Clock = (*FakeClock)(nil)

--- a/core/ports/fakes/fake_emitter.go
+++ b/core/ports/fakes/fake_emitter.go
@@ -1,0 +1,60 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// FakeEmitEvent is a single recorded emission.
+type FakeEmitEvent struct {
+	Topic   string
+	Payload any
+}
+
+// FakeEmitter records every Emit call so tests can assert the stream
+// of events produced by domain code. Errors can be queued to
+// exercise failure paths (e.g. "transport disconnected mid-stream").
+// Safe for concurrent use.
+type FakeEmitter struct {
+	mu     sync.Mutex
+	Events []FakeEmitEvent
+	// Queued errors in FIFO order. Each Emit call pops one; when
+	// the queue is empty, Emit returns nil.
+	Errs []error
+}
+
+// NewFakeEmitter returns an emitter that records events and returns
+// nil from every Emit call until errors are queued.
+func NewFakeEmitter() *FakeEmitter { return &FakeEmitter{} }
+
+func (f *FakeEmitter) Emit(topic string, payload any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Events = append(f.Events, FakeEmitEvent{Topic: topic, Payload: payload})
+	return popErr(&f.Errs)
+}
+
+// QueueErr queues an error for the next Emit call.
+func (f *FakeEmitter) QueueErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Errs = append(f.Errs, err)
+}
+
+// EventsForTopic returns recorded events whose topic matches
+// exactly. Useful for asserting on a single stream without
+// filtering in the test.
+func (f *FakeEmitter) EventsForTopic(topic string) []FakeEmitEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []FakeEmitEvent
+	for _, e := range f.Events {
+		if e.Topic == topic {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+var _ ports.Emitter = (*FakeEmitter)(nil)


### PR DESCRIPTION
## Summary

Completes the M0 ports-and-adapters foundation for the Wails rewrite.

**Ports** (`core/ports/`):
- `Emitter` — streaming abstraction for future exec/git/watcher event migration
- `Authorizer` + `Subject` — access-control call site from day one (NoopAuthorizer in desktop)
- `AuditLog` + `AuditEvent` + `AuditOutcome` — audit trail for mutating operations
- `Clock` — testable time

**Adapters** (`adapters/`):
- `SystemClock`, `NoopEmitter`, `LogEmitter` (slog-backed)
- `NoopAuthorizer`, `NoopAuditLog` — desktop defaults; hosted deployments swap these at the composition root

**Fakes** (`core/ports/fakes/`): `FakeClock`, `FakeEmitter`, `FakeAuthorizer`, `FakeAuditLog`. All follow the scripted-response + call-log pattern established in M0a–M0d.

**Composition root** (`core/container.go`): `Container` bundles every port. Entry points wire one `Container` and hand individual ports to services; hosted mode will swap adapters without touching domain code.

**Domain relocation**:
- `core/aws.Validate` extracted from `HandleAwsValidate`
- `core/github.Validate` + `DetectTokenType` extracted from `HandleGitHubValidate`
- HTTP handlers in `api/` are now thin adapters: parse JSON → delegate to core → shape response

**Architecture lint** (`core/architecture_test.go`): walks the `core/` source tree and fails if any non-test file imports `os`, `os/exec`, `syscall`, `net`, `net/http`, `aws-sdk-go-v2`, `gin`, `pty`, `fsnotify`, or `mixpanel`. Self-contained — no golangci-lint infrastructure — so the rule runs wherever `go test ./...` runs. `core/ports/fakes/` exempted (test support).

## Test plan

- [x] `go test ./...` — all existing HTTP handler tests continue to pass
- [x] `go test ./core/...` — domain unit tests for `coreaws.Validate` and `coregithub.Validate` using fakes
- [x] Architecture lint verified against a synthetic violation (temp file importing `os` and `aws-sdk-go-v2/aws`) — the test caught it with the expected error message
- [x] `go build ./...` clean
- [ ] CI green on this branch

## Stack

Stacks on `josh-padnick/m0a-env-fs-process-ports` (which has M0b/c/d merged in). M0a branch eventually merges forward to `feat/wails-rewrite`.

Closes the M0 milestone (M0a–M0f). M1 is Wails v3 hello-world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorization framework for access control checks
  * Added audit logging infrastructure to record actions and outcomes
  * Added event emission system for publishing events
  * Enhanced AWS credential validation with region opt-in status detection
  * Added GitHub token type classification

* **Refactor**
  * Refactored AWS and GitHub authentication handlers to use centralized validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->