### PR TITLE
flatten inputs so we can render inputs that are other inputs

### DIFF
--- a/electron/main/ipc/boilerplate.ts
+++ b/electron/main/ipc/boilerplate.ts
@@ -12,6 +12,7 @@ import {
   parseBoilerplateConfig,
   extractOutputDependencies,
 } from "../../../src/domain/boilerplate/config.ts"
+import { flattenVariables } from "../../../src/domain/boilerplate/flattenInputs.ts"
 import { BoilerplateRenderer } from "../../../src/services/BoilerplateRenderer.ts"
 import { FileSystem } from "../../../src/services/FileSystem.ts"
 import { WarmRenderDispatcher, type WarmRenderResult } from "../../../src/services/WarmRenderDispatcher.ts"
@@ -31,90 +32,6 @@ import type {
   BoilerplateRequest,
 } from "../../../src/types.ts"
 import { validateSessionPath } from "./path-guard.ts"
-
-/**
- * True when a value is a Go-template expression string. Such values arrive
- * from the UI because the form echoes back the unresolved `default:` from
- * `boilerplate.yml` for any variable the user hasn't overridden.
- */
-const TEMPLATE_EXPR_RE = /\{\{.*?\}\}/s
-
-function isTemplateString(v: unknown): boolean {
-  return typeof v === "string" && TEMPLATE_EXPR_RE.test(v)
-}
-
-/**
- * Recursively drop any value that's still a Go-template expression. Boilerplate
- * re-evaluates `--var-file` string values as templates; passing a raw
- * `{{ .inputs.X }}` for a value crashes when the eval happens inside a
- * dependency that doesn't expose the `inputs` namespace. By stripping those
- * placeholders we force boilerplate to fall through to its own default,
- * which it evaluates correctly in the parent scope (where `inputs`/`outputs`
- * are in scope via our var-file).
- *
- * Maps/lists are descended. A map whose resulting keys are all stripped is
- * dropped entirely so the dependency's own defaults apply instead.
- */
-function stripTemplateValues(value: unknown): unknown {
-  if (isTemplateString(value)) return undefined
-  if (Array.isArray(value)) {
-    const cleaned = value
-      .map(stripTemplateValues)
-      .filter((v) => v !== undefined)
-    return cleaned
-  }
-  if (value && typeof value === "object") {
-    const cleaned: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      const stripped = stripTemplateValues(v)
-      if (stripped !== undefined) cleaned[k] = stripped
-    }
-    return Object.keys(cleaned).length > 0 ? cleaned : undefined
-  }
-  return value
-}
-
-/**
- * Flatten `{ inputs: {...}, outputs: {...} }` into the shape boilerplate's
- * `--var-file` expects: each input variable lifted to the top level (for
- * legacy `{{ .X }}` syntax + the CLI's required-variable check), while
- * preserving the `inputs` and `outputs` namespaces (for new-style
- * `{{ .inputs.X }}` / `{{ .outputs.block.X }}` references).
- *
- * Explicit root-level keys win over the lifted inputs (matches main's
- * `applyBackwardCompatibility`). Reserved names `inputs` and `outputs` inside
- * the inputs namespace are skipped to avoid clobbering the namespaces.
- *
- * Template-expression values are stripped — see `stripTemplateValues`. The
- * `outputs` namespace is left untouched (its values are real block outputs,
- * not defaults, and we want boilerplate to resolve `.outputs.X.Y` refs
- * against them).
- */
-function flattenVariables(
-  variables: Record<string, unknown> | undefined,
-): Record<string, unknown> {
-  const src = variables ?? {}
-
-  // Strip template placeholders from `inputs` only. `outputs` is preserved
-  // verbatim so real output values reach boilerplate even if they happen to
-  // look template-ish.
-  const rawInputs = src.inputs
-  const cleanedInputs =
-    rawInputs && typeof rawInputs === "object" && !Array.isArray(rawInputs)
-      ? (stripTemplateValues(rawInputs) as Record<string, unknown> | undefined) ?? {}
-      : {}
-
-  const result: Record<string, unknown> = {
-    ...src,
-    inputs: cleanedInputs,
-  }
-
-  for (const [k, v] of Object.entries(cleanedInputs)) {
-    if (k === "inputs" || k === "outputs") continue
-    if (!(k in result)) result[k] = v
-  }
-  return result
-}
 
 /**
  * Tracks in-flight render fibers per `templateId`. When a new render starts
@@ -301,8 +218,43 @@ export function registerBoilerplateHandlers(): void {
         }
         yield* validateSessionPath(outputDir)
 
+        // Detect external wipe of the worktree (e.g., a `GitClone` block that
+        // re-clones over the worktree, `git reset --hard`, or `rm -rf`).
+        // Without this check, the warm dispatcher's dirty-set + manifest diff
+        // assume any "unchanged" file is still on disk from the prior render,
+        // so they're not re-emitted — leaving the tree partially populated.
+        // We probe a few paths from the previous manifest; if any are missing,
+        // drop the manifest + dispatcher cache so this render is treated as a
+        // first-render and rebuilds everything from scratch.
+        const existingManifest = manifestStore.get(templateId)
+        if (existingManifest && existingManifest.files.length > 0) {
+          // Walk the manifest sequentially, bailing on the first missing
+          // path. In the common case (no external wipe) every stat hits, and
+          // a hot-cache stat is sub-millisecond per file — fine even for a
+          // template that produces a few hundred files. When something does
+          // wipe the tree we bail immediately on the first miss.
+          let staleReason: string | null = null
+          for (const entry of existingManifest.files) {
+            const exists = yield* fs.exists(
+              path.join(existingManifest.outputDir, entry.path),
+            )
+            if (!exists) {
+              staleReason = entry.path
+              break
+            }
+          }
+          if (staleReason !== null) {
+            console.log(
+              "[ipc boilerplate:render] previous output dir missing files; treating as first-render",
+              { templateId, missingPathExample: staleReason },
+            )
+            manifestStore.delete(templateId)
+            yield* warmDispatcher.invalidate(templateId)
+          }
+        }
+
         const tFlatten = Date.now()
-        const flattenedVariables = flattenVariables(params.variables)
+        const flattenedVariables = yield* flattenVariables(params.variables)
         const dFlatten = Date.now() - tFlatten
 
         // ---------- Warm attempt ----------

--- a/electron/main/ipc/boilerplate.ts
+++ b/electron/main/ipc/boilerplate.ts
@@ -223,30 +223,30 @@ export function registerBoilerplateHandlers(): void {
         // Without this check, the warm dispatcher's dirty-set + manifest diff
         // assume any "unchanged" file is still on disk from the prior render,
         // so they're not re-emitted — leaving the tree partially populated.
-        // We probe a few paths from the previous manifest; if any are missing,
+        // We stat every path from the previous manifest; if any is missing,
         // drop the manifest + dispatcher cache so this render is treated as a
         // first-render and rebuilds everything from scratch.
         const existingManifest = manifestStore.get(templateId)
         if (existingManifest && existingManifest.files.length > 0) {
-          // Walk the manifest sequentially, bailing on the first missing
-          // path. In the common case (no external wipe) every stat hits, and
-          // a hot-cache stat is sub-millisecond per file — fine even for a
-          // template that produces a few hundred files. When something does
-          // wipe the tree we bail immediately on the first miss.
-          let staleReason: string | null = null
-          for (const entry of existingManifest.files) {
-            const exists = yield* fs.exists(
-              path.join(existingManifest.outputDir, entry.path),
-            )
-            if (!exists) {
-              staleReason = entry.path
-              break
-            }
-          }
-          if (staleReason !== null) {
+          // Stat the manifest concurrently. This runs on every render's hot
+          // path, and in the common case (no external wipe) every stat hits,
+          // so we can't rely on an early bail — issuing the stats in parallel
+          // keeps the check cheap even for a template producing a few hundred
+          // files. A hot-cache stat is sub-millisecond, so bounded
+          // concurrency is plenty to hide the latency.
+          const presence = yield* Effect.forEach(
+            existingManifest.files,
+            (entry) =>
+              fs
+                .exists(path.join(existingManifest.outputDir, entry.path))
+                .pipe(Effect.map((exists) => ({ path: entry.path, exists }))),
+            { concurrency: 16 },
+          )
+          const missing = presence.find((p) => !p.exists)
+          if (missing) {
             console.log(
               "[ipc boilerplate:render] previous output dir missing files; treating as first-render",
-              { templateId, missingPathExample: staleReason },
+              { templateId, missingPathExample: missing.path },
             )
             manifestStore.delete(templateId)
             yield* warmDispatcher.invalidate(templateId)

--- a/electron/main/ipc/boilerplate.ts
+++ b/electron/main/ipc/boilerplate.ts
@@ -23,6 +23,7 @@ import {
   applyDiff,
   applyDiffFromContent,
   hashFileContent,
+  BATCH_IO_CONCURRENCY,
 } from "../../../src/domain/files/manifest.ts"
 import { resolveToAbsolutePath } from "../../../src/domain/files/generated.ts"
 import type { ManifestEntry } from "../../../src/types.ts"
@@ -240,7 +241,7 @@ export function registerBoilerplateHandlers(): void {
               fs
                 .exists(path.join(existingManifest.outputDir, entry.path))
                 .pipe(Effect.map((exists) => ({ path: entry.path, exists }))),
-            { concurrency: 16 },
+            { concurrency: BATCH_IO_CONCURRENCY },
           )
           const missing = presence.find((p) => !p.exists)
           if (missing) {

--- a/src/domain/boilerplate/flattenInputs.test.ts
+++ b/src/domain/boilerplate/flattenInputs.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import {
+  flattenVariables,
+  resolveInputTemplates,
+  stripTemplateValues,
+  isTemplateString,
+} from "./flattenInputs.ts"
+import { WasmRuntime } from "../../services/WasmRuntime.ts"
+import type { WasmRuntimeShape } from "../../services/WasmRuntime.ts"
+import { WasmError } from "../../errors/index.ts"
+
+// ---------------------------------------------------------------------------
+// Fake WasmRuntime
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal stand-in for `boilerplateRenderTemplate`. Supports
+ *   {{ .inputs.<NAME> }}            → look up varsJSON.inputs[NAME]
+ *   {{ .outputs.<BLOCK>.<FIELD> }}  → look up varsJSON.outputs[BLOCK][FIELD]
+ *   {{ .<NAME> }}                   → look up varsJSON[NAME] (lifted top-level)
+ * and reproduces the WASM build's OnMissingKey=ExitWithError behavior — if any
+ * reference is missing, the whole render fails (returns a WasmError).
+ *
+ * This keeps tests free of a real WASM runtime while exercising the exact
+ * decision tree resolveInputTemplates relies on (fail-or-fully-succeed, no
+ * partial output).
+ */
+const NAMESPACED_REF_RE =
+  /\{\{-?\s*\.(inputs|outputs)\.([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\s*-?\}\}/g
+const TOPLEVEL_REF_RE = /\{\{-?\s*\.([a-zA-Z0-9_]+)\s*-?\}\}/g
+
+function fakeRenderTemplate(
+  template: string,
+  varsJSON: string,
+): { ok: true; value: string } | { ok: false; message: string } {
+  const vars = JSON.parse(varsJSON) as Record<string, unknown> & {
+    inputs?: Record<string, unknown>
+    outputs?: Record<string, Record<string, unknown>>
+  }
+  let missing: string | null = null
+  // Namespaced refs first, so `.inputs.X` doesn't get partially matched by the
+  // top-level pattern.
+  let out = template.replace(NAMESPACED_REF_RE, (_match, ns, path: string) => {
+    if (ns === "inputs") {
+      const segments = path.split(".")
+      let cur: unknown = vars.inputs ?? {}
+      for (const seg of segments) {
+        if (cur && typeof cur === "object" && seg in (cur as Record<string, unknown>)) {
+          cur = (cur as Record<string, unknown>)[seg]
+        } else {
+          missing ??= `inputs.${path}`
+          return ""
+        }
+      }
+      return cur == null ? "" : String(cur)
+    }
+    // outputs.<block>.<field>
+    const dot = path.indexOf(".")
+    if (dot < 0) {
+      missing ??= `outputs.${path}`
+      return ""
+    }
+    const block = path.slice(0, dot)
+    const field = path.slice(dot + 1)
+    const blockMap = vars.outputs?.[block]
+    if (!blockMap || !(field in blockMap)) {
+      missing ??= `outputs.${path}`
+      return ""
+    }
+    const val = blockMap[field]
+    return val == null ? "" : String(val)
+  })
+  out = out.replace(TOPLEVEL_REF_RE, (_match, name: string) => {
+    if (!(name in vars)) {
+      missing ??= name
+      return ""
+    }
+    const val = vars[name]
+    return val == null ? "" : String(val)
+  })
+  if (missing) return { ok: false, message: `missing key: ${missing}` }
+  return { ok: true, value: out }
+}
+
+interface FakeWasmOptions {
+  /** Force every renderTemplate call to fail (simulates load error / disabled). */
+  alwaysFail?: boolean
+  /** Optional spy hook — receives every (template, varsJSON) pair. */
+  onCall?: (template: string, varsJSON: string) => void
+}
+
+function makeFakeWasm(options: FakeWasmOptions = {}): WasmRuntimeShape {
+  const notImplemented = (name: string) =>
+    Effect.die(`fake WasmRuntime: ${name} not implemented in flattenInputs.test`)
+  return {
+    renderTemplate: (template, varsJSON) =>
+      Effect.suspend(() => {
+        options.onCall?.(template, varsJSON)
+        if (options.alwaysFail) {
+          return Effect.fail(
+            new WasmError({ message: "fake: alwaysFail", kind: "load" }),
+          )
+        }
+        const result = fakeRenderTemplate(template, varsJSON)
+        if (result.ok) return Effect.succeed(result.value)
+        return Effect.fail(
+          new WasmError({ message: result.message, kind: "internal" }),
+        )
+      }),
+    renderFiles: () => notImplemented("renderFiles") as never,
+    prepareBundle: () => notImplemented("prepareBundle") as never,
+    renderFilesWithHandle: () => notImplemented("renderFilesWithHandle") as never,
+    releaseBundle: () => Effect.void,
+    inputsMap: () => notImplemented("inputsMap") as never,
+    isReady: Effect.succeed(true),
+  }
+}
+
+function fakeWasmLayer(options: FakeWasmOptions = {}) {
+  return Layer.succeed(WasmRuntime, makeFakeWasm(options))
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("isTemplateString", () => {
+  it("matches Go-template syntax", () => {
+    expect(isTemplateString("{{ .inputs.X }}")).toBe(true)
+    expect(isTemplateString("hello {{ .x }} world")).toBe(true)
+  })
+
+  it("rejects non-templates", () => {
+    expect(isTemplateString("plain string")).toBe(false)
+    expect(isTemplateString("")).toBe(false)
+    expect(isTemplateString(42)).toBe(false)
+    expect(isTemplateString(null)).toBe(false)
+    expect(isTemplateString(undefined)).toBe(false)
+    expect(isTemplateString({})).toBe(false)
+  })
+})
+
+describe("stripTemplateValues", () => {
+  it("drops scalar templates and keeps literals", () => {
+    expect(stripTemplateValues("{{ .x }}")).toBeUndefined()
+    expect(stripTemplateValues("plain")).toBe("plain")
+    expect(stripTemplateValues(7)).toBe(7)
+  })
+
+  it("strips template entries from a map", () => {
+    expect(
+      stripTemplateValues({ a: "x", b: "{{ .y }}" }),
+    ).toEqual({ a: "x" })
+  })
+
+  it("drops an all-template map entirely", () => {
+    expect(stripTemplateValues({ a: "{{ .x }}" })).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveInputTemplates
+// ---------------------------------------------------------------------------
+
+describe("resolveInputTemplates", () => {
+  it("returns inputs unchanged when no template strings are present", async () => {
+    // No WASM call needed in this branch. Provide a fake that would die if called.
+    const dieingWasm = Layer.succeed(WasmRuntime, makeFakeWasm({
+      onCall: () => { throw new Error("renderTemplate should not be called") },
+    }))
+    const result = await Effect.runPromise(
+      resolveInputTemplates({ A: "literal", B: 42 }, {}).pipe(
+        Effect.provide(dieingWasm),
+      ),
+    )
+    expect(result).toEqual({ A: "literal", B: 42 })
+  })
+
+  it("resolves a composed template against other inputs", async () => {
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        {
+          EmailUsername: "alice",
+          EmailDomainName: "example.com",
+          LogsAccountEmail: "{{ .inputs.EmailUsername }}+logsct5@{{ .inputs.EmailDomainName }}",
+        },
+        {},
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    expect(result.LogsAccountEmail).toBe("alice+logsct5@example.com")
+  })
+
+  it("leaves partially unresolvable templates as-is (one ref missing)", async () => {
+    const original = "{{ .inputs.HaveThis }}+{{ .inputs.Missing }}@x"
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        { HaveThis: "alice", LogsAccountEmail: original },
+        {},
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    // OnMissingKey=ExitWithError means the whole render fails — we leave the
+    // original template in place so the downstream strip pass drops it.
+    expect(result.LogsAccountEmail).toBe(original)
+  })
+
+  it("preserves outputs references untouched in the input value (outputs in context)", async () => {
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        {
+          ManagementAccountEmail: "{{ .outputs.get_management_account.ManagementAccountEmail }}",
+        },
+        { get_management_account: { ManagementAccountEmail: "root@example.com" } },
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    // outputs are real values, so the template DOES resolve when outputs is
+    // populated — this is the same surface used elsewhere in boilerplate.
+    expect(result.ManagementAccountEmail).toBe("root@example.com")
+  })
+
+  it("falls back to original template when outputs context lacks the referenced field", async () => {
+    const original = "{{ .outputs.never_ran.something }}"
+    const result = await Effect.runPromise(
+      resolveInputTemplates({ X: original }, {}).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    // Missing output → render fails → we leave the original so strip + default
+    // can do their job.
+    expect(result.X).toBe(original)
+  })
+
+  it("resolves chained refs A → B → C across passes", async () => {
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        {
+          A: "{{ .inputs.B }}",
+          B: "{{ .inputs.C }}",
+          C: "leaf",
+        },
+        {},
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    expect(result).toEqual({ A: "leaf", B: "leaf", C: "leaf" })
+  })
+
+  it("bails out on cycles without infinite looping", async () => {
+    const original = {
+      A: "{{ .inputs.B }}",
+      B: "{{ .inputs.A }}",
+    }
+    const result = await Effect.runPromise(
+      resolveInputTemplates(original, {}).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    // Neither can resolve — both stay as their original templates.
+    expect(result).toEqual(original)
+  })
+
+  it("treats every WASM call as a no-op when the runtime is failing", async () => {
+    const original = {
+      EmailUsername: "alice",
+      LogsAccountEmail: "{{ .inputs.EmailUsername }}+x@y",
+    }
+    const result = await Effect.runPromise(
+      resolveInputTemplates(original, {}).pipe(
+        Effect.provide(fakeWasmLayer({ alwaysFail: true })),
+      ),
+    )
+    // Same shape as the legacy behavior — strip pass downstream still cleans up.
+    expect(result.EmailUsername).toBe("alice")
+    expect(result.LogsAccountEmail).toBe(original.LogsAccountEmail)
+  })
+
+  it("resolves template expressions in map keys", async () => {
+    // AccountDefaultTags default in bootstrap is exactly this shape:
+    //   "{{ .OrgNamePrefix }}:AWSAccountName": "{{ .AWSAccountName }}"
+    // Boilerplate does not re-render map keys in a var-file, so the key
+    // must be resolved here or it ends up literal in the rendered output.
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        {
+          OrgNamePrefix: "acme",
+          AWSAccountName: "logs",
+          AccountDefaultTags: {
+            "{{ .inputs.OrgNamePrefix }}:AWSAccountName": "{{ .inputs.AWSAccountName }}",
+          },
+        },
+        {},
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    expect(result.AccountDefaultTags).toEqual({
+      "acme:AWSAccountName": "logs",
+    })
+  })
+
+  it("resolves legacy top-level `{{ .X }}` refs in keys (no `.inputs.` prefix)", async () => {
+    // The bootstrap runbook uses top-level refs throughout — `{{ .OrgNamePrefix }}`
+    // rather than `{{ .inputs.OrgNamePrefix }}`. The resolver must expose lifted
+    // inputs at the top level of the context for this to work.
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        {
+          OrgNamePrefix: "acme",
+          AWSAccountName: "logs",
+          AccountDefaultTags: {
+            "{{ .OrgNamePrefix }}:AWSAccountName": "{{ .AWSAccountName }}",
+          },
+        },
+        {},
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    expect(result.AccountDefaultTags).toEqual({
+      "acme:AWSAccountName": "logs",
+    })
+  })
+
+  it("leaves an unresolvable key in place", async () => {
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        {
+          Known: "x",
+          Tags: {
+            "{{ .Missing }}:Team": "DevOps",
+          },
+        },
+        {},
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    expect(result.Tags).toEqual({
+      "{{ .Missing }}:Team": "DevOps",
+    })
+  })
+
+  it("descends into nested map / array inputs", async () => {
+    const result = await Effect.runPromise(
+      resolveInputTemplates(
+        {
+          Domain: "example.com",
+          AWSAccounts: {
+            logs: {
+              email: "logs+{{ .inputs.Domain }}",
+            },
+            list: ["a@{{ .inputs.Domain }}", "static"],
+          },
+        },
+        {},
+      ).pipe(Effect.provide(fakeWasmLayer())),
+    )
+    expect(result).toEqual({
+      Domain: "example.com",
+      AWSAccounts: {
+        logs: { email: "logs+example.com" },
+        list: ["a@example.com", "static"],
+      },
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// flattenVariables — the public entry point used by the IPC handler.
+// ---------------------------------------------------------------------------
+
+describe("flattenVariables", () => {
+  const run = (vars: Record<string, unknown> | undefined, options: FakeWasmOptions = {}) =>
+    Effect.runPromise(
+      flattenVariables(vars).pipe(Effect.provide(fakeWasmLayer(options))),
+    )
+
+  it("handles undefined / missing inputs", async () => {
+    expect(await run(undefined)).toEqual({ inputs: {} })
+    expect(await run({})).toEqual({ inputs: {} })
+  })
+
+  it("resolves a composed default and lifts it to the top level", async () => {
+    const result = await run({
+      inputs: {
+        EmailUsername: "alice",
+        EmailDomainName: "example.com",
+        LogsAccountEmail: "{{ .inputs.EmailUsername }}+logsct5@{{ .inputs.EmailDomainName }}",
+      },
+      outputs: {},
+    })
+    expect(result.inputs).toEqual({
+      EmailUsername: "alice",
+      EmailDomainName: "example.com",
+      LogsAccountEmail: "alice+logsct5@example.com",
+    })
+    // Lifted to top-level so legacy `{{ .LogsAccountEmail }}` access still works.
+    expect(result.LogsAccountEmail).toBe("alice+logsct5@example.com")
+  })
+
+  it("strips an unresolvable input but keeps the rest", async () => {
+    const result = await run({
+      inputs: {
+        EmailUsername: "alice",
+        // Only one ref is resolvable; whole render fails; strip drops the value.
+        LogsAccountEmail: "{{ .inputs.EmailUsername }}+x@{{ .inputs.Missing }}",
+      },
+      outputs: {},
+    })
+    expect(result.inputs).toEqual({ EmailUsername: "alice" })
+    expect("LogsAccountEmail" in result).toBe(false)
+  })
+
+  it("preserves outputs verbatim and lets boilerplate-style output refs reach it", async () => {
+    const outputs = {
+      get_management_account: { ManagementAccountEmail: "root@example.com" },
+    }
+    const result = await run({
+      inputs: {
+        // This is what AWSAccounts.management.email looks like in real
+        // runbooks — a default that references an upstream block output.
+        ManagementAccountEmail: "{{ .outputs.get_management_account.ManagementAccountEmail }}",
+      },
+      outputs,
+    })
+    // The outputs namespace must reach boilerplate unchanged for .hcl files
+    // that reference it directly.
+    expect(result.outputs).toEqual(outputs)
+    // And our resolution pass also turned the input value into the resolved
+    // email so it flows through as a literal.
+    expect(result.inputs).toEqual({
+      ManagementAccountEmail: "root@example.com",
+    })
+  })
+
+  it("keeps an outputs-referencing input as a template when outputs is empty (legacy strip path still works)", async () => {
+    const result = await run({
+      inputs: {
+        ManagementAccountEmail: "{{ .outputs.get_management_account.ManagementAccountEmail }}",
+      },
+      outputs: {},
+    })
+    // No outputs yet → render fails → strip drops the value → boilerplate's
+    // own `default:` evaluation runs in the parent scope. This is the
+    // pre-existing behavior that the bootstrap runbook depends on.
+    expect(result.inputs).toEqual({})
+    expect("ManagementAccountEmail" in result).toBe(false)
+  })
+
+  it("respects the input/output reserved names when lifting", async () => {
+    // `inputs` and `outputs` inside the inputs namespace must NOT clobber the
+    // top-level namespaces of the same name.
+    const result = await run({
+      inputs: { Foo: "bar", inputs: "should-not-lift", outputs: "neither" },
+      outputs: { block: { x: "1" } },
+    })
+    expect(result.Foo).toBe("bar")
+    // Top-level inputs/outputs preserved as namespaces (not the lifted strings).
+    expect(result.inputs).toEqual({ Foo: "bar", inputs: "should-not-lift", outputs: "neither" })
+    expect(result.outputs).toEqual({ block: { x: "1" } })
+  })
+
+  it("explicit root-level keys win over lifted inputs", async () => {
+    const result = await run({
+      Foo: "root-wins",
+      inputs: { Foo: "lifted-loses" },
+    })
+    expect(result.Foo).toBe("root-wins")
+  })
+})

--- a/src/domain/boilerplate/flattenInputs.ts
+++ b/src/domain/boilerplate/flattenInputs.ts
@@ -1,0 +1,240 @@
+/**
+ * Adapter from the UI's `{ inputs, outputs }` payload to the var-file shape
+ * boilerplate expects. Two concerns:
+ *
+ *   1. Resolve user-typed template expressions in `inputs.*` against the
+ *      other inputs + outputs map, so a form value like
+ *      `{{ .inputs.A }}+suffix@{{ .inputs.B }}` produces the composed
+ *      string before it reaches boilerplate.
+ *   2. Strip any template values that survived resolution. A raw
+ *      `{{ .inputs.X }}` reaching boilerplate as a var-file value crashes
+ *      when boilerplate re-evaluates the var-file string inside a
+ *      dependency that doesn't expose the `inputs` namespace — stripping
+ *      forces fallback to the variable's own `default:` clause, which
+ *      boilerplate evaluates correctly in the parent scope.
+ *
+ * The `outputs` namespace is preserved verbatim throughout. Its values are
+ * real block outputs, and downstream `.hcl` files reference
+ * `{{ .outputs.X.Y }}` against them.
+ */
+
+import { Effect } from "effect"
+import { WasmRuntime } from "../../services/WasmRuntime.ts"
+import type { WasmRuntimeShape } from "../../services/WasmRuntime.ts"
+
+/** Matches any Go-template expression. `s` flag so `.` spans multi-line defaults. */
+const TEMPLATE_EXPR_RE = /\{\{.*?\}\}/s
+
+export function isTemplateString(v: unknown): boolean {
+  return typeof v === "string" && TEMPLATE_EXPR_RE.test(v)
+}
+
+/**
+ * Recursively drop any value that's still a Go-template expression. A map
+ * whose resulting keys are all stripped is dropped entirely so the
+ * dependency's own defaults apply instead.
+ */
+export function stripTemplateValues(value: unknown): unknown {
+  if (isTemplateString(value)) return undefined
+  if (Array.isArray(value)) {
+    const cleaned = value
+      .map(stripTemplateValues)
+      .filter((v) => v !== undefined)
+    return cleaned
+  }
+  if (value && typeof value === "object") {
+    const cleaned: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const stripped = stripTemplateValues(v)
+      if (stripped !== undefined) cleaned[k] = stripped
+    }
+    return Object.keys(cleaned).length > 0 ? cleaned : undefined
+  }
+  return value
+}
+
+/**
+ * Tight bound on resolution passes. Three covers chained refs A→B→C; deeper
+ * chains are almost always a user mistake and would also blow up
+ * boilerplate's own `default:` evaluation later, so there's no point
+ * looping further.
+ */
+const MAX_RESOLVE_PASSES = 3
+
+/**
+ * Walk `inputs` recursively. For each template-string leaf, render it via
+ * WASM against `{ inputs: <non-template-values>, outputs }`.
+ *
+ *  - Success and the result has no remaining `{{ }}`: replace the leaf.
+ *  - Failure (missing key / parse error / runtime not loaded) OR the
+ *    result still contains `{{ }}`: leave the original in place. The
+ *    strip pass will drop it and boilerplate's `default:` clause runs.
+ *
+ * Iterates to a fixed point (≤ `MAX_RESOLVE_PASSES`) so chained refs
+ * resolve when independent of order. A pass with no replacements ends
+ * the loop early, which also handles cycles — neither side ever
+ * resolves, so we don't spin.
+ */
+export function resolveInputTemplates(
+  inputs: Record<string, unknown>,
+  outputs: unknown,
+): Effect.Effect<Record<string, unknown>, never, WasmRuntime> {
+  return Effect.gen(function* () {
+    if (!hasAnyTemplateString(inputs)) return inputs
+
+    const wasm = yield* WasmRuntime
+    let current: unknown = inputs
+
+    for (let pass = 0; pass < MAX_RESOLVE_PASSES; pass++) {
+      // Feed only already-resolved values into the render context. A
+      // template string in context would render as its literal `{{ }}`
+      // text, which is never what the user meant.
+      const context =
+        (stripTemplateValues(current) as Record<string, unknown> | undefined) ?? {}
+      // Mirror the lifting `flattenVariables` does at the end: legacy template
+      // refs use top-level `{{ .OrgNamePrefix }}` syntax, not
+      // `{{ .inputs.OrgNamePrefix }}`. If we only expose the `inputs`
+      // namespace, those refs fail and the value reaches boilerplate
+      // unresolved. Reserved namespace names are skipped so they don't
+      // clobber the namespaces.
+      const contextWithLifted: Record<string, unknown> = {
+        inputs: context,
+        outputs: outputs ?? {},
+      }
+      for (const [k, v] of Object.entries(context)) {
+        if (k === "inputs" || k === "outputs") continue
+        contextWithLifted[k] = v
+      }
+      const varsJSON = JSON.stringify(contextWithLifted)
+      const result = yield* resolveTree(current, wasm, varsJSON)
+      current = result.value
+      if (!result.changed) break
+    }
+
+    return current as Record<string, unknown>
+  })
+}
+
+function hasAnyTemplateString(value: unknown): boolean {
+  if (isTemplateString(value)) return true
+  if (Array.isArray(value)) return value.some(hasAnyTemplateString)
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).some(
+      hasAnyTemplateString,
+    )
+  }
+  return false
+}
+
+function renderString(
+  value: string,
+  wasm: WasmRuntimeShape,
+  varsJSON: string,
+): Effect.Effect<{ value: string; changed: boolean }, never, never> {
+  return wasm.renderTemplate(value, varsJSON).pipe(
+    Effect.either,
+    Effect.map((either) => {
+      if (either._tag === "Right" && !TEMPLATE_EXPR_RE.test(either.right)) {
+        return { value: either.right, changed: either.right !== value }
+      }
+      return { value, changed: false }
+    }),
+  )
+}
+
+function resolveTree(
+  value: unknown,
+  wasm: WasmRuntimeShape,
+  varsJSON: string,
+): Effect.Effect<{ value: unknown; changed: boolean }, never, never> {
+  if (isTemplateString(value)) {
+    return renderString(value as string, wasm, varsJSON)
+  }
+  if (Array.isArray(value)) {
+    return Effect.gen(function* () {
+      const out: unknown[] = []
+      let changed = false
+      for (const item of value) {
+        const r = yield* resolveTree(item, wasm, varsJSON)
+        out.push(r.value)
+        if (r.changed) changed = true
+      }
+      return { value: out, changed }
+    })
+  }
+  if (value && typeof value === "object") {
+    return Effect.gen(function* () {
+      const out: Record<string, unknown> = {}
+      let changed = false
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        // Map keys can themselves be templates (e.g. the `AccountDefaultTags`
+        // default in bootstrap is `{ "{{ .OrgNamePrefix }}:Team": "DevOps" }`).
+        // Boilerplate doesn't re-evaluate var-file map keys, so unless we
+        // render the key here the literal `{{ ... }}` flows through to the
+        // rendered output.
+        let resolvedKey = k
+        if (isTemplateString(k)) {
+          const keyResult = yield* renderString(k, wasm, varsJSON)
+          if (keyResult.changed) {
+            resolvedKey = keyResult.value as string
+            changed = true
+          }
+        }
+        const r = yield* resolveTree(v, wasm, varsJSON)
+        out[resolvedKey] = r.value
+        if (r.changed) changed = true
+      }
+      return { value: out, changed }
+    })
+  }
+  return Effect.succeed({ value, changed: false })
+}
+
+/**
+ * Flatten `{ inputs, outputs }` into the var-file shape boilerplate expects:
+ * each input lifted to the top level (for legacy `{{ .X }}` syntax + the
+ * CLI's required-variable check) while the `inputs` and `outputs`
+ * namespaces are preserved (for `{{ .inputs.X }}` / `{{ .outputs.block.X }}`
+ * references).
+ *
+ * Explicit root-level keys win over the lifted inputs (matches main's
+ * `applyBackwardCompatibility`). Reserved names `inputs` and `outputs`
+ * inside the inputs namespace are skipped to avoid clobbering the
+ * namespaces.
+ *
+ * User-typed template values in `inputs` are first resolved against the
+ * other inputs + outputs (see `resolveInputTemplates`). Anything that
+ * doesn't resolve is then stripped (see `stripTemplateValues`).
+ */
+export function flattenVariables(
+  variables: Record<string, unknown> | undefined,
+): Effect.Effect<Record<string, unknown>, never, WasmRuntime> {
+  return Effect.gen(function* () {
+    const src = variables ?? {}
+    const rawInputs = src.inputs
+    const inputsObj =
+      rawInputs && typeof rawInputs === "object" && !Array.isArray(rawInputs)
+        ? (rawInputs as Record<string, unknown>)
+        : {}
+
+    const resolvedInputs = yield* resolveInputTemplates(inputsObj, src.outputs)
+
+    // Anything that didn't resolve gets dropped so boilerplate's own
+    // `default:` clause runs in the parent scope.
+    const cleanedInputs =
+      (stripTemplateValues(resolvedInputs) as
+        | Record<string, unknown>
+        | undefined) ?? {}
+
+    const result: Record<string, unknown> = {
+      ...src,
+      inputs: cleanedInputs,
+    }
+
+    for (const [k, v] of Object.entries(cleanedInputs)) {
+      if (k === "inputs" || k === "outputs") continue
+      if (!(k in result)) result[k] = v
+    }
+    return result
+  })
+}

--- a/src/domain/boilerplate/flattenInputs.ts
+++ b/src/domain/boilerplate/flattenInputs.ts
@@ -30,6 +30,32 @@ export function isTemplateString(v: unknown): boolean {
 }
 
 /**
+ * `inputs` and `outputs` are namespace keys in the var-file boilerplate
+ * consumes. When lifting individual inputs to the top level we skip these so
+ * a user-named variable can never clobber a namespace.
+ */
+export function isReservedNamespace(key: string): boolean {
+  return key === "inputs" || key === "outputs"
+}
+
+/**
+ * Lift each non-reserved input key onto a copy of `base`. Explicit keys
+ * already on `base` win (matches main's `applyBackwardCompatibility`), and
+ * the `inputs`/`outputs` namespaces are never overwritten.
+ */
+function liftInputsToRoot(
+  base: Record<string, unknown>,
+  inputs: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...base }
+  for (const [k, v] of Object.entries(inputs)) {
+    if (isReservedNamespace(k)) continue
+    if (!(k in out)) out[k] = v
+  }
+  return out
+}
+
+/**
  * Recursively drop any value that's still a Go-template expression. A map
  * whose resulting keys are all stripped is dropped entirely so the
  * dependency's own defaults apply instead.
@@ -95,16 +121,11 @@ export function resolveInputTemplates(
       // refs use top-level `{{ .OrgNamePrefix }}` syntax, not
       // `{{ .inputs.OrgNamePrefix }}`. If we only expose the `inputs`
       // namespace, those refs fail and the value reaches boilerplate
-      // unresolved. Reserved namespace names are skipped so they don't
-      // clobber the namespaces.
-      const contextWithLifted: Record<string, unknown> = {
-        inputs: context,
-        outputs: outputs ?? {},
-      }
-      for (const [k, v] of Object.entries(context)) {
-        if (k === "inputs" || k === "outputs") continue
-        contextWithLifted[k] = v
-      }
+      // unresolved.
+      const contextWithLifted = liftInputsToRoot(
+        { inputs: context, outputs: outputs ?? {} },
+        context,
+      )
       const varsJSON = JSON.stringify(contextWithLifted)
       const result = yield* resolveTree(current, wasm, varsJSON)
       current = result.value
@@ -226,15 +247,6 @@ export function flattenVariables(
         | Record<string, unknown>
         | undefined) ?? {}
 
-    const result: Record<string, unknown> = {
-      ...src,
-      inputs: cleanedInputs,
-    }
-
-    for (const [k, v] of Object.entries(cleanedInputs)) {
-      if (k === "inputs" || k === "outputs") continue
-      if (!(k in result)) result[k] = v
-    }
-    return result
+    return liftInputsToRoot({ ...src, inputs: cleanedInputs }, cleanedInputs)
   })
 }

--- a/src/domain/files/manifest.ts
+++ b/src/domain/files/manifest.ts
@@ -34,7 +34,7 @@ import type {
  * 16 is well under macOS's default 256 open-FD ulimit while saturating
  * the small-file SSD workload templates produce.
  */
-const BATCH_IO_CONCURRENCY = 16
+export const BATCH_IO_CONCURRENCY = 16
 
 // ---------------------------------------------------------------------------
 // Hashing

--- a/src/layers/NodeWarmRenderDispatcher.test.ts
+++ b/src/layers/NodeWarmRenderDispatcher.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "bun:test"
+import { Effect, Layer } from "effect"
+import {
+  WarmRenderDispatcher,
+  type WarmRenderDispatcherShape,
+} from "../services/WarmRenderDispatcher.ts"
+import {
+  BundleProducer,
+  type BundleProducerShape,
+  type BundleArtifact,
+} from "../services/BundleProducer.ts"
+import { WasmRuntime } from "../services/WasmRuntime.ts"
+import type {
+  WasmRuntimeShape,
+  WasmRenderFilesResult,
+  InputsMapResult,
+} from "../services/WasmRuntime.ts"
+import { NodeWarmRenderDispatcherLive } from "./NodeWarmRenderDispatcher.ts"
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+const KNOWN_PATHS = ["a.txt", "b.txt"]
+
+function fakeInputsMap(): InputsMapResult {
+  // No declared input deps — the dirty-set computation only cares about the
+  // `outputs` namespace + root-name diff for these tests.
+  return {
+    inputs: {},
+    files: Object.fromEntries(KNOWN_PATHS.map((p) => [p, []])),
+  } as unknown as InputsMapResult
+}
+
+function fakeBundleLayer() {
+  const artifact: BundleArtifact = {
+    templateId: "ignored",
+    templatePath: "/tmp/template",
+    inputsMap: fakeInputsMap(),
+    bundleJSON: "{}",
+    producedAt: 0,
+  }
+  const impl: BundleProducerShape = {
+    get: (templateId, templatePath) =>
+      Effect.succeed({ ...artifact, templateId, templatePath }),
+    clear: Effect.void,
+    invalidate: () => Effect.void,
+  }
+  return Layer.succeed(BundleProducer, impl)
+}
+
+interface WasmSpy {
+  prepareCalls: number
+  releasedHandles: string[]
+}
+
+function fakeWasmLayer(spy: WasmSpy) {
+  let nextHandle = 0
+  const renderAll = (paths: ReadonlyArray<string>): WasmRenderFilesResult => ({
+    results: paths.map((path) => ({ path, content: `rendered:${path}` })),
+  })
+  const impl: WasmRuntimeShape = {
+    isReady: Effect.succeed(true),
+    prepareBundle: () =>
+      Effect.sync(() => {
+        spy.prepareCalls++
+        return `handle-${nextHandle++}`
+      }),
+    renderFilesWithHandle: (_handle, paths) => Effect.succeed(renderAll(paths)),
+    renderFiles: (_bundleJSON, paths) => Effect.succeed(renderAll(paths)),
+    releaseBundle: (handle) =>
+      Effect.sync(() => {
+        spy.releasedHandles.push(handle)
+      }),
+    renderTemplate: () => Effect.die("renderTemplate not implemented"),
+    inputsMap: () => Effect.die("inputsMap not implemented"),
+  }
+  return Layer.succeed(WasmRuntime, impl)
+}
+
+function makeDispatcher(spy: WasmSpy) {
+  return NodeWarmRenderDispatcherLive.pipe(
+    Layer.provide(fakeBundleLayer()),
+    Layer.provide(fakeWasmLayer(spy)),
+  )
+}
+
+const run = <A>(
+  spy: WasmSpy,
+  f: (d: WarmRenderDispatcherShape) => Effect.Effect<A, unknown, never>,
+) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const d = yield* WarmRenderDispatcher
+      return yield* f(d)
+    }).pipe(Effect.provide(makeDispatcher(spy))) as Effect.Effect<A, never, never>,
+  )
+
+// Unique templateId per test keeps the module-scoped caches
+// (previousVarsByTemplate / handlesByTemplate) from leaking between tests.
+let counter = 0
+function freshTemplateId(): string {
+  return `tmpl-${counter++}`
+}
+
+describe("NodeWarmRenderDispatcher.invalidate", () => {
+  let spy: WasmSpy
+  beforeEach(() => {
+    spy = { prepareCalls: 0, releasedHandles: [] }
+  })
+
+  it("releases the prepared handle and clears cached vars so the next render is a first-render", async () => {
+    const templateId = freshTemplateId()
+    const vars = { Foo: "bar", inputs: { Foo: "bar" }, outputs: {} }
+
+    await run(spy, (d) =>
+      Effect.gen(function* () {
+        // 1. First render seeds prevVars + prepares a handle, rendering the world.
+        const first = yield* d.render(templateId, "/tmp/template", vars)
+        expect(first.noChanges).toBe(false)
+        expect(first.attemptedPaths).toEqual(KNOWN_PATHS)
+        expect(spy.prepareCalls).toBe(1)
+
+        // 2. Same vars again → dirty set empty → no-op (proves prevVars cached).
+        const second = yield* d.render(templateId, "/tmp/template", vars)
+        expect(second.noChanges).toBe(true)
+        expect(spy.prepareCalls).toBe(1)
+        expect(spy.releasedHandles).toEqual([])
+
+        // 3. Invalidate: should release the handle and drop cached vars.
+        yield* d.invalidate(templateId)
+        expect(spy.releasedHandles).toEqual(["handle-0"])
+
+        // 4. Same vars once more → treated as first-render again (everything
+        //    dirty) and a new handle is prepared.
+        const third = yield* d.render(templateId, "/tmp/template", vars)
+        expect(third.noChanges).toBe(false)
+        expect(third.attemptedPaths).toEqual(KNOWN_PATHS)
+        expect(spy.prepareCalls).toBe(2)
+      }),
+    )
+  })
+
+  it("is a no-op when the templateId was never rendered", async () => {
+    const templateId = freshTemplateId()
+    await run(spy, (d) => d.invalidate(templateId))
+    expect(spy.releasedHandles).toEqual([])
+  })
+})

--- a/src/layers/NodeWarmRenderDispatcher.ts
+++ b/src/layers/NodeWarmRenderDispatcher.ts
@@ -28,6 +28,7 @@ import {
   type WarmPerFileError,
 } from "../services/WarmRenderDispatcher.ts"
 import { BundleProducer } from "../services/BundleProducer.ts"
+import { isReservedNamespace } from "../domain/boilerplate/flattenInputs.ts"
 import { WasmRuntime } from "../services/WasmRuntime.ts"
 import type {
   WasmRenderResult,
@@ -81,12 +82,12 @@ function changedRootNames(
   const changed = new Set<string>()
   const seen = new Set<string>()
   for (const [k, v] of Object.entries(curr)) {
-    if (k === "inputs" || k === "outputs") continue
+    if (isReservedNamespace(k)) continue
     seen.add(k)
     if (!(k in prev) || !varsEqual(prev[k], v)) changed.add(k)
   }
   for (const k of Object.keys(prev)) {
-    if (k === "inputs" || k === "outputs") continue
+    if (isReservedNamespace(k)) continue
     if (!seen.has(k)) changed.add(k)
   }
   return changed

--- a/src/layers/NodeWarmRenderDispatcher.ts
+++ b/src/layers/NodeWarmRenderDispatcher.ts
@@ -376,6 +376,19 @@ export const NodeWarmRenderDispatcherLive = Layer.effect(
         previousVarsByTemplate.clear()
         yield* bundles.clear
       }),
+
+      invalidate: (templateId: string) =>
+        Effect.gen(function* () {
+          const handle = handlesByTemplate.get(templateId)
+          if (handle) {
+            // Best-effort release; if the WASM runtime is unavailable or
+            // the handle is already gone on the Go side, we still want to
+            // clear our local maps so subsequent renders re-prepare.
+            yield* wasm.releaseBundle(handle).pipe(Effect.ignore)
+            handlesByTemplate.delete(templateId)
+          }
+          previousVarsByTemplate.delete(templateId)
+        }),
     }
 
     return impl

--- a/src/services/WarmRenderDispatcher.ts
+++ b/src/services/WarmRenderDispatcher.ts
@@ -97,6 +97,16 @@ export interface WarmRenderDispatcherShape {
 
   /** Clear all cached bundles. */
   readonly reset: Effect.Effect<void>
+
+  /**
+   * Drop cached vars + handle for a single template. Use when the previous
+   * render's output directory was wiped externally (e.g., a `GitClone` over
+   * the worktree, `rm -rf`, `git reset --hard`). Without this, the next
+   * render's dirty-set diff would only re-emit files whose vars changed —
+   * leaving the rest of the tree missing from disk because the dispatcher
+   * trusts that prior output is still where it was left.
+   */
+  readonly invalidate: (templateId: string) => Effect.Effect<void>
 }
 
 export class WarmRenderDispatcher extends Context.Tag("WarmRenderDispatcher")<


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced template variable handling in boilerplate rendering with improved reference resolution
  * Automatic cache cleanup when previously rendered output files are deleted

* **Tests**
  * Added comprehensive test coverage for template variable flattening and resolution logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/runbooks/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->