### PR TITLE
fix: open runbook on double click

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -9,6 +9,7 @@ import { app, shell, ipcMain, dialog, protocol, net, nativeTheme } from "electro
 import * as path from "path"
 import * as fs from "fs"
 import { createMainWindow, focusOrCreateWindow, getMainWindow, setTitleBarTheme } from "./window.ts"
+import { openRunbookInWindow } from "./open-runbook.ts"
 import { getStoredTheme } from "./theme-store.ts"
 import { setupApplicationMenu } from "./menu.ts"
 import { initAutoUpdater } from "./updater.ts"
@@ -224,14 +225,25 @@ ipcMain.handle("native:get-cli-config", () => ({
 // macOS: handle open-file events (double-click .mdx in Finder)
 // ---------------------------------------------------------------------------
 
+// Holds a path from an open-file event that arrived before the window existed
+// (cold launch). The whenReady handler below delivers it once the window is up.
+let pendingOpenFilePath: string | null = null
+
 app.on("open-file", (event, filePath) => {
   event.preventDefault()
   const win = getMainWindow()
   if (win) {
-    win.webContents.send("file:open-runbook", { path: filePath })
+    // App already running (e.g. "Open with… > Runbooks"): hand it straight to
+    // the window. openRunbookInWindow defers internally if it's mid-load.
+    openRunbookInWindow(win, { path: filePath })
   } else {
-    // App hasn't finished launching yet — stash the path so we can open it
-    // once the window is ready.
+    // App hasn't finished launching yet (Finder double-click on a cold start).
+    // On macOS this event commonly fires before app.whenReady() has created
+    // the window, so stash the path for the whenReady handler to open. Also
+    // seed runbookConfig.localPath so the runbook-asset protocol resolves
+    // assets correctly if an image request races ahead of the renderer's
+    // runbook:get call (mirrors the CLI-path handling above).
+    pendingOpenFilePath = filePath
     setRunbookConfig({ ...runbookConfig, localPath: filePath })
   }
 })
@@ -310,10 +322,16 @@ app.whenReady().then(() => {
         })
     })
   } else if (cliConfig.runbookPath) {
+    const runbookPath = cliConfig.runbookPath
     const win = getMainWindow()
-    win?.webContents.once("did-finish-load", () => {
-      win.webContents.send("file:open-runbook", { path: cliConfig.runbookPath })
-    })
+    if (win) openRunbookInWindow(win, { path: runbookPath })
+  } else if (pendingOpenFilePath) {
+    // A macOS open-file event (Finder double-click) arrived before the window
+    // was ready. Now that the window exists, open the stashed runbook.
+    const filePath = pendingOpenFilePath
+    pendingOpenFilePath = null
+    const win = getMainWindow()
+    if (win) openRunbookInWindow(win, { path: filePath })
   }
 
   app.on("activate", () => {

--- a/electron/main/open-runbook.test.ts
+++ b/electron/main/open-runbook.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test"
+import { openRunbookInWindow } from "./open-runbook.ts"
+import type { BrowserWindow } from "electron"
+
+type SendCall = { channel: string; payload: unknown }
+
+/**
+ * Build a stand-in exposing just the webContents surface openRunbookInWindow
+ * uses. `fireFinishLoad` simulates the renderer's page finishing its load — the
+ * point where it has registered its IPC listeners.
+ */
+function makeFakeWindow(isLoading: boolean) {
+  const calls: SendCall[] = []
+  let finishLoadCb: (() => void) | null = null
+  const win = {
+    webContents: {
+      isLoading: () => isLoading,
+      once: (event: string, cb: () => void) => {
+        if (event === "did-finish-load") finishLoadCb = cb
+      },
+      send: (channel: string, payload: unknown) => {
+        calls.push({ channel, payload })
+      },
+    },
+  } as unknown as BrowserWindow
+  return { win, calls, fireFinishLoad: () => finishLoadCb?.() }
+}
+
+describe("openRunbookInWindow", () => {
+  it("sends immediately when the window has already finished loading", () => {
+    // The "app already running" case (e.g. Finder "Open with… > Runbooks").
+    const { win, calls } = makeFakeWindow(false)
+    openRunbookInWindow(win, { path: "/x/runbook.mdx" })
+    expect(calls).toEqual([
+      { channel: "file:open-runbook", payload: { path: "/x/runbook.mdx" } },
+    ])
+  })
+
+  it("defers until did-finish-load when the window is still loading", () => {
+    // The cold-start case: sending before the renderer registers its listener
+    // would drop the event, so nothing is sent until the load finishes.
+    const { win, calls, fireFinishLoad } = makeFakeWindow(true)
+    openRunbookInWindow(win, { path: "/x/runbook.mdx" })
+    expect(calls).toEqual([])
+
+    fireFinishLoad()
+    expect(calls).toEqual([
+      { channel: "file:open-runbook", payload: { path: "/x/runbook.mdx" } },
+    ])
+  })
+
+  it("forwards remoteSource in the payload", () => {
+    const { win, calls } = makeFakeWindow(false)
+    openRunbookInWindow(win, {
+      path: "/x/runbook.mdx",
+      remoteSource: "github.com/o/r",
+    })
+    expect(calls[0]?.payload).toEqual({
+      path: "/x/runbook.mdx",
+      remoteSource: "github.com/o/r",
+    })
+  })
+})

--- a/electron/main/open-runbook.ts
+++ b/electron/main/open-runbook.ts
@@ -1,0 +1,29 @@
+// Type-only import: this module deliberately has no runtime dependency on
+// electron so it stays unit-testable without an Electron runtime (or a
+// module mock that would collide with other main-process tests).
+import type { BrowserWindow } from "electron"
+
+/** Payload for the "file:open-runbook" event the renderer listens for. */
+export type OpenRunbookPayload = { path: string; remoteSource?: string }
+
+/**
+ * Tell a window to open a runbook, deferring until the renderer has finished
+ * loading if the page is still in flight.
+ *
+ * The renderer registers its "file:open-runbook" listener only after its JS
+ * runs (around did-finish-load); sending before then silently drops the event.
+ * On a cold launch the window is freshly created and still loading when the
+ * path arrives, so we can't assume the renderer is listening yet. Checking
+ * `isLoading()` sends immediately for an already-loaded window (the "app
+ * already running" case, e.g. Finder "Open with… > Runbooks") while deferring
+ * for a freshly-created one (the macOS Finder double-click cold-start case).
+ */
+export function openRunbookInWindow(win: BrowserWindow, payload: OpenRunbookPayload): void {
+  if (win.webContents.isLoading()) {
+    win.webContents.once("did-finish-load", () => {
+      win.webContents.send("file:open-runbook", payload)
+    })
+  } else {
+    win.webContents.send("file:open-runbook", payload)
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file-opening behavior on macOS to reliably deliver files to the application, especially when launched from a cold state.

* **Tests**
  * Added test coverage to verify file-opening functionality works correctly across different application startup states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/runbooks/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->