### PR TITLE
[Wails] M5.5: desktop binary binds no TCP listener

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1,10 +1,11 @@
 // Package desktop boots the Wails v3 window that hosts the Gruntbooks
 // React UI.
 //
-// M2 scope: register the WelcomeService over IPC, serve the embedded
-// SPA, and proxy /api/* requests to the embedded Gin server once it
-// starts. Later milestones (M3/M4) migrate the remaining HTTP
-// endpoints to IPC services and remove the proxy.
+// Post-M5.5 scope: register every IPC service, serve the embedded SPA
+// for asset requests, and open one window. The desktop binary binds no
+// TCP listener — the previous /api/* reverse proxy to an embedded Gin
+// server has been removed; every frontend operation is a Wails IPC
+// call against a service in services/.
 package desktop
 
 import (
@@ -14,8 +15,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"runtime"
 	"strings"
 
@@ -58,8 +57,7 @@ type Options struct {
 }
 
 // Run boots Wails, registers the IPC services, serves the embedded
-// React bundle (proxying /api/* to the embedded Gin server once it's
-// running), and opens a single window. Blocks until the window is
+// React bundle, and opens a single window. Blocks until the window is
 // closed. Returns any error from the Wails runtime; callers typically
 // log.Fatal on failure.
 func Run(opts Options) error {
@@ -75,7 +73,7 @@ func Run(opts Options) error {
 	defer cancelUpdateCheck()
 	go services.RunAutoCheck(updateCtx, svcs.Update)
 
-	handler, err := assetHandler(svcs.Welcome)
+	handler, err := assetHandler()
 	if err != nil {
 		return fmt.Errorf("build asset handler: %w", err)
 	}
@@ -243,35 +241,20 @@ func showAboutDialog(app *application.App) {
 	dialog.Show()
 }
 
-// assetHandler returns an http.Handler that:
-//   - Proxies /api/* requests to the embedded Gin server on whatever
-//     localhost port WelcomeService has started it on. Same-origin
-//     proxying means the frontend doesn't have to care about ports,
-//     CORS, or token scoping.
-//   - Serves the embedded web/dist tree for everything else, falling
-//     back to index.html for anything that doesn't resolve to a real
-//     file (SPA client-side routing).
-//
-// The proxy looks up the current Gin port on every request rather than
-// capturing it once, so a late-starting backend (Welcome → OpenLocal)
-// transparently starts handling requests as soon as Gin binds.
-func assetHandler(welcome *services.WelcomeService) (http.Handler, error) {
+// assetHandler returns an http.Handler that serves the embedded
+// web/dist tree, falling back to index.html for routes that don't
+// resolve to a real file (SPA client-side routing). Wails uses this
+// handler internally to satisfy webview asset requests; it is not
+// bound to any TCP socket.
+func assetHandler() (http.Handler, error) {
 	distFS, err := web.GetDistFS()
 	if err != nil {
 		return nil, err
 	}
 	fileServer := http.FileServer(http.FS(distFS))
-	apiProxy := newAPIProxy(welcome)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-
-		if strings.HasPrefix(path, "/api/") {
-			apiProxy.ServeHTTP(w, r)
-			return
-		}
-
-		trimmed := strings.TrimPrefix(path, "/")
+		trimmed := strings.TrimPrefix(r.URL.Path, "/")
 		if trimmed == "" {
 			fileServer.ServeHTTP(w, r)
 			return
@@ -283,39 +266,6 @@ func assetHandler(welcome *services.WelcomeService) (http.Handler, error) {
 		}
 		serveIndex(w, r, distFS)
 	}), nil
-}
-
-// newAPIProxy returns an http.Handler that reverse-proxies API calls
-// to Gin. If Gin isn't running yet (user is still on the Welcome
-// screen), it returns 503 rather than trying to contact a phantom
-// upstream.
-func newAPIProxy(welcome *services.WelcomeService) http.Handler {
-	proxy := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			port := welcome.Status().ServerPort
-			if port == 0 {
-				// Director can't fail cleanly; leaving the URL alone
-				// causes httputil to surface a "no Host in request URL"
-				// error. The wrapper below checks the port first.
-				return
-			}
-			target, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
-			req.URL.Scheme = target.Scheme
-			req.URL.Host = target.Host
-			req.Host = target.Host
-		},
-		// Flush immediately so SSE (watch mode, exec streaming, etc.)
-		// works through the proxy.
-		FlushInterval: -1,
-	}
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if welcome.Status().ServerPort == 0 {
-			http.Error(w, "gruntbook server not running", http.StatusServiceUnavailable)
-			return
-		}
-		proxy.ServeHTTP(w, r)
-	})
 }
 
 func serveIndex(w http.ResponseWriter, r *http.Request, distFS fs.FS) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -4,9 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/gruntwork-io/runbooks/adapters"
