### PR TITLE
Feat: make git clone block vendor neutral

### DIFF
--- a/src/domain/git/operations.test.ts
+++ b/src/domain/git/operations.test.ts
@@ -52,6 +52,34 @@ describe("parseOwnerRepoFromURL", () => {
     expect(result).toEqual({ owner: "group", repo: "project" })
   })
 
+  it("parses GitLab HTTPS URL with nested groups (full group path as owner)", () => {
+    const result = parseOwnerRepoFromURL(
+      "https://gitlab.com/group/subgroup/project.git",
+    )
+    expect(result).toEqual({ owner: "group/subgroup", repo: "project" })
+  })
+
+  it("parses GitLab HTTPS URL with deeply nested groups", () => {
+    const result = parseOwnerRepoFromURL(
+      "https://gitlab.com/group/subgroup/deeper/project",
+    )
+    expect(result).toEqual({ owner: "group/subgroup/deeper", repo: "project" })
+  })
+
+  it("parses GitLab SSH URL with nested groups", () => {
+    const result = parseOwnerRepoFromURL(
+      "git@gitlab.com:group/subgroup/project.git",
+    )
+    expect(result).toEqual({ owner: "group/subgroup", repo: "project" })
+  })
+
+  it("parses self-hosted GitLab SSH URL with nested groups", () => {
+    const result = parseOwnerRepoFromURL(
+      "git@gitlab.example.com:group/subgroup/project.git",
+    )
+    expect(result).toEqual({ owner: "group/subgroup", repo: "project" })
+  })
+
   it("strips .git suffix from HTTPS URL with trailing slash absent", () => {
     const result = parseOwnerRepoFromURL("https://github.com/owner/repo.git")
     expect(result).toEqual({ owner: "owner", repo: "repo" })

--- a/src/domain/git/operations.ts
+++ b/src/domain/git/operations.ts
@@ -204,33 +204,45 @@ export const countFiles = (dir: string) =>
 // ---------------------------------------------------------------------------
 
 /**
- * Parse owner and repo from a GitHub URL.
+ * Parse owner and repo from a git remote URL.
  * Supports both HTTPS and SSH formats:
  *   https://github.com/owner/repo.git
  *   https://github.com/owner/repo
  *   git@github.com:owner/repo.git
  *   git@github.com:owner/repo
+ *
+ * The last path segment is treated as the repo (project) and everything
+ * before it as the owner. This keeps GitHub URLs (always `owner/repo`)
+ * unchanged while correctly handling GitLab nested groups, where the owner
+ * is the full group path:
+ *   https://gitlab.com/group/subgroup/project.git → owner "group/subgroup",
+ *                                                    repo  "project"
  */
 export const parseOwnerRepoFromURL = (rawURL: string): OwnerRepo | undefined => {
-  // Try SSH format: git@github.com:owner/repo.git
-  const sshMatch = rawURL.match(/^git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/)
+  // Extract the path portion (everything after the host) for both forms.
+  //   SSH:   git@host:group/.../repo.git → path is the part after the colon
+  //   HTTPS: https://host/group/.../repo → path is the URL pathname
+  let path: string
+  const sshMatch = rawURL.match(/^git@[^:]+:(.+)$/)
   if (sshMatch) {
-    return { owner: sshMatch[1], repo: sshMatch[2] }
-  }
-
-  // Try HTTPS format
-  try {
-    const url = new URL(rawURL)
-    const parts = url.pathname.split("/").filter(Boolean)
-    if (parts.length >= 2) {
-      const repo = parts[1].replace(/\.git$/, "")
-      return { owner: parts[0], repo }
+    path = sshMatch[1]
+  } else {
+    try {
+      path = new URL(rawURL).pathname
+    } catch {
+      // Not a valid URL
+      return undefined
     }
-  } catch {
-    // Not a valid URL
   }
 
-  return undefined
+  const parts = path.split("/").filter(Boolean)
+  if (parts.length < 2) {
+    return undefined
+  }
+
+  const repo = parts[parts.length - 1].replace(/\.git$/, "")
+  const owner = parts.slice(0, -1).join("/")
+  return { owner, repo }
 }
 
 /**

--- a/src/remote-source.test.ts
+++ b/src/remote-source.test.ts
@@ -33,6 +33,32 @@ describe("parseRemoteSource", () => {
       expect(result.path).toBe("modules/vpc")
       expect(result.ref).toBeUndefined()
     })
+
+    it("parses git::https URL with GitLab nested groups", () => {
+      const result = parse(
+        "git::https://gitlab.com/group/subgroup/project.git//modules/vpc?ref=v1.0",
+      )
+      expect(result.host).toBe("gitlab.com")
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
+      expect(result.path).toBe("modules/vpc")
+      expect(result.ref).toBe("v1.0")
+      expect(result.cloneURL).toBe(
+        "https://gitlab.com/group/subgroup/project.git",
+      )
+    })
+
+    it("parses git::https URL on a self-hosted host with nested groups", () => {
+      const result = parse(
+        "git::https://gitlab.example.com/group/subgroup/project.git//path?ref=main",
+      )
+      expect(result.host).toBe("gitlab.example.com")
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
+      expect(result.cloneURL).toBe(
+        "https://gitlab.example.com/group/subgroup/project.git",
+      )
+    })
   })
 
   describe("GitHub shorthand", () => {
@@ -76,6 +102,42 @@ describe("parseRemoteSource", () => {
       const result = parse("https://gitlab.com/owner/repo/-/blob/main/file.ts")
       expect(result.isBlobURL).toBe(true)
     })
+
+    it("parses tree URL with nested groups (full group path as owner)", () => {
+      const result = parse(
+        "https://gitlab.com/group/subgroup/project/-/tree/main/path/to/dir",
+      )
+      expect(result.host).toBe("gitlab.com")
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
+      expect(result.path).toBe("main/path/to/dir")
+      expect(result.cloneURL).toBe(
+        "https://gitlab.com/group/subgroup/project.git",
+      )
+    })
+
+    it("parses blob URL with nested groups", () => {
+      const result = parse(
+        "https://gitlab.com/group/subgroup/project/-/blob/main/file.ts",
+      )
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
+      expect(result.path).toBe("main/file.ts")
+      expect(result.isBlobURL).toBe(true)
+    })
+
+    it("parses a tree URL on a self-hosted GitLab instance", () => {
+      const result = parse(
+        "https://gitlab.example.com/group/subgroup/project/-/tree/main/path",
+      )
+      expect(result.host).toBe("gitlab.example.com")
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
+      expect(result.path).toBe("main/path")
+      expect(result.cloneURL).toBe(
+        "https://gitlab.example.com/group/subgroup/project.git",
+      )
+    })
   })
 
   describe("plain repo URLs", () => {
@@ -91,6 +153,22 @@ describe("parseRemoteSource", () => {
     it("parses GitLab repo URL", () => {
       const result = parse("https://gitlab.com/owner/repo")
       expect(result.host).toBe("gitlab.com")
+    })
+
+    it("parses GitLab repo URL with nested groups", () => {
+      const result = parse("https://gitlab.com/group/subgroup/project")
+      expect(result.host).toBe("gitlab.com")
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
+      expect(result.cloneURL).toBe(
+        "https://gitlab.com/group/subgroup/project.git",
+      )
+    })
+
+    it("parses GitLab repo URL with nested groups and .git suffix", () => {
+      const result = parse("https://gitlab.com/group/subgroup/project.git")
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
     })
   })
 

--- a/src/remote-source.ts
+++ b/src/remote-source.ts
@@ -14,9 +14,13 @@ import type { ParsedRemoteSource } from "./types.ts"
 // URL patterns
 // ---------------------------------------------------------------------------
 
-/** OpenTofu git:: prefix: git::https://host/owner/repo.git//path?ref=v1.0 */
+/**
+ * OpenTofu git:: prefix: git::https://host/owner/.../repo.git//path?ref=v1.0
+ * The owner/repo portion (everything between the host and the `//` path
+ * delimiter) may be a nested group path on GitLab.
+ */
 const GIT_PREFIX_REGEX =
-  /^git::https?:\/\/([^/]+)\/([^/]+)\/([^/.]+?)(?:\.git)?\/\/(.+?)(?:\?ref=(.+))?$/
+  /^git::https?:\/\/([^/]+)\/(.+?)\/\/(.+?)(?:\?ref=(.+))?$/
 
 /** OpenTofu GitHub shorthand: github.com/owner/repo//path?ref=v1.0 */
 const GITHUB_SHORTHAND_REGEX =
@@ -30,17 +34,45 @@ const GITHUB_TREE_REGEX =
 const GITHUB_BLOB_REGEX =
   /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/
 
-/** GitLab browser tree URL: https://gitlab.com/owner/repo/-/tree/ref/path */
+/**
+ * GitLab browser tree URL: https://host/group/.../repo/-/tree/ref/path
+ * The `/-/` marker is GitLab-specific, so the host may be gitlab.com or a
+ * self-hosted instance, and the owner may be a nested group path.
+ */
 const GITLAB_TREE_REGEX =
-  /^https?:\/\/gitlab\.com\/([^/]+)\/([^/]+)\/-\/tree\/(.+)$/
+  /^https?:\/\/([^/]+)\/(.+?)\/-\/tree\/(.+)$/
 
-/** GitLab browser blob URL: https://gitlab.com/owner/repo/-/blob/ref/file */
+/** GitLab browser blob URL: https://host/group/.../repo/-/blob/ref/file */
 const GITLAB_BLOB_REGEX =
-  /^https?:\/\/gitlab\.com\/([^/]+)\/([^/]+)\/-\/blob\/(.+)$/
+  /^https?:\/\/([^/]+)\/(.+?)\/-\/blob\/(.+)$/
 
-/** Plain repo URL: https://github.com/owner/repo or https://gitlab.com/owner/repo */
-const PLAIN_REPO_REGEX =
-  /^https?:\/\/(github\.com|gitlab\.com)\/([^/]+)\/([^/.]+?)(?:\.git)?$/
+/** Plain GitHub repo URL: https://github.com/owner/repo (no nested groups) */
+const PLAIN_GITHUB_REPO_REGEX =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/.]+?)(?:\.git)?$/
+
+/**
+ * Plain GitLab repo URL: https://gitlab.com/group/.../repo
+ * Supports nested groups — the last path segment is the repo (project) and
+ * everything before it is the owner.
+ */
+const PLAIN_GITLAB_REPO_REGEX =
+  /^https?:\/\/gitlab\.com\/(.+?)(?:\.git)?$/
+
+/**
+ * Split a slash-delimited `owner/.../repo` path into its owner and repo parts.
+ * The last segment is the repo (project, with any `.git` suffix stripped) and
+ * everything before it is the owner. For GitLab nested groups the owner is the
+ * full group path, e.g. `group/subgroup/project` → owner "group/subgroup",
+ * repo "project".
+ */
+const splitOwnerRepo = (
+  ownerRepoPath: string,
+): { owner: string; repo: string } => {
+  const segments = ownerRepoPath.split("/").filter(Boolean)
+  const repo = segments[segments.length - 1].replace(/\.git$/, "")
+  const owner = segments.slice(0, -1).join("/")
+  return { owner, repo }
+}
 
 // ---------------------------------------------------------------------------
 // parseRemoteSource
@@ -53,10 +85,11 @@ export const parseRemoteSource = (raw: string): Effect.Effect<ParsedRemoteSource
       return yield* Effect.fail(new RemoteSourceError({ url: raw, message: "empty URL" }))
     }
 
