### PR TITLE
chore: clean up references to auth block to consistently name it

### DIFF
--- a/cli/test/executor.ts
+++ b/cli/test/executor.ts
@@ -1144,10 +1144,10 @@ export class TestExecutor {
     // Inject token for GitHub URLs
     let effectiveURL = cloneURL
     if (cloneURL.includes("github.com")) {
-      const gitHubAuthId = extractProp(block.props, "gitHubAuthId")
+      const githubAuthId = extractProp(block.props, "githubAuthId")
       let token = ""
-      if (gitHubAuthId) {
-        const creds = this.authBlockCredentials.get(gitHubAuthId)
+      if (githubAuthId) {
+        const creds = this.authBlockCredentials.get(githubAuthId)
         if (creds) token = creds["GITHUB_TOKEN"] ?? ""
       }
       if (!token) {

--- a/docs/src/content/docs/authoring/blocks/Check.md
+++ b/docs/src/content/docs/authoring/blocks/Check.md
@@ -40,6 +40,7 @@ Check blocks and [Command](/authoring/blocks/command/) blocks share many feature
 - `failMessage` (string) - Message shown when check fails (default: "Failed"). Supports inline markdown.
 - `runningMessage` (string) - Message shown while running (default: "Checking..."). Supports inline markdown.
 - `usePty` (boolean) - Whether to use a pseudo-terminal (PTY) for script execution. Defaults to `true`. Set to `false` to use pipes instead, which may be needed for scripts that don't work well with PTY or when simpler output handling is preferred. See [PTY Support](/authoring/blocks/advanced#pseudo-terminal-pty-support) for details.
+- `timeoutMs` (number) - Maximum time, in milliseconds, the check script is allowed to run before it is killed and the block is marked as failed. Defaults to `300000` (5 minutes). Use this for checks that legitimately take longer than the default — for example, `timeoutMs={1800000}` for a 30-minute probe.
 
 ### Inline content
 

--- a/docs/src/content/docs/authoring/blocks/GitClone.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitClone.mdx
@@ -33,7 +33,7 @@ When paired with a `<GitHubAuth>` block, the GitClone block enables a "Browse Gi
 
 <GitClone
   id="clone-repo"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone a Repo"
   description="Browse or enter a git URL to clone"
 />
@@ -61,7 +61,7 @@ You can pre-populate the URL, ref, sparse checkout path, and local path fields. 
 | `id` | `string` | Yes | Unique block identifier. Used by downstream blocks to reference outputs. |
 | `title` | `string` | No | Display title for the block header. Supports inline markdown. |
 | `description` | `string` | No | Description text below the title. Supports inline markdown. |
-| `gitHubAuthId` | `string` | No | Reference to a [`<GitHubAuth>`](/authoring/blocks/githubauth) block. When set, the block waits for authentication to complete and uses the token for GitHub API access and clone authentication. |
+| `githubAuthId` | `string` | No | Reference to a [`<GitHubAuth>`](/authoring/blocks/githubauth) block. When set, the block waits for authentication to complete and uses the token for GitHub API access and clone authentication. |
 | `prefilledUrl` | `string` | No | Pre-fills the Git URL input field. The user can edit this value before cloning. |
 | `prefilledRef` | `string` | No | Pre-fills the ref (branch or tag) to clone. When set, the specified ref is passed to `git clone --branch`. Defaults to the repository's default branch if empty. |
 | `prefilledRepoPath` | `string` | No | Pre-fills the sparse checkout path. When set, only the specified subdirectory of the repository will be cloned (e.g., `modules/vpc`). |
@@ -104,7 +104,7 @@ The GitClone block accepts the following URL formats:
 
 The GitClone block resolves GitHub credentials in the following order:
 
-1. **`gitHubAuthId`** — If specified, uses the `GITHUB_TOKEN` from the referenced GitHubAuth block's outputs.
+1. **`githubAuthId`** — If specified, uses the `GITHUB_TOKEN` from the referenced GitHubAuth block's outputs.
 2. **Session environment** — Checks the session environment for `GITHUB_TOKEN` or `GH_TOKEN`.
 3. **No token** — The "Browse GitHub repositories" section is hidden. The user can still clone public repos or use SSH URLs.
 
@@ -194,7 +194,7 @@ The GitClone block includes a collapsible "View Logs" section (identical to the 
 
 <GitClone
   id="clone-infra"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone Infrastructure Repo"
   description="Clone the infrastructure repository to make changes"
   prefilledUrl="https://github.com/acme-corp/infrastructure-live"

--- a/docs/src/content/docs/authoring/blocks/GitHubPullRequest.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitHubPullRequest.mdx
@@ -20,7 +20,7 @@ Pair with `<GitHubAuth>` and `<GitClone>` to create a complete workflow:
 
 <GitClone
   id="clone-repo"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone Repository"
   prefilledUrl="https://github.com/acme-corp/infrastructure"
 />
@@ -130,7 +130,7 @@ The block fetches available labels from the repository and presents them in a se
 
 <GitClone
   id="clone-infra"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone Infrastructure Repo"
   prefilledUrl="https://github.com/acme-corp/infrastructure-live"
 />

--- a/testdata/feature-demos/git-clone/runbook.mdx
+++ b/testdata/feature-demos/git-clone/runbook.mdx
@@ -22,7 +22,7 @@ Clone any repository. If you authenticated above, you'll see a "Browse GitHub re
 
 <GitClone
   id="clone-github"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone a GitHub Repo"
   description="Enter a git URL or browse GitHub to select a repository"
 />
@@ -33,7 +33,7 @@ This example pre-fills the URL and clones only the `docs` subdirectory using spa
 
 <GitClone
   id="clone-subdir"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone a Subdirectory"
   description="Clone only the docs directory from the runbooks repo"
   prefilledUrl="https://github.com/gruntwork-io/runbooks"

--- a/testdata/feature-demos/git-clone/runbook_test.yml
+++ b/testdata/feature-demos/git-clone/runbook_test.yml
@@ -29,7 +29,7 @@ tests:
       - block: gh-auth
         expect: skip
       - block: clone-github
-        expect: skip  # Skipped because gitHubAuthId dependency was skipped
+        expect: skip  # Skipped because githubAuthId dependency was skipped
 
   - name: generic-clone-public-repo
     description: Clone a public repo without any GitHub authentication

--- a/testdata/feature-demos/github-pull-request/runbook.mdx
+++ b/testdata/feature-demos/github-pull-request/runbook.mdx
@@ -18,7 +18,7 @@ This runbook demonstrates the GitHubPullRequest block, which provides a streamli
 
 <GitClone
   id="clone-repo"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone a Repository"
   description="Clone the repository you want to create a PR for"
   prefilledUrl="https://github.com/gruntwork-io/runbooks-test"

--- a/testdata/sample-runbooks/new-infra-live-repo/runbook.mdx
+++ b/testdata/sample-runbooks/new-infra-live-repo/runbook.mdx
@@ -72,7 +72,7 @@ Create a new empty repository on GitHub. The scaffolded files will be pushed to 
 
 <GitClone
   id="clone-repo"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone the new repository"
   description="Clone the empty repository so we can scaffold files into it."
   prefilledUrl="https://github.com/{{ .inputs.OrgName }}/{{ .inputs.RepoName }}"

--- a/testdata/sample-runbooks/next-app/runbook.mdx
+++ b/testdata/sample-runbooks/next-app/runbook.mdx
@@ -62,7 +62,7 @@ Clone the repository you created above, or an existing repository you'd like to 
 
 <GitClone
   id="clone-repo"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone the Repository"
   description="Clone the repository so we can scaffold the Next.js app into it"
   prefilledUrl="https://github.com/gruntwork-test/empty-repo"

--- a/testdata/sample-runbooks/openclaw/runbook.mdx
+++ b/testdata/sample-runbooks/openclaw/runbook.mdx
@@ -113,7 +113,7 @@ Clone the **infra-catalog** repo where the OpenTofu module will be written.
 
 <GitClone
   id="clone-catalog"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone infra-catalog"
   description="Clone the repository where the OpenTofu module will be written."
 
@@ -179,7 +179,7 @@ Clone the **infra-live** repo where the Terragrunt unit (terragrunt.hcl) will be
 
 <GitClone
   id="clone-live"
-  gitHubAuthId="gh-auth"
+  githubAuthId="gh-auth"
   title="Clone infra-live"
   description="Clone the repository where the Terragrunt unit (terragrunt.hcl) will be written."
 

--- a/web/src/components/mdx/Check/Check.tsx
+++ b/web/src/components/mdx/Check/Check.tsx
@@ -14,7 +14,7 @@ import type { AppError } from "@/types/error"
 
 interface CheckProps {
   id: string
-  title: string
+  title?: string
   description?: string
   path?: string
   command?: string
@@ -31,6 +31,8 @@ interface CheckProps {
   children?: ReactNode // For inline Inputs component
   /** Whether to use PTY (pseudo-terminal) for script execution. Defaults to true. Set to false to use pipes instead, which may be needed for scripts that don't work well with PTY or when simpler output handling is preferred. */
   usePty?: boolean
+  /** Per-execution timeout in milliseconds. When omitted, the executor's default timeout (5 minutes) applies. */
+  timeoutMs?: number
 }
 
 function Check({
@@ -48,6 +50,7 @@ function Check({
   runningMessage = "Checking...",
   children,
   usePty,
+  timeoutMs,
 }: CheckProps) {
   // Validate required props
   const validationError = useMemo((): AppError | null => {
@@ -109,6 +112,7 @@ function Check({
     children,
     componentType: 'check',
     usePty,
+    timeoutMs,
   })
   
   // Clone children and add variant="embedded" prop if it's an Inputs component
@@ -143,19 +147,15 @@ function Check({
     return null
   }, [path, command, sourceCode])
 
-  // Validate required props after all hooks are called (Rules of Hooks)
+  // Validate required props after all hooks are called (Rules of Hooks).
+  // `title` is optional (matching <Command>); add future prop validations here.
   const validationErrors = useMemo(() => {
     const errors: string[] = [];
-    
-    if (!title) {
-      errors.push('The "title" prop is required but was not provided.');
-    }
-    
-    // Add more validation checks here as needed
+
     // Example: if (!path && !children) { errors.push('Either path or children must be provided.'); }
-    
+
     return errors;
-  }, [title]);
+  }, []);
 
   // Resolve display string props using template context
   const resolvedTitle = useMemo(() => title ? resolveTemplateReferences(title, templateContext) : title, [title, templateContext])
@@ -401,9 +401,11 @@ function Check({
 
         <div className="">
         <div className="flex-1 space-y-2">
-          <div className="text-md font-bold text-muted-foreground">
-            <InlineMarkdown>{resolvedTitle}</InlineMarkdown>
-          </div>
+          {resolvedTitle && (
+            <div className="text-md font-bold text-muted-foreground">
+              <InlineMarkdown>{resolvedTitle}</InlineMarkdown>
+            </div>
+          )}
           {resolvedDescription && (
             <div className="text-md text-muted-foreground mb-3">
               <InlineMarkdown>{resolvedDescription}</InlineMarkdown>

--- a/web/src/components/mdx/Check/__tests__/Check.test.tsx
+++ b/web/src/components/mdx/Check/__tests__/Check.test.tsx
@@ -34,9 +34,15 @@ const defaultScriptExecution = {
 }
 
 let mockScriptExecution = { ...defaultScriptExecution }
+// Captures the props the component passes to useScriptExecution so tests can
+// assert wiring (e.g. that timeoutMs is forwarded).
+let lastScriptExecutionProps: Record<string, unknown> | null = null
 
 vi.mock("@/components/mdx/_shared/hooks/useScriptExecution", () => ({
-  useScriptExecution: () => mockScriptExecution,
+  useScriptExecution: (props: Record<string, unknown>) => {
+    lastScriptExecutionProps = props
+    return mockScriptExecution
+  },
 }))
 
 vi.mock("@/contexts/useLogs", () => ({
@@ -54,11 +60,30 @@ function renderCheck(props: Partial<React.ComponentProps<typeof Check>> = {}) {
 describe("Check", () => {
   beforeEach(() => {
     mockScriptExecution = { ...defaultScriptExecution, execute: vi.fn(), cancel: vi.fn() }
+    lastScriptExecutionProps = null
   })
 
   it("renders with valid props", () => {
     renderCheck()
     expect(screen.getByTestId("test-check")).toBeInTheDocument()
+  })
+
+  it("renders without a title (title is optional, matching <Command>)", () => {
+    // Regression guard: title used to be required and rendered a validation
+    // error block when omitted. It is now optional.
+    render(
+      <TestWrapper>
+        <Check id="no-title-check" command="exit 0" />
+      </TestWrapper>,
+    )
+    expect(screen.getByTestId("no-title-check")).toBeInTheDocument()
+    expect(screen.queryByText(/required but was not provided/)).toBeNull()
+    expect(screen.queryByText(/Missing required props/)).toBeNull()
+  })
+
+  it("forwards timeoutMs to the execution hook", () => {
+    renderCheck({ timeoutMs: 1234 })
+    expect(lastScriptExecutionProps?.timeoutMs).toBe(1234)
   })
 
   it("renders title and description", () => {

--- a/web/src/components/mdx/DirPicker/DirPicker.tsx
+++ b/web/src/components/mdx/DirPicker/DirPicker.tsx
@@ -19,7 +19,7 @@ function DirPickerInteractive({
   gitCloneId,
   title = "Select Directory",
   description = "Choose a target directory",
-  dirLabels,
+  dirLabels = [],
   dirLabelsExtra = false,
   pathLabel = "Target Path",
   pathLabelDescription,
@@ -59,8 +59,10 @@ function DirPickerInteractive({
     trackBlockRender('DirPicker')
   }, [id, trackBlockRender])
 
-  // Cap dropdown depth to dirLabels.length unless dirLabelsExtra is true
-  const maxLevels = dirLabelsExtra ? undefined : dirLabels.length
+  // Cap dropdown depth to dirLabels.length unless dirLabelsExtra is true. When
+  // dirLabels is omitted (empty), leave depth unbounded — levels then fall back
+  // to "Level N" labels below.
+  const maxLevels = dirLabelsExtra || dirLabels.length === 0 ? undefined : dirLabels.length
 
   // Core hook
   const {

--- a/web/src/components/mdx/DirPicker/__tests__/DirPicker.test.tsx
+++ b/web/src/components/mdx/DirPicker/__tests__/DirPicker.test.tsx
@@ -17,6 +17,19 @@ describe('DirPicker', () => {
     vi.clearAllMocks()
   })
 
+  it('renders without crashing when dirLabels is omitted', () => {
+    // Regression guard: dirLabels was a required prop dereferenced via
+    // `dirLabels.length`, so omitting it crashed the block at render.
+    render(
+      <TestWrapper>
+        <DirPicker id="test-picker" rootDir="/tmp/test-dir" />
+      </TestWrapper>
+    )
+
+    expect(screen.getByTestId('test-picker')).toBeDefined()
+    expect(screen.queryByText(/requires either a/)).toBeNull()
+  })
+
   it('renders title and description', () => {
     render(
       <TestWrapper>

--- a/web/src/components/mdx/DirPicker/types.ts
+++ b/web/src/components/mdx/DirPicker/types.ts
@@ -12,8 +12,8 @@ export interface DirPickerProps {
   title?: string
   /** Description text (supports inline markdown). */
   description?: string
-  /** Ordered labels for each cascading directory level (e.g., ['Environment', 'Region', 'Category']). Each dropdown is labelled with the corresponding entry. Also controls the maximum depth unless dirLabelsExtra is true. */
-  dirLabels: string[]
+  /** Ordered labels for each cascading directory level (e.g., ['Environment', 'Region', 'Category']). Each dropdown is labelled with the corresponding entry. Also controls the maximum depth unless dirLabelsExtra is true. When omitted, levels are labelled "Level N" and depth is unbounded. */
+  dirLabels?: string[]
   /** When true, allow navigating deeper than dirLabels.length. Extra levels are labelled "Level N". Defaults to false. */
   dirLabelsExtra?: boolean
   /** Label for the editable path input. Defaults to "Target Path". */

--- a/web/src/components/mdx/GitClone/GitClone.tsx
+++ b/web/src/components/mdx/GitClone/GitClone.tsx
@@ -41,7 +41,7 @@ function GitCloneInteractive({
   title = "Clone Repository",
   description = "Enter a git URL to clone a repository",
   inputsId,
-  gitHubAuthId,
+  githubAuthId,
   prefilledUrl = '',
   prefilledRef = '',
   prefilledRepoPath = '',
@@ -138,7 +138,7 @@ function GitCloneInteractive({
     fetchOrgs,
     fetchRepos,
     fetchRefs,
-  } = useGitClone({ id, gitHubAuthId })
+  } = useGitClone({ id, githubAuthId })
 
   // Get registered outputs for this block
   const outputValues = useOutputs(id)
@@ -346,7 +346,7 @@ function GitCloneInteractive({
               <div>
                 <p className="text-sm font-medium text-warning-foreground m-0">Waiting for GitHub authentication</p>
                 <p className="text-xs text-warning-foreground m-0 mt-0.5">
-                  Complete the &apos;{gitHubAuthId}&apos; GitHubAuth block above before cloning.
+                  Complete the &apos;{githubAuthId}&apos; GitHubAuth block above before cloning.
                 </p>
               </div>
             </div>

--- a/web/src/components/mdx/GitClone/__tests__/GitClone.test.tsx
+++ b/web/src/components/mdx/GitClone/__tests__/GitClone.test.tsx
@@ -1,11 +1,13 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { TestWrapper } from "@/test/test-utils"
 import GitClone from ".."
+import { useGitClone } from "../hooks/useGitClone"
 
-// Mock useGitClone hook
+// Mock useGitClone hook. A vi.fn lets us assert which auth id the component
+// forwards to the hook.
 vi.mock("../hooks/useGitClone", () => ({
-  useGitClone: () => ({
+  useGitClone: vi.fn(() => ({
     status: "idle",
     progress: null,
     cloneResult: null,
@@ -13,7 +15,7 @@ vi.mock("../hooks/useGitClone", () => ({
     logs: [],
     handleClone: vi.fn(),
     handleCancel: vi.fn(),
-  }),
+  })),
 }))
 
 // Mock useGitWorkTree context
@@ -35,6 +37,10 @@ function renderGitClone(props: Record<string, unknown> = {}) {
 }
 
 describe("GitClone", () => {
+  beforeEach(() => {
+    vi.mocked(useGitClone).mockClear()
+  })
+
   it("renders with default title", () => {
     renderGitClone()
     expect(screen.getByTestId("test-clone")).toBeInTheDocument()
@@ -64,5 +70,10 @@ describe("GitClone", () => {
     renderGitClone()
     const block = screen.getByTestId("test-clone")
     expect(block.querySelector(".bg-destructive-muted")).toBeNull()
+  })
+
+  it("forwards githubAuthId to the hook", () => {
+    renderGitClone({ githubAuthId: "gh-auth" })
+    expect(useGitClone).toHaveBeenCalledWith({ id: "test-clone", githubAuthId: "gh-auth" })
   })
 })

--- a/web/src/components/mdx/GitClone/hooks/useGitClone.ts
+++ b/web/src/components/mdx/GitClone/hooks/useGitClone.ts
@@ -21,10 +21,10 @@ function createLogEntry(line: string, timestamp?: string): LogEntry {
 
 interface UseGitCloneOptions {
   id: string
-  gitHubAuthId?: string
+  githubAuthId?: string
 }
 
-export function useGitClone({ id, gitHubAuthId }: UseGitCloneOptions) {
+export function useGitClone({ id, githubAuthId }: UseGitCloneOptions) {
   const api = useApi()
   const { registerOutputs, blockOutputs: allOutputs } = useRunbookContext()
 
@@ -40,11 +40,11 @@ export function useGitClone({ id, gitHubAuthId }: UseGitCloneOptions) {
   // Ref to the progress listener unsubscriber so cancel() can clean up
   const unsubLogRef = useRef<(() => void) | null>(null)
 
-  // Check if gitHubAuthId dependency is met
+  // Check if the githubAuthId dependency is met
   const gitHubAuthMet = useMemo((): boolean => {
-    if (!gitHubAuthId) return true // No dependency
+    if (!githubAuthId) return true // No dependency
 
-    const normalizedId = normalizeBlockId(gitHubAuthId)
+    const normalizedId = normalizeBlockId(githubAuthId)
     const blockOutputs = allOutputs[normalizedId]
 
     // Check for GITHUB_TOKEN in outputs
@@ -58,7 +58,7 @@ export function useGitClone({ id, gitHubAuthId }: UseGitCloneOptions) {
     }
 
     return false
-  }, [gitHubAuthId, allOutputs])
+  }, [githubAuthId, allOutputs])
 
   // Fetch session working directory for path preview
   const fetchWorkingDir = useCallback(async () => {

--- a/web/src/components/mdx/GitClone/types.ts
+++ b/web/src/components/mdx/GitClone/types.ts
@@ -8,8 +8,8 @@ export interface GitCloneProps {
   description?: string
   /** ID or array of IDs of Inputs components to get variable values from */
   inputsId?: string | string[]
-  /** Reference to a GitHubAuth block for token */
-  gitHubAuthId?: string
+  /** Reference to a GitHubAuth block by ID for credentials. Matches the `githubAuthId` prop used by every other block (Command, Check, GitHubPullRequest). */
+  githubAuthId?: string
   /** Pre-fill the Git URL input (supports template expressions like {{ .inputs.repo_url }}) */
   prefilledUrl?: string
   /** Pre-fill the ref (branch or tag) to clone (supports template expressions) */


### PR DESCRIPTION
We refer to github everywhere else as "github" and not "gitHub". This makes it consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `timeoutMs` property to Check block for configurable script execution timeout (default 5 minutes).

* **Bug Fixes**
  * Standardized GitHub authentication property naming to `githubAuthId` across components for consistency.
  * Made `title` property optional in Check block and `dirLabels` in DirPicker for improved flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/runbooks/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->