-	"github.com/gruntwork-io/runbooks/services"
 )
 
 // TestAssetHandlerFallbackToIndex verifies the handler serves the
@@ -20,11 +17,7 @@ import (
 // HTTP 200 with a non-empty body — the exact markup is a property of
 // whatever dist happens to be embedded when the test runs.
 func TestAssetHandlerFallbackToIndex(t *testing.T) {
-	svcs, err := services.NewServices("", false, adapters.NewNoopEmitter(), "dev")
-	if err != nil {
-		t.Fatalf("NewServices: %v", err)
-	}
-	handler, err := assetHandler(svcs.Welcome)
+	handler, err := assetHandler()
 	if err != nil {
 		t.Fatalf("assetHandler returned error: %v", err)
 	}
@@ -38,28 +31,5 @@ func TestAssetHandlerFallbackToIndex(t *testing.T) {
 	}
 	if rec.Body.Len() == 0 {
 		t.Fatalf("expected non-empty fallback body, got empty")
-	}
-}
-
-// TestAPIProxyReturns503WhenServerNotRunning verifies that API
-// requests made before the backend starts (user still on Welcome)
-// surface as 503 Service Unavailable rather than trying to contact a
-// phantom upstream and timing out.
-func TestAPIProxyReturns503WhenServerNotRunning(t *testing.T) {
-	svcs, err := services.NewServices("", false, adapters.NewNoopEmitter(), "dev")
-	if err != nil {
-		t.Fatalf("NewServices: %v", err)
-	}
-	handler, err := assetHandler(svcs.Welcome)
-	if err != nil {
-		t.Fatalf("assetHandler returned error: %v", err)
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/gruntbook", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected 503 when no gruntbook is open, got %d", rec.Code)
 	}
 }

--- a/services/server_manager.go
+++ b/services/server_manager.go
@@ -8,103 +8,81 @@ import (
 	"github.com/gruntwork-io/runbooks/api"
 )
 
-// serverManager owns the lifecycle of the embedded Gin API server.
+// serverManager tracks the runtime state of the currently-open gruntbook
+// for the desktop binary: the SessionManager (env vars, worktree state,
+// per-block exec counts) and the optional ExecutableRegistry. It is
+// shared across every IPC service so they all see the same view.
 //
-// M2 keeps Gin running behind the desktop window — the frontend still
-// reaches the runbook, exec, boilerplate, etc. endpoints over HTTP. The
-// manager starts Gin lazily once the user picks a gruntbook from
-// Welcome, and stops it cleanly when the user closes the gruntbook and
-// returns to Welcome (so they can open a different one in the same
-// session).
+// History: through M5 this type also owned an embedded Gin HTTP server
+// — the desktop window proxied /api/* requests to a local listener that
+// the frontend pre-IPC migration relied on. M5.5 deleted that listener.
+// The desktop binary now binds no TCP port; HTTP only exists in the
+// separate `gruntbooks serve` CLI path that Playwright drives. The name
+// "serverManager" is kept to minimise churn across the dozen-plus
+// services that hold a reference; it now manages the gruntbook session
+// state, not a server.
 type serverManager struct {
-	mu       sync.Mutex
-	started  bool
-	port     int
-	config   api.ServerConfig
-	shutdown func(context.Context) error
-	errCh    <-chan error
+	mu      sync.Mutex
+	started bool
+	config  api.ServerConfig
 
-	// sessions is the SessionManager shared between the embedded Gin
-	// server and the IPC services. A fresh one is created on every
-	// Start so each open gruntbook gets clean session state (env vars,
-	// worktrees, exec counts). M4+ IPC services reach it via Sessions()
+	// sessions is the SessionManager shared between every IPC service.
+	// A fresh one is created on every Start so each open gruntbook gets
+	// clean session state. M4+ IPC services reach it via Sessions()
 	// rather than holding their own reference — that way Stop+Start
 	// (Welcome → different gruntbook) transparently rebinds them.
 	sessions *api.SessionManager
 
-	// registry is the ExecutableRegistry shared between Gin and the
-	// IPC ExecService. Nil when the open gruntbook runs in watch mode
-	// (which re-parses on every exec instead). Populated in Start()
-	// ahead of Gin boot so both transports resolve executable_id the
-	// same way.
+	// registry is the ExecutableRegistry for the open gruntbook. Nil
+	// when the gruntbook runs in watch / Author Mode (which re-parses
+	// on every exec instead).
 	registry *api.ExecutableRegistry
 }
 