-    // 1) git::https://host/owner/repo.git//path?ref=v1.0
+    // 1) git::https://host/owner/.../repo.git//path?ref=v1.0
     let match = trimmed.match(GIT_PREFIX_REGEX)
     if (match) {
-      const [, host, owner, repo, path, ref] = match
+      const [, host, ownerRepoPath, path, ref] = match
+      const { owner, repo } = splitOwnerRepo(ownerRepoPath)
       return {
         host,
         owner,
@@ -115,13 +148,14 @@ export const parseRemoteSource = (raw: string): Effect.Effect<ParsedRemoteSource
     // 5) GitLab tree URL
     match = trimmed.match(GITLAB_TREE_REGEX)
     if (match) {
-      const [, owner, repo, refAndPath] = match
+      const [, host, ownerRepoPath, refAndPath] = match
+      const { owner, repo } = splitOwnerRepo(ownerRepoPath)
       return {
-        host: "gitlab.com",
+        host,
         owner,
         repo,
         path: refAndPath,
-        cloneURL: `https://gitlab.com/${owner}/${repo}.git`,
+        cloneURL: `https://${host}/${owner}/${repo}.git`,
         isBlobURL: false,
       }
     }
@@ -129,27 +163,45 @@ export const parseRemoteSource = (raw: string): Effect.Effect<ParsedRemoteSource
     // 6) GitLab blob URL
     match = trimmed.match(GITLAB_BLOB_REGEX)
     if (match) {
-      const [, owner, repo, refAndPath] = match
-      return {
-        host: "gitlab.com",
-        owner,
-        repo,
-        path: refAndPath,
-        cloneURL: `https://gitlab.com/${owner}/${repo}.git`,
-        isBlobURL: true,
-      }
-    }
-
-    // 7) Plain repo URL
-    match = trimmed.match(PLAIN_REPO_REGEX)
-    if (match) {
-      const [, host, owner, repo] = match
+      const [, host, ownerRepoPath, refAndPath] = match
+      const { owner, repo } = splitOwnerRepo(ownerRepoPath)
       return {
         host,
         owner,
         repo,
+        path: refAndPath,
         cloneURL: `https://${host}/${owner}/${repo}.git`,
+        isBlobURL: true,
+      }
+    }
+
+    // 7) Plain GitHub repo URL (GitHub has no nested groups → exactly owner/repo)
+    match = trimmed.match(PLAIN_GITHUB_REPO_REGEX)
+    if (match) {
+      const [, owner, repo] = match
+      return {
+        host: "github.com",
+        owner,
+        repo,
+        cloneURL: `https://github.com/${owner}/${repo}.git`,
         isBlobURL: false,
+      }
+    }
+
+    // 8) Plain GitLab repo URL (supports nested groups → last segment is the repo)
+    match = trimmed.match(PLAIN_GITLAB_REPO_REGEX)
+    if (match) {
+      const { owner, repo } = splitOwnerRepo(match[1])
+      // A GitLab project always lives under at least one namespace, so a
+      // single-segment path (no owner) is not a valid repo URL.
+      if (owner) {
+        return {
+          host: "gitlab.com",
+          owner,
+          repo,
+          cloneURL: `https://gitlab.com/${owner}/${repo}.git`,
+          isBlobURL: false,
+        }
       }
     }
 

--- a/web/src/components/mdx/GitClone/GitClone.tsx
+++ b/web/src/components/mdx/GitClone/GitClone.tsx
@@ -23,17 +23,36 @@ import { GitCloneInstruction } from "./GitCloneInstruction"
 import type { AppError } from "@/types/error"
 import type { GitCloneProps } from "./types"
 
-/** Parse org and repo from a GitHub URL */
-function parseGitHubURL(url: string): { org: string; repo: string } | null {
-  try {
-    const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/)
-    if (match) {
-      return { org: match[1], repo: match[2] }
+/**
+ * Parse owner and repo from a git remote URL (GitHub, GitLab, or self-hosted).
+ *
+ * The last path segment is the repo (project) and everything before it is the
+ * owner. This handles GitHub's `owner/repo` as well as GitLab nested groups,
+ * where the owner is the full group path (e.g. `group/subgroup`).
+ */
+function parseOwnerRepoFromURL(url: string): { org: string; repo: string } | null {
+  // Extract the path after the host for both SSH (git@host:path) and HTTPS forms.
+  let path: string
+  const sshMatch = url.trim().match(/^git@[^:]+:(.+)$/)
+  if (sshMatch) {
+    path = sshMatch[1]
+  } else {
+    try {
+      path = new URL(url.trim()).pathname
+    } catch {
+      // Not a parseable URL
+      return null
     }
-  } catch {
-    // Not a parseable URL
   }
-  return null
+
+  const parts = path.split('/').filter(Boolean)
+  if (parts.length < 2) {
+    return null
+  }
+
+  const repo = parts[parts.length - 1].replace(/\.git$/, '')
+  const org = parts.slice(0, -1).join('/')
+  return { org, repo }
 }
 
 function GitCloneInteractive({
@@ -226,7 +245,7 @@ function GitCloneInteractive({
   useEffect(() => {
     if (cloneStatus === 'success' && cloneResult && showFileTree) {
       // Parse owner/repoName from the git URL
-      const parsed = parseGitHubURL(gitUrl)
+      const parsed = parseOwnerRepoFromURL(gitUrl)
       registerWorkTree({
         id,
         repoUrl: gitUrl.trim(),
@@ -246,10 +265,11 @@ function GitCloneInteractive({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cloneStatus, cloneResult])
 
-  // Determine if the GitHub browser should be pre-opened
+  // Seed the GitHub browser's org/repo, but only from GitHub URLs — feeding a
+  // GitLab owner/repo into the GitHub browser would be meaningless.
   const prefilledGitHub = useMemo(() => {
-    if (resolvedUrl) {
-      return parseGitHubURL(resolvedUrl)
+    if (resolvedUrl && /(?:\/\/|@)github\.com[/:]/.test(resolvedUrl)) {
+      return parseOwnerRepoFromURL(resolvedUrl)
     }
     return null
   }, [resolvedUrl])


### PR DESCRIPTION
Git clone blocks previously assumed github.

Now we parse the last / separated string as the project/repo and the previous bits of path as owner/group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git repository URL parsing to support GitLab repositories with nested group paths.
  * Added support for self-hosted GitLab instances.
  * Enhanced compatibility with SSH and HTTPS remote URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->