### PR TITLE
[Wails] Add CodeRabbit-generated unit tests for adapters

### DIFF
--- a/adapters/cli_git_client_test.go
+++ b/adapters/cli_git_client_test.go
@@ -1,0 +1,166 @@
+package adapters
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// ---------------------------------------------------------------------------
+// buildCloneArgs
+// ---------------------------------------------------------------------------
+
+func TestBuildCloneArgs_NoRef(t *testing.T) {
+	args := buildCloneArgs("https://github.com/org/repo.git", "/tmp/dest", "")
+	want := []string{"clone", "--progress", "https://github.com/org/repo.git", "/tmp/dest"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("buildCloneArgs = %v, want %v", args, want)
+	}
+}
+
+func TestBuildCloneArgs_WithRef(t *testing.T) {
+	args := buildCloneArgs("https://github.com/org/repo.git", "/tmp/dest", "main")
+	want := []string{"clone", "--progress", "--branch", "main", "https://github.com/org/repo.git", "/tmp/dest"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("buildCloneArgs with ref = %v, want %v", args, want)
+	}
+}
+
+func TestBuildCloneArgs_URLAndDestPreserved(t *testing.T) {
+	url := "https://token@github.com/org/private.git"
+	dest := "/home/user/workspace/project"
+	args := buildCloneArgs(url, dest, "")
+	// URL must appear before destPath
+	last2 := args[len(args)-2:]
+	if last2[0] != url || last2[1] != dest {
+		t.Errorf("expected last two args to be [%q, %q], got %v", url, dest, last2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildSparseCloneSteps
+// ---------------------------------------------------------------------------
+
+func TestBuildSparseCloneSteps_AlwaysThreeSteps(t *testing.T) {
+	steps := buildSparseCloneSteps("https://github.com/org/repo.git", "/tmp/dest", "modules/vpc", "")
+	if len(steps) != 3 {
+		t.Fatalf("buildSparseCloneSteps returned %d steps, want 3", len(steps))
+	}
+}
+
+func TestBuildSparseCloneSteps_NoRef(t *testing.T) {
+	steps := buildSparseCloneSteps("https://github.com/org/repo.git", "/tmp/dest", "modules/vpc", "")
+
+	cloneArgs := steps[0].args
+	// Must contain filter and no-checkout flags
+	if !containsAll(cloneArgs, []string{"--filter=blob:none", "--no-checkout", "--progress"}) {
+		t.Errorf("step 0 args %v missing required sparse-clone flags", cloneArgs)
+	}
+	// Must NOT contain --branch when ref is empty
+	if contains(cloneArgs, "--branch") {
+		t.Errorf("step 0 args %v contains --branch but no ref was given", cloneArgs)
+	}
+	// URL and dest must be the last two elements
+	last2 := cloneArgs[len(cloneArgs)-2:]
+	if last2[0] != "https://github.com/org/repo.git" || last2[1] != "/tmp/dest" {
+		t.Errorf("step 0 args last two = %v, want [url, dest]", last2)
+	}
+}
+
+func TestBuildSparseCloneSteps_WithRef(t *testing.T) {
+	steps := buildSparseCloneSteps("https://github.com/org/repo.git", "/tmp/dest", "modules/vpc", "v1.2.3")
+
+	cloneArgs := steps[0].args
+	if !containsSequence(cloneArgs, []string{"--branch", "v1.2.3"}) {
+		t.Errorf("step 0 args %v missing '--branch v1.2.3'", cloneArgs)
+	}
+}
+
+func TestBuildSparseCloneSteps_SparseCheckoutSet(t *testing.T) {
+	repoPath := "modules/vpc"
+	destPath := "/tmp/dest"
+	steps := buildSparseCloneSteps("https://github.com/org/repo.git", destPath, repoPath, "")
+
+	setArgs := steps[1].args
+	// Must be: -C <destPath> sparse-checkout set <repoPath>
+	want := []string{"-C", destPath, "sparse-checkout", "set", repoPath}
+	if !reflect.DeepEqual(setArgs, want) {
+		t.Errorf("step 1 args = %v, want %v", setArgs, want)
+	}
+	if steps[1].errWrap != "sparse-checkout set failed" {
+		t.Errorf("step 1 errWrap = %q, want %q", steps[1].errWrap, "sparse-checkout set failed")
+	}
+}
+
+func TestBuildSparseCloneSteps_Checkout(t *testing.T) {
+	destPath := "/tmp/dest"
+	steps := buildSparseCloneSteps("https://github.com/org/repo.git", destPath, "sub", "")
+
+	checkoutArgs := steps[2].args
+	want := []string{"-C", destPath, "checkout"}
+	if !reflect.DeepEqual(checkoutArgs, want) {
+		t.Errorf("step 2 args = %v, want %v", checkoutArgs, want)
+	}
+	if steps[2].errWrap != "checkout failed" {
+		t.Errorf("step 2 errWrap = %q, want %q", steps[2].errWrap, "checkout failed")
+	}
+}
+
+func TestBuildSparseCloneSteps_ErrWrapsAreSet(t *testing.T) {
+	steps := buildSparseCloneSteps("url", "dest", "path", "")
+	wantWraps := []string{"sparse clone failed", "sparse-checkout set failed", "checkout failed"}
+	for i, step := range steps {
+		if step.errWrap != wantWraps[i] {
+			t.Errorf("step[%d].errWrap = %q, want %q", i, step.errWrap, wantWraps[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CliGitClient constructor
+// ---------------------------------------------------------------------------
+
+func TestNewCliGitClient_ImplementsInterface(t *testing.T) {
+	c := NewCliGitClient()
+	if c == nil {
+		t.Fatal("NewCliGitClient returned nil")
+	}
+	// Compile-time check: if this assignment compiles, the interface is satisfied.
+	var _ ports.GitClient = c
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAll(slice []string, targets []string) bool {
+	for _, t := range targets {
+		if !contains(slice, t) {
+			return false
+		}
+	}
+	return true
+}
+
+// containsSequence reports whether needle appears as a contiguous sub-slice.
+func containsSequence(haystack, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		if reflect.DeepEqual(haystack[i:i+len(needle)], needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/adapters/http_github_client_test.go
+++ b/adapters/http_github_client_test.go
@@ -1,0 +1,322 @@
+package adapters
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// roundTripFunc lets a test supply a plain function as an http.RoundTripper.
+// This avoids the need for a real TCP listener (httptest.Server) so the tests
+// work in network-restricted sandbox environments.
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// githubResponse is a convenience builder for well-formed GitHub /user JSON bodies.
+type githubResponse struct {
+	Login     string `json:"login"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+	Email     string `json:"email"`
+}
+
+func jsonBody(v any) io.ReadCloser {
+	b, _ := json.Marshal(v)
+	return io.NopCloser(bytes.NewReader(b))
+}
+
+// newMockedClient builds an HttpGitHubClient whose HTTP calls are intercepted
+// by fn — no TCP socket is opened.
+func newMockedClient(fn roundTripFunc) *HttpGitHubClient {
+	return &HttpGitHubClient{
+		client: &http.Client{Transport: fn},
+		base:   "https://api.github.com", // real base; fn intercepts before dial
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — success path
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_Success(t *testing.T) {
+	var capturedReq *http.Request
+
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		capturedReq = r
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: jsonBody(githubResponse{
+				Login:     "octocat",
+				Name:      "Octo Cat",
+				AvatarURL: "https://github.com/images/octocat.png",
+				Email:     "octocat@github.com",
+			}),
+		}
+		resp.Header.Set("X-OAuth-Scopes", "repo, read:user")
+		return resp, nil
+	})
+
+	user, scopes, err := c.ValidateToken(context.Background(), "test-token")
+
+	if err != nil {
+		t.Fatalf("ValidateToken: unexpected error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("ValidateToken: user is nil")
+	}
+	if user.Login != "octocat" {
+		t.Errorf("user.Login = %q, want %q", user.Login, "octocat")
+	}
+	if user.Name != "Octo Cat" {
+		t.Errorf("user.Name = %q, want %q", user.Name, "Octo Cat")
+	}
+	if user.AvatarURL != "https://github.com/images/octocat.png" {
+		t.Errorf("user.AvatarURL = %q, want %q", user.AvatarURL, "https://github.com/images/octocat.png")
+	}
+	if user.Email != "octocat@github.com" {
+		t.Errorf("user.Email = %q, want %q", user.Email, "octocat@github.com")
+	}
+
+	wantScopes := []string{"repo", "read:user"}
+	if len(scopes) != len(wantScopes) {
+		t.Fatalf("scopes = %v, want %v", scopes, wantScopes)
+	}
+	for i, s := range scopes {
+		if s != wantScopes[i] {
+			t.Errorf("scopes[%d] = %q, want %q", i, s, wantScopes[i])
+		}
+	}
+
+	// Verify the request was wired up correctly.
+	if capturedReq == nil {
+		t.Fatal("no request was captured")
+	}
+	if capturedReq.URL.Path != "/user" {
+		t.Errorf("path = %q, want /user", capturedReq.URL.Path)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — request headers
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_SetsRequiredHeaders(t *testing.T) {
+	var capturedHeaders http.Header
+
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		capturedHeaders = r.Header.Clone()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       jsonBody(githubResponse{Login: "test"}),
+		}, nil
+	})
+
+	_, _, _ = c.ValidateToken(context.Background(), "my-token")
+
+	if got := capturedHeaders.Get("Authorization"); got != "Bearer my-token" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer my-token")
+	}
+	if got := capturedHeaders.Get("Accept"); got != "application/vnd.github+json" {
+		t.Errorf("Accept = %q, want %q", got, "application/vnd.github+json")
+	}
+	if got := capturedHeaders.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+		t.Errorf("X-GitHub-Api-Version = %q, want %q", got, "2022-11-28")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — 401 Unauthorized
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_Unauthorized(t *testing.T) {
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	user, scopes, err := c.ValidateToken(context.Background(), "bad-token")
+
+	if err == nil {
+		t.Fatal("ValidateToken: want error for 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid or expired token") {
+		t.Errorf("error = %q, want 'invalid or expired token'", err.Error())
+	}
+	if user != nil {
+		t.Errorf("user = %v, want nil", user)
+	}
+	if scopes != nil {
+		t.Errorf("scopes = %v, want nil", scopes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — non-200, non-401 status
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_ServerError(t *testing.T) {
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("internal server error body")),
+		}, nil
+	})
+
+	_, _, err := c.ValidateToken(context.Background(), "any-token")
+
+	if err == nil {
+		t.Fatal("ValidateToken: want error for 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "GitHub API error") {
+		t.Errorf("error = %q, want it to contain 'GitHub API error'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error = %q, want it to mention status 500", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — empty X-OAuth-Scopes header
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_EmptyScopes(t *testing.T) {
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		// No X-OAuth-Scopes header at all
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       jsonBody(githubResponse{Login: "noScopes"}),
+		}, nil
+	})
+
+	user, scopes, err := c.ValidateToken(context.Background(), "token")
+
+	if err != nil {
+		t.Fatalf("ValidateToken: unexpected error: %v", err)
+	}
+	if user.Login != "noScopes" {
+		t.Errorf("user.Login = %q, want %q", user.Login, "noScopes")
+	}
+	if len(scopes) != 0 {
+		t.Errorf("scopes = %v, want empty slice", scopes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — scope header with extra whitespace
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_ScopesAreTrimmed(t *testing.T) {
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		h := make(http.Header)
+		h.Set("X-OAuth-Scopes", "  repo ,  gist ,  ")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     h,
+			Body:       jsonBody(githubResponse{Login: "alice"}),
+		}, nil
+	})
+
+	_, scopes, err := c.ValidateToken(context.Background(), "token")
+
+	if err != nil {
+		t.Fatalf("ValidateToken: unexpected error: %v", err)
+	}
+	want := []string{"repo", "gist"}
+	if len(scopes) != len(want) {
+		t.Fatalf("scopes = %v, want %v", scopes, want)
+	}
+	for i, s := range scopes {
+		if s != want[i] {
+			t.Errorf("scopes[%d] = %q, want %q", i, s, want[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — malformed JSON body
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_MalformedBody(t *testing.T) {
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("{not valid json")),
+		}, nil
+	})
+
+	_, _, err := c.ValidateToken(context.Background(), "token")
+
+	if err == nil {
+		t.Fatal("ValidateToken: want error for malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse GitHub response") {
+		t.Errorf("error = %q, want 'failed to parse GitHub response'", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — transport-level error (e.g. no network)
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_TransportError(t *testing.T) {
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("network unreachable")
+	})
+
+	_, _, err := c.ValidateToken(context.Background(), "token")
+
+	if err == nil {
+		t.Fatal("ValidateToken: want error for transport failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to call GitHub API") {
+		t.Errorf("error = %q, want it to mention 'failed to call GitHub API'", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateToken — context cancellation surfaces as an error
+// ---------------------------------------------------------------------------
+
+func TestHttpGitHubClient_ValidateToken_CancelledContext(t *testing.T) {
+	c := newMockedClient(func(r *http.Request) (*http.Response, error) {
+		// Return context error to simulate cancellation propagation through the transport.
+		return nil, r.Context().Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := c.ValidateToken(ctx, "token")
+	if err == nil {
+		t.Fatal("ValidateToken: want error for cancelled context, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Constructor and interface compliance
+// ---------------------------------------------------------------------------
+
+func TestNewHttpGitHubClient_ImplementsInterface(t *testing.T) {
+	c := NewHttpGitHubClient()
+	if c == nil {
+		t.Fatal("NewHttpGitHubClient returned nil")
+	}
+	// Compile-time check: assignment verifies the interface is satisfied.
+	var _ ports.GitHubClient = c
+}

--- a/adapters/noop_adapters_test.go
+++ b/adapters/noop_adapters_test.go
@@ -1,0 +1,122 @@
+package adapters
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/runbooks/core/ports"
+)
+
+// ---------------------------------------------------------------------------
+// NoopEmitter
+// ---------------------------------------------------------------------------
+
+func TestNoopEmitter_EmitReturnsNil(t *testing.T) {
+	e := NewNoopEmitter()
+	if err := e.Emit("exec:run:log", map[string]any{"line": "hello"}); err != nil {
+		t.Errorf("Emit: want nil, got %v", err)
+	}
+}
+
+func TestNoopEmitter_EmitEmptyTopic(t *testing.T) {
+	e := NewNoopEmitter()
+	if err := e.Emit("", nil); err != nil {
+		t.Errorf("Emit empty topic: want nil, got %v", err)
+	}
+}
+
+func TestNoopEmitter_ImplementsEmitter(t *testing.T) {
+	var _ ports.Emitter = NewNoopEmitter()
+}
+
+// ---------------------------------------------------------------------------
+// LogEmitter
+// ---------------------------------------------------------------------------
+
+func TestLogEmitter_EmitReturnsNil(t *testing.T) {
+	e := NewLogEmitter()
+	if err := e.Emit("exec:run:log", "some payload"); err != nil {
+		t.Errorf("Emit: want nil, got %v", err)
+	}
+}
+
+func TestLogEmitter_EmitNilPayload(t *testing.T) {
+	e := NewLogEmitter()
+	if err := e.Emit("topic", nil); err != nil {
+		t.Errorf("Emit nil payload: want nil, got %v", err)
+	}
+}
+
+func TestLogEmitter_ImplementsEmitter(t *testing.T) {
+	var _ ports.Emitter = NewLogEmitter()
+}
+
+// ---------------------------------------------------------------------------
+// NoopAuditLog
+// ---------------------------------------------------------------------------
+
+func TestNoopAuditLog_RecordReturnsNil(t *testing.T) {
+	a := NewNoopAuditLog()
+	event := ports.AuditEvent{
+		Time:     time.Now(),
+		Subject:  ports.Subject{Tenant: "local", UserID: "alice"},
+		Action:   "exec.run",
+		Resource: "sha256:abc123",
+		Outcome:  ports.AuditOutcomeSuccess,
+		Details:  map[string]any{"script": "echo hello"},
+	}
+	if err := a.Record(context.Background(), event); err != nil {
+		t.Errorf("Record: want nil, got %v", err)
+	}
+}
+
+func TestNoopAuditLog_RecordZeroEventReturnsNil(t *testing.T) {
+	a := NewNoopAuditLog()
+	if err := a.Record(context.Background(), ports.AuditEvent{}); err != nil {
+		t.Errorf("Record zero event: want nil, got %v", err)
+	}
+}
+
+func TestNoopAuditLog_ImplementsAuditLog(t *testing.T) {
+	var _ ports.AuditLog = NewNoopAuditLog()
+}
+
+// ---------------------------------------------------------------------------
+// NoopAuthorizer
+// ---------------------------------------------------------------------------
+
+func TestNoopAuthorizer_CheckReturnsNil(t *testing.T) {
+	az := NewNoopAuthorizer()
+	subject := ports.Subject{Tenant: "local", UserID: "alice"}
+	if err := az.Check(context.Background(), subject, "exec.run", "sha256:abc"); err != nil {
+		t.Errorf("Check: want nil, got %v", err)
+	}
+}
+
+func TestNoopAuthorizer_CheckEmptySubjectReturnsNil(t *testing.T) {
+	az := NewNoopAuthorizer()
+	if err := az.Check(context.Background(), ports.Subject{}, "", ""); err != nil {
+		t.Errorf("Check empty subject: want nil, got %v", err)
+	}
+}
+
+func TestNoopAuthorizer_ImplementsAuthorizer(t *testing.T) {
+	var _ ports.Authorizer = NewNoopAuthorizer()
+}
+
+// ---------------------------------------------------------------------------
+// Regression: noop adapters must never inspect context cancellation
+// ---------------------------------------------------------------------------
+
+func TestNoopAdapters_CancelledContextDoesNotCauseError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	if err := NewNoopAuditLog().Record(ctx, ports.AuditEvent{}); err != nil {
+		t.Errorf("NoopAuditLog.Record with cancelled ctx: want nil, got %v", err)
+	}
+	if err := NewNoopAuthorizer().Check(ctx, ports.Subject{}, "any", "any"); err != nil {
+		t.Errorf("NoopAuthorizer.Check with cancelled ctx: want nil, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Cherry-picks the three adapter unit-test files originally produced by CodeRabbit in #134 onto a fresh branch off `feat/wails-rewrite`. #134 was based on old `main` (pre-dating the ports-and-adapters extraction), so its CI failed with `no required module provides package github.com/gruntwork-io/runbooks/core/ports`. Retargeting alone wasn't enough; rebasing required a force-push to a bot-owned branch. This PR is the cleaner path — same three test files, correct base, green CI.

Supersedes and closes #134.

Tests added:
- `adapters/cli_git_client_test.go` (166 lines)
- `adapters/http_github_client_test.go` (322 lines)
- `adapters/noop_adapters_test.go` (122 lines)

## Test plan

- [x] `go test ./adapters/...` passes locally
- [ ] CI passes on `feat/wails-rewrite` base

🤖 Generated with [Claude Code](https://claude.com/claude-code)