-// startInfo is the subset of state that Start returns to the caller.
-type startInfo struct {
-	// Port is the TCP port Gin bound to. Callers hand this to the
-	// frontend so it knows where to make API requests.
-	Port int
-	// ErrCh fires once if Gin exits. Useful if a later milestone wants
-	// to surface backend crashes in the UI; M2 ignores it.
-	ErrCh <-chan error
-}
-
-// Start boots Gin if it isn't already running. Returns an error if a
-// server is already running — callers must Stop it first to swap
-// gruntbooks. The config's Port is forced to 0 so the kernel picks a
-// free port; the actual bound port is reported back in startInfo.Port.
-func (sm *serverManager) Start(cfg api.ServerConfig) (*startInfo, error) {
+// Start initialises the per-gruntbook session + registry state. Returns
+// an error if a gruntbook is already open — callers must Stop first to
+// swap gruntbooks. No HTTP listener is bound; this is in-process state
+// only.
+func (sm *serverManager) Start(cfg api.ServerConfig) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	if sm.started {
-		return nil, fmt.Errorf("gruntbook server is already running for %q", sm.config.GruntbookPath)
+		return fmt.Errorf("gruntbook is already open: %q", sm.config.GruntbookPath)
 	}
 
-	cfg.Port = 0
 	sessions := api.NewSessionManager()
 	cfg.Sessions = sessions
 
-	// Build the registry up front (outside Gin's buildHandler) so the
-	// IPC ExecService sees the same registry Gin is about to install.
-	// Only relevant when the open gruntbook runs in registry mode; watch
-	// mode re-parses on every exec so cfg.Registry stays nil.
+	// Build the registry up front so the IPC ExecService sees it
+	// before the user can trigger an exec. Watch mode (Author Mode)
+	// re-parses on each exec, so registry stays nil.
 	var registry *api.ExecutableRegistry
 	if cfg.UseExecutableRegistry {
 		resolved, err := api.ResolveGruntbookPath(cfg.GruntbookPath)
 		if err != nil {
-			return nil, fmt.Errorf("resolve gruntbook path: %w", err)
+			return fmt.Errorf("resolve gruntbook path: %w", err)
 		}
 		registry, err = api.NewExecutableRegistry(resolved)
 		if err != nil {
-			return nil, fmt.Errorf("build executable registry: %w", err)
+			return fmt.Errorf("build executable registry: %w", err)
 		}
 		cfg.Registry = registry
 	}
 
-	handle, err := api.StartServerWithShutdown(cfg)
-	if err != nil {
-		return nil, err
-	}
-	cfg.Port = handle.Port
-
 	sm.started = true
-	sm.port = handle.Port
 	sm.config = cfg
-	sm.shutdown = handle.Shutdown
-	sm.errCh = handle.ErrCh
 	sm.sessions = sessions
 	sm.registry = registry
 
-	return &startInfo{Port: handle.Port, ErrCh: handle.ErrCh}, nil
+	return nil
 }
 
-// Stop gracefully shuts down the running server and waits for the
-// listener goroutine to exit. It is a no-op when no server is running.
-// The provided context bounds how long to wait for in-flight requests
-// before forcing shutdown.
-func (sm *serverManager) Stop(ctx context.Context) error {
+// Stop clears the per-gruntbook state so the user can return to Welcome
+// and open a different gruntbook. The ctx is accepted for API
+// compatibility with the M5-era Gin shutdown path; nothing now blocks
+// on it. No-op if no gruntbook is open.
+func (sm *serverManager) Stop(_ context.Context) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
@@ -112,19 +90,12 @@ func (sm *serverManager) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	shutdownErr := sm.shutdown(ctx)
-	// Drain errCh so the serve goroutine isn't blocked writing.
-	<-sm.errCh
-
 	sm.started = false
-	sm.port = 0
 	sm.config = api.ServerConfig{}
-	sm.shutdown = nil
-	sm.errCh = nil
 	sm.sessions = nil
 	sm.registry = nil
 
-	return shutdownErr
+	return nil
 }
 
 // Sessions returns the SessionManager for the currently-open gruntbook,
@@ -139,24 +110,16 @@ func (sm *serverManager) Sessions() *api.SessionManager {
 
 // Registry returns the ExecutableRegistry for the currently-open
 // gruntbook. Returns (nil, nil) when no gruntbook is open or when the
-// gruntbook runs in watch mode (registry-less). Returns an error only
-// for misuse — the error slot is reserved for future modes where
-// registry construction can fail outside of Start().
+// gruntbook runs in watch mode. The error slot is reserved for future
+// modes where registry construction can fail outside Start().
 func (sm *serverManager) Registry() (*api.ExecutableRegistry, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	return sm.registry, nil
 }
 
-// Port returns the bound port, or 0 if the server is not running.
-func (sm *serverManager) Port() int {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-	return sm.port
-}
-
-// Config returns the config the server was started with. Returns the
-// zero value if the server has not been started.
+// Config returns the config the gruntbook was opened with. Returns the
+// zero value if no gruntbook is open.
 func (sm *serverManager) Config() api.ServerConfig {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()

--- a/services/welcome_service.go
+++ b/services/welcome_service.go
@@ -13,26 +13,22 @@ import (
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
-// closeShutdownTimeout caps how long we wait for in-flight requests to
-// drain when closing a gruntbook. The backend holds no long-polling
-// connections in M2, so 5s is plenty.
+// closeShutdownTimeout is retained for API compatibility with the M5
+// Stop signature. With Gin removed, Stop is in-process state clearing
+// and doesn't actually wait on the context; the timeout is unused.
 const closeShutdownTimeout = 5 * time.Second
 
 // OpenResult is the return shape of OpenLocal (and, in later milestones,
 // OpenRemote). Carries everything the frontend needs to navigate from
 // the Welcome screen into the runbook view.
 type OpenResult struct {
-	// GruntbookPath is the resolved absolute path to gruntbook.mdx that
-	// Gin is now serving.
+	// GruntbookPath is the resolved absolute path to the open
+	// gruntbook.mdx.
 	GruntbookPath string `json:"gruntbookPath"`
 	// DisplayPath is what the UI should show in the header. For local
 	// opens it's the on-disk path; for remote opens (future) it's the
 	// original URL.
 	DisplayPath string `json:"displayPath"`
-	// Port is the localhost port Gin bound to. The desktop asset
-	// handler proxies /api/* to this port, so the frontend doesn't
-	// hard-code it — this is surfaced for logging/debug only.
-	Port int `json:"port"`
 }
 
 // DesktopStatus is the initial-state snapshot the Welcome page reads
@@ -47,10 +43,8 @@ type DesktopStatus struct {
 	// Frontend uses it to seed AuthorModeContext on mount.
 	InitialAuthorMode bool `json:"initialAuthorMode"`
 	// GruntbookOpen is true once OpenLocal (or a pre-launch path) has
-	// started the backend and a runbook is loaded.
+	// loaded a runbook.
 	GruntbookOpen bool `json:"gruntbookOpen"`
-	// ServerPort is the bound Gin port (0 if not running).
-	ServerPort int `json:"serverPort"`
 	// GruntbookPath mirrors OpenResult.GruntbookPath when a gruntbook
 	// is open.
 	GruntbookPath string `json:"gruntbookPath"`
@@ -82,16 +76,13 @@ func (s *WelcomeService) ServiceName() string {
 	return "WelcomeService"
 }
 
-// Status returns the frontend's initial boot snapshot. Invariant: if
-// GruntbookOpen is true, ServerPort is > 0.
+// Status returns the frontend's initial boot snapshot.
 func (s *WelcomeService) Status() DesktopStatus {
 	cfg := s.servers.Config()
-	port := s.servers.Port()
 	return DesktopStatus{
 		InitialPath:       s.initialPath,
 		InitialAuthorMode: s.initialAuthorMode,
-		GruntbookOpen:     port != 0,
-		ServerPort:        port,
+		GruntbookOpen:     cfg.GruntbookPath != "",
 		GruntbookPath:     cfg.GruntbookPath,
 	}
 }
@@ -157,8 +148,7 @@ func (s *WelcomeService) OpenLocal(path string) (*OpenResult, error) {
 		ReleaseMode:           true,
 	}
 
-	info, err := s.servers.Start(cfg)
-	if err != nil {
+	if err := s.servers.Start(cfg); err != nil {
 		return nil, err
 	}
 
@@ -170,13 +160,11 @@ func (s *WelcomeService) OpenLocal(path string) (*OpenResult, error) {
 
 	slog.Info("Opened gruntbook",
 		"path", gruntbookPath,
-		"workingDir", cwd,
-		"port", info.Port)
+		"workingDir", cwd)
 
 	return &OpenResult{
 		GruntbookPath: gruntbookPath,
 		DisplayPath:   abs,
-		Port:          info.Port,
 	}, nil
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,7 +54,6 @@ function App() {
             result: {
               gruntbookPath: status.gruntbookPath,
               displayPath: status.gruntbookPath,
-              port: status.serverPort,
             },
           })
           return
@@ -165,7 +164,6 @@ function browserOpenResult(): OpenResult {
   return {
     gruntbookPath: '',
     displayPath: '',
-    port: 0,
   }
 }
 

--- a/web/src/bindings/github.com/gruntwork-io/runbooks/services/models.ts
+++ b/web/src/bindings/github.com/gruntwork-io/runbooks/services/models.ts
@@ -33,14 +33,9 @@ export class DesktopStatus {
 
     /**
      * GruntbookOpen is true once OpenLocal (or a pre-launch path) has
-     * started the backend and a runbook is loaded.
+     * loaded a runbook.
      */
     "gruntbookOpen": boolean;
-
-    /**
-     * ServerPort is the bound Gin port (0 if not running).
-     */
-    "serverPort": number;
 
     /**
      * GruntbookPath mirrors OpenResult.GruntbookPath when a gruntbook
@@ -58,9 +53,6 @@ export class DesktopStatus {
         }
         if (!("gruntbookOpen" in $$source)) {
             this["gruntbookOpen"] = false;
-        }
-        if (!("serverPort" in $$source)) {
-            this["serverPort"] = 0;
         }
         if (!("gruntbookPath" in $$source)) {
             this["gruntbookPath"] = "";
@@ -302,8 +294,8 @@ export class GruntbookResult {
  */
 export class OpenResult {
     /**
-     * GruntbookPath is the resolved absolute path to gruntbook.mdx that
-     * Gin is now serving.
+     * GruntbookPath is the resolved absolute path to the open
+     * gruntbook.mdx.
      */
     "gruntbookPath": string;
 
@@ -314,13 +306,6 @@ export class OpenResult {
      */
     "displayPath": string;
 
-    /**
-     * Port is the localhost port Gin bound to. The desktop asset
-     * handler proxies /api/* to this port, so the frontend doesn't
-     * hard-code it — this is surfaced for logging/debug only.
-     */
-    "port": number;
-
     /** Creates a new OpenResult instance. */
     constructor($$source: Partial<OpenResult> = {}) {
         if (!("gruntbookPath" in $$source)) {
@@ -328,9 +313,6 @@ export class OpenResult {
         }
         if (!("displayPath" in $$source)) {
             this["displayPath"] = "";
-        }
-        if (!("port" in $$source)) {
-            this["port"] = 0;
         }
 
         Object.assign(this, $$source);

--- a/web/src/bindings/github.com/gruntwork-io/runbooks/services/welcomeservice.ts
+++ b/web/src/bindings/github.com/gruntwork-io/runbooks/services/welcomeservice.ts
@@ -80,8 +80,7 @@ export function PickLocalFolder(): $CancellablePromise<string> {
 }
 
 /**
- * Status returns the frontend's initial boot snapshot. Invariant: if
- * GruntbookOpen is true, ServerPort is > 0.
+ * Status returns the frontend's initial boot snapshot.
  */
 export function Status(): $CancellablePromise<$models.DesktopStatus> {
     return $Call.ByID(2004347322).then(($result: any) => {

--- a/web/src/components/mdx/TemplateInline/TemplateInline.tsx
+++ b/web/src/components/mdx/TemplateInline/TemplateInline.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useState, useEffect, useMemo, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { LoadingDisplay } from '@/components/mdx/_shared/components/LoadingDisplay'
 import { ErrorDisplay } from '@/components/mdx/_shared/components/ErrorDisplay'
@@ -7,7 +7,7 @@ import { useInputs, useAllOutputs, flattenInputs, useGruntbookContext } from '@/
 import { extractTemplateDependencies, extractTemplateDependenciesFromString, splitDependencies } from '@/lib/extractTemplateDependencies'
 import { extractTemplateFiles } from './lib/extractTemplateFiles'
 import type { File, FileTreeNode } from '@/components/artifacts/code/FileTree'
-import type { AppError } from '@/types/error'
+import { createAppError, type AppError } from '@/types/error'
 import { useApi } from '@/hooks/useApi'
 import { useFileTreeUpdater } from '../_shared/hooks/useFileTreeUpdater'
 import { computeChangeKey } from '@/lib/changeDetection'
@@ -18,6 +18,9 @@ import { useComponentIdRegistry } from '@/contexts/ComponentIdRegistry'
 import { useErrorReporting } from '@/contexts/useErrorReporting'
 import { useTelemetry } from '@/contexts/useTelemetry'
 import { buildTemplatePayload, computeUnmetInputDependencies, computeUnmetOutputDependencies, flattenBlockOutputs, hasEmptyNumericInputs, resolveTemplateReferences } from '@/lib/templateUtils'
+import { isDesktop } from '@/lib/wails'
+import * as BoilerplateService from '@/bindings/github.com/gruntwork-io/runbooks/services/boilerplateservice'
+import { RenderInlineRequest } from '@/bindings/github.com/gruntwork-io/runbooks/api/models'
 
 interface RenderInlineResult {
   renderedFiles: Record<string, File>
@@ -104,10 +107,69 @@ function TemplateInline({
   // Track last rendered change key to avoid duplicate renders
   const lastRenderedKeyRef = useRef<string | null>(null);
 
-  // API hook — lazy mode skips auto-fetch on mount; we use debouncedRequest explicitly
-  const { data, error, isLoading, debouncedRequest } = useApi<RenderInlineResult>(
-    '/api/boilerplate/render-inline', 'POST', undefined, 300, undefined, true
+  // Browser-mode HTTP path. The endpoint is empty in desktop mode so
+  // useApi is inert; the IPC branch below drives rendering instead.
+  // Lazy mode skips auto-fetch on mount; we use debouncedRequest explicitly.
+  const httpResult = useApi<RenderInlineResult>(
+    isDesktop() ? '' : '/api/boilerplate/render-inline', 'POST', undefined, 300, undefined, true
   );
+
+  // Desktop-mode IPC path. Mirrors the dual-path pattern in
+  // useApiBoilerplateRender: a debounced invoker drives BoilerplateService.RenderInline,
+  // and a monotonic seq guard discards stale responses so a slow earlier
+  // call can't clobber a faster later one when inputs change rapidly.
+  const [ipcData, setIpcData] = useState<RenderInlineResult | null>(null)
+  const [ipcLoading, setIpcLoading] = useState(false)
+  const [ipcError, setIpcError] = useState<string | null>(null)
+  const ipcSeqRef = useRef(0)
+  const ipcDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (ipcDebounceTimerRef.current) clearTimeout(ipcDebounceTimerRef.current)
+    }
+  }, [])
+
+  const ipcDebouncedRequest = useCallback(
+    (body: { templateFiles: Record<string, string>; inputs: unknown; generateFile?: boolean; target?: string }) => {
+      if (ipcDebounceTimerRef.current) clearTimeout(ipcDebounceTimerRef.current)
+      ipcDebounceTimerRef.current = setTimeout(() => {
+        const seq = ++ipcSeqRef.current
+        setIpcLoading(true)
+        setIpcError(null)
+        ;(async () => {
+          try {
+            const req = RenderInlineRequest.createFrom({
+              templateFiles: body.templateFiles,
+              inputs: body.inputs as Parameters<typeof RenderInlineRequest.createFrom>[0]['inputs'],
+              ...(body.generateFile !== undefined ? { generateFile: body.generateFile } : {}),
+              ...(body.target ? { target: body.target } : {}),
+            })
+            const res = await BoilerplateService.RenderInline(req)
+            if (seq !== ipcSeqRef.current) return
+            if (!res) {
+              setIpcError('RenderInline returned null')
+              return
+            }
+            setIpcData(res as unknown as RenderInlineResult)
+          } catch (err) {
+            if (seq !== ipcSeqRef.current) return
+            setIpcError(err instanceof Error ? err.message : String(err))
+          } finally {
+            if (seq === ipcSeqRef.current) setIpcLoading(false)
+          }
+        })()
+      }, 300)
+    },
+    [],
+  )
+
+  const data = isDesktop() ? ipcData : httpResult.data
+  const isLoading = isDesktop() ? ipcLoading : httpResult.isLoading
+  const error: AppError | null = isDesktop()
+    ? (ipcError ? createAppError(ipcError) : null)
+    : httpResult.error
+  const debouncedRequest = isDesktop() ? ipcDebouncedRequest : httpResult.debouncedRequest;
 
   // File tree updater — handles Generated tab vs worktree updates
   const { applyFileTreeUpdate } = useFileTreeUpdater(target);


### PR DESCRIPTION
## Summary

Removes the lazy embedded Gin server from the desktop binary so a running Gruntbooks process listens on no network sockets. The threat-model goal of M5.5 — eliminating the localhost API that any sibling process running as the same user could discover and abuse — is delivered: `lsof -a -p $PID -iTCP -sTCP:LISTEN` after opening a gruntbook returns nothing.

## What changed

- `services/serverManager.Start` no longer calls `api.StartServerWithShutdown`. It still creates the `SessionManager` and `ExecutableRegistry` that every IPC service depends on; it just doesn't bind a port.
- `desktop/app.go` drops the `/api/*` reverse-proxy block and the `newAPIProxy` helper. The asset handler now only serves the embedded React build with SPA fallback. `OpenResult.port` and `DesktopStatus.serverPort` are gone — the frontend never used the number anyway.
- TS bindings regenerated.

## What did not change (deferred from the original M5.5 plan)

The original M5.5 plan was: migrate Playwright onto Wails's `-tags server` build mode (real bindings over HTTP at `/wails/runtime`), then delete `cmd/serve.go`, `api/server.go`, every `if (!isDesktop()) fetch('/api/...')` branch in the frontend, and `gin-gonic/gin` from `go.mod`.

That plan is **blocked on a Wails alpha.78 bug**: `go build -tags server` fails to compile because `BrowserWindow` (in `pkg/application/browser_window.go`) is missing `Window.SetScreen`, a regression introduced when the `Window` interface gained screen-management methods (PR wailsapp/wails#5067) without a matching update on `BrowserWindow`. The bug is also present on the upstream `v3-alpha` branch tip — there is no later alpha to bump to. Filed upstream as [wailsapp/wails#5262](https://github.com/wailsapp/wails/issues/5262).

Until either (a) a future alpha ships the fix or (b) we adopt a custom HTTP transport on top of `application.MessageProcessor`, Playwright stays on the legacy `gruntbooks serve` harness. The dual-pathed `fetch('/api/...')` branches in frontend hooks remain in place for that path. **None of that code runs in the shipped desktop binary** — that's the headline guarantee this PR delivers.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./services/... ./desktop/...` clean (full suite green)
- [x] `bun x tsc --noEmit` clean
- [x] `bun run lint` clean (one pre-existing warning unrelated)
- [x] Playwright e2e: 17/17 passing on Chromium
- [x] `lsof -a -p $PID -iTCP -sTCP:LISTEN` empty for the desktop binary with a gruntbook open
- [x] `gruntbooks serve` still works for Playwright (verified via /api/health probe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)