### PR TITLE
fix: don't hardcode gitlab.com

### DIFF
--- a/electron/main/ipc/git.ts
+++ b/electron/main/ipc/git.ts
@@ -22,6 +22,7 @@ import {
   type CreatePullRequestParams,
 } from "../../../src/domain/git/operations.ts"
 import { injectTokenIntoUrl } from "../../../src/domain/git/url.ts"
+import { gitSpawnEnv } from "../../../src/domain/git/env.ts"
 import { GitClient } from "../../../src/services/GitClient.ts"
 import type { CloneOptions, PushOptions } from "../../../src/services/GitClient.ts"
 import { isContainedIn } from "../../../src/path-validation.ts"
@@ -232,7 +233,10 @@ export function registerGitHandlers(): void {
           cloneArgs.push(effectiveUrl, paths.absolutePath)
 
           log.debug("spawning git process...")
-          const proc = yield* spawner.spawn("git", cloneArgs, {})
+          // gitSpawnEnv keeps git/ssh non-interactive: an SSH clone of a host
+          // not yet in known_hosts fails fast instead of hanging on the
+          // host-key verification prompt.
+          const proc = yield* spawner.spawn("git", cloneArgs, { env: gitSpawnEnv() })
 
           log.debug("draining output stream...")
           const stderrLines: string[] = []
@@ -251,10 +255,25 @@ export function registerGitHandlers(): void {
           log.debug("exit code:", exitCode)
           if (exitCode !== 0) {
             const stderr = stderrLines.join("\n").trim()
+            // With strict host-key checking, cloning a host that isn't in
+            // known_hosts yet fails with "Host key verification failed." rather
+            // than hanging on the interactive prompt. git's bare message gives
+            // no remedy, so append the exact command to trust the host. The
+            // host is pulled from the SSH/SCP-form URL (git@host:owner/repo),
+            // for which new URL() yields no hostname.
+            let stderrOut =
+              stderr || `clone to ${paths.absolutePath} failed (exit ${exitCode})`
+            if (/host key verification failed/i.test(stderr)) {
+              const sshHost =
+                params.url.match(/^(?:ssh:\/\/)?(?:[^@/]+@)?([^:/]+)/)?.[1] ?? "<host>"
+              stderrOut +=
+                `\n\nThe SSH host key for ${sshHost} isn't trusted yet. Add it to ` +
+                `known_hosts, then clone again:\n  ssh-keyscan ${sshHost} >> ~/.ssh/known_hosts`
+            }
             return yield* Effect.fail(
               new GitError({
                 command: "git clone",
-                stderr: stderr || `clone to ${paths.absolutePath} failed (exit ${exitCode})`,
+                stderr: stderrOut,
                 exitCode,
               }),
             )

--- a/electron/main/ipc/gitlab.ts
+++ b/electron/main/ipc/gitlab.ts
@@ -5,9 +5,10 @@
  * validation and credential detection (env var, `glab` CLI, and glab's
  * config.yml). Mirrors github.ts:
  * detection handlers inject the resolved token into the session environment so
- * git operations against gitlab.com can resolve it server-side, while
- * `gitlab:validate` only validates (the renderer owns the PAT-paste session
- * write, matching the GitHub flow).
+ * git operations can resolve it server-side, while `gitlab:validate` only
+ * validates (the renderer owns the PAT-paste session write, matching the GitHub
+ * flow). An optional `instanceUrl` targets a self-hosted GitLab instance for
+ * validation/detection; it defaults to gitlab.com.
  */
 import { Effect } from "effect"
 import { ipcMain } from "electron"
@@ -20,15 +21,17 @@ import {
   detectCliCredentials,
   detectConfigCredentials,
 } from "../../../src/domain/gitlab/auth.ts"
+import { normalizeGitLabBaseUrl } from "../../../src/domain/git/gitlab-host.ts"
 
 export function registerGitLabHandlers(): void {
   ipcMain.handle(
     "gitlab:validate",
-    async (_event, params: { token: string }) => {
+    async (_event, params: { token: string; instanceUrl?: string }) => {
       const tokenType = detectTokenType(params.token)
+      const baseUrl = normalizeGitLabBaseUrl(params.instanceUrl)
       try {
         const { user, scopes } = await runtime.runPromise(
-          validateToken(params.token),
+          validateToken(params.token, baseUrl),
         )
         return { valid: true, user, scopes, tokenType }
       } catch (err) {
@@ -41,16 +44,17 @@ export function registerGitLabHandlers(): void {
     },
   )
 
-  ipcMain.handle("gitlab:env-credentials", async () => {
+  ipcMain.handle("gitlab:env-credentials", async (_event, params?: { envVar?: string; prefix?: string; githubAuthId?: string; instanceUrl?: string }) => {
     const token = await runtime.runPromise(detectEnvCredentials())
     if (!token) {
       return { found: false as const }
     }
 
     const tokenType = detectTokenType(token)
+    const baseUrl = normalizeGitLabBaseUrl(params?.instanceUrl)
 
     try {
-      const { user, scopes } = await runtime.runPromise(validateToken(token))
+      const { user, scopes } = await runtime.runPromise(validateToken(token, baseUrl))
 
       // Inject the token into the session environment (mirrors github.ts).
       await runtime.runPromise(
@@ -76,13 +80,16 @@ export function registerGitLabHandlers(): void {
     }
   })
 
-  ipcMain.handle("gitlab:cli-credentials", async () => {
+  ipcMain.handle("gitlab:cli-credentials", async (_event, params?: { instanceUrl?: string }) => {
+    const baseUrl = normalizeGitLabBaseUrl(params?.instanceUrl)
+    const host = new URL(baseUrl).host
     // Prefer the `glab` binary (it refreshes OAuth tokens); if it yields no
     // token (not on PATH, not installed, not authenticated, or it timed out),
-    // read glab's config.yml directly, where `glab auth login` stores the token.
+    // read glab's config.yml directly for the target host, where
+    // `glab auth login` stores the token.
     const token =
       (await runtime.runPromise(detectCliCredentials())) ??
-      (await runtime.runPromise(detectConfigCredentials()))
+      (await runtime.runPromise(detectConfigCredentials(host)))
     if (!token) {
       return { found: false as const }
     }
@@ -90,7 +97,7 @@ export function registerGitLabHandlers(): void {
     const tokenType = detectTokenType(token)
 
     try {
-      const { user, scopes } = await runtime.runPromise(validateToken(token))
+      const { user, scopes } = await runtime.runPromise(validateToken(token, baseUrl))
 
       // Inject the token into the session environment so git operations
       // (e.g. git:clone) can resolve it server-side, matching the
@@ -115,14 +122,15 @@ export function registerGitLabHandlers(): void {
   // and must never block opening a merge request.
   ipcMain.handle(
     "gitlab:labels",
-    async (_event, params: { owner: string; repo: string }) => {
+    async (_event, params: { owner: string; repo: string; host?: string }) => {
+      const baseUrl = normalizeGitLabBaseUrl(params.host)
       const program = Effect.gen(function* () {
         const token = yield* getSessionTokenForProvider(
           "gitlab",
           () => new Error("No GitLab token available in session"),
         )
         const client = yield* GitLabClient
-        return yield* client.listLabels(token, params.owner, params.repo)
+        return yield* client.listLabels(token, params.owner, params.repo, baseUrl)
       })
 
       try {

--- a/electron/main/remote.ts
+++ b/electron/main/remote.ts
@@ -19,6 +19,7 @@ import {
 import { resolveRunbookPath } from "../../src/domain/workspace/file.ts"
 import { GitClient } from "../../src/services/GitClient.ts"
 import { injectTokenIntoUrl } from "../../src/domain/git/url.ts"
+import { isGitLabHost } from "../../src/domain/git/gitlab-host.ts"
 import { makeLogger } from "./logger.ts"
 
 const log = makeLogger("remote")
@@ -72,8 +73,8 @@ export function authHintForHost(host: string): string {
   if (host === "github.com") {
     return "GitHub authentication failed. Your token may be expired or missing the `repo` scope. Try setting GITHUB_TOKEN, or run `gh auth login`."
   }
-  if (host === "gitlab.com") {
-    return "GitLab authentication failed. Set GITLAB_TOKEN, or run `glab auth login`."
+  if (isGitLabHost(host)) {
+    return `GitLab authentication failed for ${host}. Set GITLAB_TOKEN, or run \`glab auth login${host === "gitlab.com" ? "" : ` --hostname ${host}`}\`.`
   }
   return `Authentication failed for ${host}. Set the appropriate access-token environment variable for that host.`
 }

--- a/electron/shared/channels.ts
+++ b/electron/shared/channels.ts
@@ -185,16 +185,19 @@ export interface IpcChannelMap {
   "github:refs": { params: { owner: string; repo: string }; result: GitHubRef[] }
   "github:labels": { params: { owner: string; repo: string }; result: { labels?: string[] } }
 
-  // GitLab Authentication
+  // GitLab Authentication.
+  // `instanceUrl` is the optional self-hosted GitLab origin
+  // (e.g. https://gitlab.example.com) the token is validated against; omitted /
+  // empty means gitlab.com.
   "gitlab:validate": {
-    params: { token: string }
+    params: { token: string; instanceUrl?: string }
     result: { valid: boolean; user?: GitHubUser; scopes?: string[]; tokenType?: string; error?: string }
   }
   "gitlab:env-credentials": {
     // Param keys mirror github:env-credentials so the shared useGitAuth hook can
     // call either channel with one payload shape; the gitlab handler ignores
     // envVar/githubAuthId.
-    params: { envVar?: string; prefix?: string; githubAuthId?: string }
+    params: { envVar?: string; prefix?: string; githubAuthId?: string; instanceUrl?: string }
     result: {
       found: boolean
       valid?: boolean
@@ -206,7 +209,7 @@ export interface IpcChannelMap {
     }
   }
   "gitlab:cli-credentials": {
-    params: Record<string, never>
+    params: { instanceUrl?: string }
     result: {
       found: boolean
       token?: string
@@ -216,7 +219,9 @@ export interface IpcChannelMap {
       error?: string
     }
   }
-  "gitlab:labels": { params: { owner: string; repo: string }; result: { labels?: string[] } }
+  // `host` is the GitLab instance host the repo lives on (self-hosted or
+  // gitlab.com), derived by the renderer from the repo's remote URL.
+  "gitlab:labels": { params: { owner: string; repo: string; host?: string }; result: { labels?: string[] } }
 
   // Git Operations
   "git:clone": {

--- a/src/domain/git/env.test.ts
+++ b/src/domain/git/env.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "bun:test"
+import { gitSpawnEnv } from "./env.ts"
+
+describe("gitSpawnEnv", () => {
+  it("forces ssh into batch mode with strict host-key checking", () => {
+    // BatchMode=yes makes ssh fail instead of prompting (passphrase/password),
+    // and StrictHostKeyChecking=yes makes an unknown host fail fast rather than
+    // hanging on the "Are you sure you want to continue connecting?" prompt.
+    const env = gitSpawnEnv()
+    expect(env.GIT_SSH_COMMAND).toContain("BatchMode=yes")
+    expect(env.GIT_SSH_COMMAND).toContain("StrictHostKeyChecking=yes")
+  })
+
+  it("disables git's own interactive credential prompt", () => {
+    expect(gitSpawnEnv().GIT_TERMINAL_PROMPT).toBe("0")
+  })
+
+  it("preserves the inherited environment so git/ssh still find PATH, HOME, and the ssh-agent", () => {
+    // spawn() replaces the inherited env wholesale when given an explicit one,
+    // so dropping these would break git and ssh entirely.
+    process.env.SSH_AUTH_SOCK = "/tmp/agent.test.sock"
+    const env = gitSpawnEnv()
+    expect(env.PATH).toBe(process.env.PATH)
+    expect(env.HOME).toBe(process.env.HOME)
+    expect(env.SSH_AUTH_SOCK).toBe("/tmp/agent.test.sock")
+    delete process.env.SSH_AUTH_SOCK
+  })
+
+  it("overrides any inherited values that would re-enable prompting", () => {
+    process.env.GIT_TERMINAL_PROMPT = "1"
+    expect(gitSpawnEnv().GIT_TERMINAL_PROMPT).toBe("0")
+    delete process.env.GIT_TERMINAL_PROMPT
+  })
+})

--- a/src/domain/git/env.ts
+++ b/src/domain/git/env.ts
@@ -1,0 +1,33 @@
+/**
+ * Environment for spawning `git` so it can never block on an interactive
+ * prompt. Shared by the GitClient layer, the Electron IPC clone handler, and
+ * the remote-source resolver — every place that shells out to git.
+ *
+ * Without these, a clone/push/ls-remote can hang forever:
+ *
+ *  - SSH host-key verification. The first time we connect to a host that isn't
+ *    in known_hosts, ssh asks "Are you sure you want to continue connecting?"
+ *    and reads the answer from the controlling terminal — which a spawned git
+ *    process has no way to answer, so it blocks indefinitely.
+ *  - SSH passphrase / password prompts.
+ *  - git's own HTTPS credential prompt.
+ *
+ * GIT_SSH_COMMAND forces ssh into batch mode (BatchMode=yes → never prompt;
+ * fail instead) and keeps strict host-key checking on: an unknown host fails
+ * fast with "Host key verification failed" rather than hanging or silently
+ * trusting it. To clone such a host, add its key to known_hosts first
+ * (e.g. `ssh-keyscan <host> >> ~/.ssh/known_hosts`). ssh still reads
+ * ~/.ssh/config, so per-host IdentityFile settings are honored.
+ *
+ * GIT_TERMINAL_PROMPT=0 makes git itself fail instead of prompting for
+ * credentials on the terminal (the HTTPS equivalent of the SSH hang).
+ *
+ * process.env is spread first so PATH, HOME, and SSH_AUTH_SOCK (the ssh-agent
+ * socket) are preserved — passing an explicit env to spawn() replaces the
+ * inherited one wholesale, so omitting these would break git and ssh entirely.
+ */
+export const gitSpawnEnv = (): Record<string, string | undefined> => ({
+  ...process.env,
+  GIT_TERMINAL_PROMPT: "0",
+  GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o StrictHostKeyChecking=yes",
+})

--- a/src/domain/git/gitlab-host.test.ts
+++ b/src/domain/git/gitlab-host.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "bun:test"
+import {
+  DEFAULT_GITLAB_BASE_URL,
+  normalizeGitLabBaseUrl,
+  gitlabApiBase,
+  hostToBaseUrl,
+  gitHostFromRemoteUrl,
+  gitlabBaseUrlFromRemoteUrl,
+  isGitLabHost,
+} from "./gitlab-host.ts"
+
+describe("normalizeGitLabBaseUrl", () => {
+  it("defaults to gitlab.com for empty/nullish input", () => {
+    expect(normalizeGitLabBaseUrl(undefined)).toBe(DEFAULT_GITLAB_BASE_URL)
+    expect(normalizeGitLabBaseUrl(null)).toBe(DEFAULT_GITLAB_BASE_URL)
+    expect(normalizeGitLabBaseUrl("")).toBe(DEFAULT_GITLAB_BASE_URL)
+    expect(normalizeGitLabBaseUrl("   ")).toBe(DEFAULT_GITLAB_BASE_URL)
+  })
+
+  it("keeps a full https URL's origin and drops path/query/trailing slash", () => {
+    expect(normalizeGitLabBaseUrl("https://gitlab.example.com")).toBe("https://gitlab.example.com")
+    expect(normalizeGitLabBaseUrl("https://gitlab.example.com/")).toBe("https://gitlab.example.com")
+    expect(normalizeGitLabBaseUrl("https://gitlab.example.com/api/v4")).toBe("https://gitlab.example.com")
+    expect(normalizeGitLabBaseUrl("https://gitlab.example.com:8443/foo?x=1")).toBe(
+      "https://gitlab.example.com:8443",
+    )
+  })
+
+  it("assumes https when the scheme is missing", () => {
+    expect(normalizeGitLabBaseUrl("gitlab.example.com")).toBe("https://gitlab.example.com")
+    expect(normalizeGitLabBaseUrl("gitlab.example.com:8443")).toBe("https://gitlab.example.com:8443")
+  })
+
+  it("preserves an explicit http scheme", () => {
+    expect(normalizeGitLabBaseUrl("http://gitlab.internal")).toBe("http://gitlab.internal")
+  })
+
+  it("falls back to gitlab.com for a non-http(s) or unparseable scheme", () => {
+    expect(normalizeGitLabBaseUrl("ftp://gitlab.example.com")).toBe(DEFAULT_GITLAB_BASE_URL)
+  })
+})
+
+describe("gitlabApiBase", () => {
+  it("appends /api/v4 and tolerates a trailing slash", () => {
+    expect(gitlabApiBase("https://gitlab.com")).toBe("https://gitlab.com/api/v4")
+    expect(gitlabApiBase("https://gitlab.example.com/")).toBe("https://gitlab.example.com/api/v4")
+  })
+})
+
+describe("hostToBaseUrl", () => {
+  it("wraps a host in an https origin", () => {
+    expect(hostToBaseUrl("gitlab.example.com")).toBe("https://gitlab.example.com")
+  })
+})
+
+describe("gitHostFromRemoteUrl", () => {
+  it("reads the host from an HTTPS remote (incl. port)", () => {
+    expect(gitHostFromRemoteUrl("https://gitlab.example.com/group/project.git")).toBe(
+      "gitlab.example.com",
+    )
+    expect(gitHostFromRemoteUrl("https://gitlab.example.com:8443/group/project.git")).toBe(
+      "gitlab.example.com:8443",
+    )
+  })
+
+  it("reads the host from an SSH/SCP remote", () => {
+    expect(gitHostFromRemoteUrl("git@gitlab.example.com:group/project.git")).toBe(
+      "gitlab.example.com",
+    )
+  })
+
+  it("returns undefined for empty or unparseable input", () => {
+    expect(gitHostFromRemoteUrl("")).toBeUndefined()
+    expect(gitHostFromRemoteUrl("   ")).toBeUndefined()
+  })
+})
+
+describe("gitlabBaseUrlFromRemoteUrl", () => {
+  it("derives a self-hosted origin from the repo's remote", () => {
+    expect(gitlabBaseUrlFromRemoteUrl("https://gitlab.example.com/group/project.git")).toBe(
+      "https://gitlab.example.com",
+    )
+    expect(gitlabBaseUrlFromRemoteUrl("git@gitlab.example.com:group/project.git")).toBe(
+      "https://gitlab.example.com",
+    )
+  })
+
+  it("falls back to gitlab.com when the host can't be determined", () => {
+    expect(gitlabBaseUrlFromRemoteUrl("")).toBe(DEFAULT_GITLAB_BASE_URL)
+  })
+})
+
+describe("isGitLabHost", () => {
+  it("matches gitlab.com and self-hosted hosts carrying a gitlab label", () => {
+    expect(isGitLabHost("gitlab.com")).toBe(true)
+    expect(isGitLabHost("gitlab.example.com")).toBe(true)
+    expect(isGitLabHost("gitlab-ce.corp.net")).toBe(true)
+    expect(isGitLabHost("code.gitlab.internal")).toBe(true)
+    expect(isGitLabHost("GitLab.Example.COM")).toBe(true)
+  })
+
+  it("does not match unrelated hosts", () => {
+    expect(isGitLabHost("github.com")).toBe(false)
+    expect(isGitLabHost("bitbucket.org")).toBe(false)
+    expect(isGitLabHost("git.corp.net")).toBe(false)
+    expect(isGitLabHost("mygitlabby.com")).toBe(false)
+  })
+})

--- a/src/domain/git/gitlab-host.ts
+++ b/src/domain/git/gitlab-host.ts
@@ -1,0 +1,100 @@
+/**
+ * GitLab host/instance helpers.
+ *
+ * The GitLab REST API client, token validation, and credential detection all
+ * need to target the right GitLab instance — `gitlab.com` for SaaS, or an
+ * arbitrary host for a self-hosted instance. These helpers turn a user-supplied
+ * instance URL (from the GitAuth block) or a repo's own remote URL into the
+ * base URL the API client builds requests against.
+ *
+ * The auth token is still resolved by PROVIDER (GITLAB_TOKEN), never by host —
+ * the host only selects which instance's API/glab-config to talk to.
+ */
+
+/** The default GitLab instance when no self-hosted instance is specified. */
+export const DEFAULT_GITLAB_BASE_URL = "https://gitlab.com"
+
+/**
+ * Normalize a user-supplied GitLab instance URL (or bare host) into a clean
+ * origin like `https://gitlab.example.com`. Tolerates a missing scheme
+ * (`gitlab.example.com` → `https://gitlab.example.com`), trailing slashes, and
+ * stray paths/queries. Falls back to gitlab.com for empty or unparseable input.
+ *
+ * GitLab installed under a URL sub-path (relative URL root) is out of scope —
+ * only the origin is kept.
+ */
+export function normalizeGitLabBaseUrl(input?: string | null): string {
+  const raw = (input ?? "").trim()
+  if (!raw) return DEFAULT_GITLAB_BASE_URL
+  // Reject a non-http(s) scheme rather than gluing https:// in front of it
+  // (which would turn `ftp://host` into the bogus `https://ftp`).
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)
+  if (hasScheme && !/^https?:\/\//i.test(raw)) return DEFAULT_GITLAB_BASE_URL
+  const withScheme = hasScheme ? raw : `https://${raw}`
+  try {
+    const u = new URL(withScheme)
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      return DEFAULT_GITLAB_BASE_URL
+    }
+    // Keep protocol + host (including any port); drop path/query/hash so callers
+    // can append `/api/v4` etc.
+    return `${u.protocol}//${u.host}`
+  } catch {
+    return DEFAULT_GITLAB_BASE_URL
+  }
+}
+
+/** Build the `/api/v4` REST base from a GitLab origin. */
+export function gitlabApiBase(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/api/v4`
+}
+
+/** Turn a host (`gitlab.example.com`) into an origin (`https://gitlab.example.com`). */
+export function hostToBaseUrl(host: string): string {
+  return `https://${host}`
+}
+
+/**
+ * Extract the host (including any port) from a git remote URL in either HTTPS
+ * (`https://host/owner/repo.git`) or SSH/SCP (`git@host:owner/repo.git`) form.
+ * Returns undefined for input that has no recognizable host.
+ */
+export function gitHostFromRemoteUrl(url: string): string | undefined {
+  const trimmed = url.trim()
+  if (!trimmed) return undefined
+  // SSH/SCP form: [user@]host:owner/repo(.git)
+  const ssh = trimmed.match(/^[^/@]+@([^:/]+):/)
+  if (ssh) return ssh[1]
+  try {
+    const host = new URL(trimmed).host
+    return host || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Derive the GitLab API origin for a repo from its own remote URL, defaulting
+ * to gitlab.com when the host can't be determined. Used by operations that act
+ * on a cloned repo (merge requests, labels), where the instance is whatever the
+ * repo actually lives on rather than something the user typed.
+ */
+export function gitlabBaseUrlFromRemoteUrl(url: string): string {
+  const host = gitHostFromRemoteUrl(url)
+  return host ? hostToBaseUrl(host) : DEFAULT_GITLAB_BASE_URL
+}
+
+/**
+ * Best-effort check for whether a host is a GitLab instance, by name. Matches
+ * `gitlab.com` and self-hosted hosts that carry a `gitlab` label
+ * (`gitlab.example.com`, `gitlab-ce.corp.net`, `code.gitlab.internal`).
+ *
+ * This is a heuristic used only where the provider isn't already known (the
+ * remote-runbook resolver's `getTokenForHost`). A self-hosted GitLab on an
+ * unrelated hostname (e.g. `git.corp.net`) won't be recognized here — those
+ * flows authenticate through the GitAuth block, which knows the provider
+ * explicitly and doesn't rely on this guess.
+ */
+export function isGitLabHost(host: string): boolean {
+  return /(^|[.-])gitlab([.-]|$)/.test(host.toLowerCase())
+}

--- a/src/domain/git/operations.test.ts
+++ b/src/domain/git/operations.test.ts
@@ -302,6 +302,59 @@ describe("createMergeRequest", () => {
     expect(mrLabels).toEqual(["enhancement"])
   })
 
+  it("targets the MR at the repo's own GitLab instance (self-hosted), derived from its remote", async () => {
+    let mrBaseUrl: string | undefined
+
+    const layer = makeTestLayer({
+      git: {
+        getRemoteUrl: () => Effect.succeed("https://gitlab.acme.com/group/subgroup/project.git"),
+        status: () => Effect.succeed([]),
+        createBranch: () => Effect.void,
+        stageAll: () => Effect.void,
+        commit: () => Effect.void,
+        push: () => Effect.void,
+      },
+      gitlab: {
+        createMergeRequest: (_token, p) =>
+          Effect.sync(() => {
+            mrBaseUrl = p.baseUrl
+            return { url: "https://gitlab.acme.com/g/p/-/merge_requests/7", number: 7, branch: p.headBranch }
+          }),
+      },
+    })
+
+    await Effect.runPromise(createMergeRequest("tok", params).pipe(Effect.provide(layer)))
+
+    expect(mrBaseUrl).toBe("https://gitlab.acme.com")
+  })
+
+  it("falls back to gitlab.com when the repo remote can't be read", async () => {
+    let mrBaseUrl: string | undefined
+
+    // getRemoteUrl is left at the test layer's default (which fails), exercising
+    // the orElseSucceed fallback.
+    const layer = makeTestLayer({
+      git: {
+        status: () => Effect.succeed([]),
+        createBranch: () => Effect.void,
+        stageAll: () => Effect.void,
+        commit: () => Effect.void,
+        push: () => Effect.void,
+      },
+      gitlab: {
+        createMergeRequest: (_token, p) =>
+          Effect.sync(() => {
+            mrBaseUrl = p.baseUrl
+            return { url: "https://gitlab.com/g/p/-/merge_requests/1", number: 1, branch: p.headBranch }
+          }),
+      },
+    })
+
+    await Effect.runPromise(createMergeRequest("tok", params).pipe(Effect.provide(layer)))
+
+    expect(mrBaseUrl).toBe("https://gitlab.com")
+  })
+
   it("propagates a non-empty message when GitLab rejects with a 409", async () => {
     const layer = makeTestLayer({
       git: {

--- a/src/domain/git/operations.ts
+++ b/src/domain/git/operations.ts
@@ -11,6 +11,8 @@ import { GitLabClient } from "../../services/GitLabClient.ts"
 import type { CreateMRParams } from "../../services/GitLabClient.ts"
 import { ProcessSpawner } from "../../services/ProcessSpawner.ts"
 import { GitError } from "../../errors/index.ts"
+import { gitSpawnEnv } from "./env.ts"
+import { gitlabBaseUrlFromRemoteUrl } from "./gitlab-host.ts"
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -215,8 +217,18 @@ export const createMergeRequest = (
   Effect.gen(function* () {
     yield* runGitSteps(token, params, onProgress)
 
+    const gitClient = yield* GitClient
     const glClient = yield* GitLabClient
     const report = (line: string) => Effect.sync(() => onProgress?.(line))
+
+    // Target the MR at the repo's own GitLab instance (self-hosted or
+    // gitlab.com), derived from its remote rather than assumed to be gitlab.com.
+    // Best-effort: if the remote can't be read, the client falls back to
+    // gitlab.com.
+    const remoteUrl = yield* gitClient
+      .getRemoteUrl(params.repoPath)
+      .pipe(Effect.orElseSucceed(() => ""))
+    const baseUrl = gitlabBaseUrlFromRemoteUrl(remoteUrl)
 
     // Create the MR via GitLab API (labels applied inline)
     yield* report("Opening merge request…")
@@ -228,6 +240,7 @@ export const createMergeRequest = (
       baseBranch: params.baseBranch,
       headBranch: params.headBranch,
       labels: params.labels,
+      baseUrl,
     }
 
     return yield* glClient.createMergeRequest(token, mrParams)
@@ -283,7 +296,7 @@ export const resolveClonePaths = (
 export const countFiles = (dir: string) =>
   Effect.gen(function* () {
     const spawner = yield* ProcessSpawner
-    const proc = yield* spawner.spawn("git", ["ls-files"], { cwd: dir })
+    const proc = yield* spawner.spawn("git", ["ls-files"], { cwd: dir, env: gitSpawnEnv() })
     const chunks = yield* Stream.runCollect(proc.output)
     const lines = Chunk.toArray(chunks)
     const code = yield* proc.exitCode

--- a/src/domain/gitlab/auth.test.ts
+++ b/src/domain/gitlab/auth.test.ts
@@ -173,6 +173,18 @@ describe("parseGlabToken", () => {
     expect(parseGlabToken(yaml)).toBeUndefined()
   })
 
+  it("reads a self-hosted host's token when that host is passed", () => {
+    const yaml =
+      "hosts:\n" +
+      "  gitlab.com:\n" +
+      "    token: glpat-saas\n" +
+      "  gitlab.example.com:\n" +
+      "    token: !!null glpat-selfmanaged\n"
+    expect(parseGlabToken(yaml, "gitlab.example.com")).toBe("glpat-selfmanaged")
+    // gitlab.com is still the default.
+    expect(parseGlabToken(yaml)).toBe("glpat-saas")
+  })
+
   it("returns undefined for empty or malformed content", () => {
     expect(parseGlabToken("")).toBeUndefined()
     expect(parseGlabToken("not: [valid")).toBeUndefined()
@@ -200,6 +212,26 @@ describe("detectConfigCredentials", () => {
       detectConfigCredentials().pipe(Effect.provide(layer)),
     )
     expect(result).toBe("glpat-from_config")
+  })
+
+  it("reads a self-hosted host's token when that host is passed", async () => {
+    const home = "/home/tester"
+    const layer = Layer.merge(
+      makeTestFileSystem({
+        [`${home}/.config/glab-cli/config.yml`]:
+          "hosts:\n" +
+          "  gitlab.com:\n" +
+          "    token: glpat-saas\n" +
+          "  gitlab.example.com:\n" +
+          "    token: glpat-selfmanaged\n",
+      }),
+      makeTestEnvironment({ HOME: home }),
+    )
+
+    const result = await Effect.runPromise(
+      detectConfigCredentials("gitlab.example.com").pipe(Effect.provide(layer)),
+    )
+    expect(result).toBe("glpat-selfmanaged")
   })
 
   it("honors a GLAB_CONFIG_DIR override", async () => {

--- a/src/domain/gitlab/auth.ts
+++ b/src/domain/gitlab/auth.ts
@@ -27,11 +27,14 @@ const GLAB_CLI_TIMEOUT_MS = 5_000
 
 /**
  * Validate a GitLab token by calling the GitLab API (GET /user).
+ *
+ * `baseUrl` is the instance origin (e.g. `https://gitlab.example.com`) so a
+ * self-hosted token validates against its own instance; defaults to gitlab.com.
  */
-export const validateToken = (token: string) =>
+export const validateToken = (token: string, baseUrl?: string) =>
   Effect.gen(function* () {
     const glClient = yield* GitLabClient
-    return yield* glClient.validateToken(token)
+    return yield* glClient.validateToken(token, baseUrl)
   })
 
 // ---------------------------------------------------------------------------
@@ -126,11 +129,11 @@ export const detectCliCredentials = () =>
 // ---------------------------------------------------------------------------
 
 /**
- * The GitLab host this app authenticates against. The HTTP client targets
- * gitlab.com only, so we read the gitlab.com credentials out of glab's config
- * regardless of which host glab itself defaults to.
+ * The default GitLab host to read credentials for when no self-hosted host is
+ * specified. glab's config.yml stores tokens per host (`hosts: { <host>: ... }`),
+ * so a self-hosted instance is read by passing its host instead.
  */
-const GITLAB_HOST = "gitlab.com"
+const DEFAULT_GITLAB_HOST = "gitlab.com"
 
 /**
  * Resolve the candidate paths to glab's `config.yml`, in glab's own lookup
@@ -149,8 +152,8 @@ const GITLAB_HOST = "gitlab.com"
  *
  * We probe these in glab's directory-precedence order and return the first
  * gitlab.com token found. (glab itself uses the first directory whose config.yml
- * exists; we instead skip a config that has no gitlab.com token, since our only
- * goal is to surface a usable gitlab.com credential the user already has.)
+ * exists; we instead skip a config that has no token for the target host, since
+ * our only goal is to surface a usable credential the user already has.)
  * Exported for testing.
  */
 export function resolveGlabConfigPaths(opts: {
@@ -192,7 +195,8 @@ interface GlabConfig {
 }
 
 /**
- * Extract the gitlab.com access token from glab `config.yml` contents.
+ * Extract a host's access token from glab `config.yml` contents. `host`
+ * defaults to gitlab.com; pass a self-hosted host to read its credentials.
  *
  * glab obfuscates stored secrets by tagging them as `!!null`
  * (e.g. `token: !!null glpat-...`), which makes a naive YAML load return null.
@@ -201,14 +205,17 @@ interface GlabConfig {
  *
  * Exported for testing.
  */
-export function parseGlabToken(yamlContent: string): string | undefined {
+export function parseGlabToken(
+  yamlContent: string,
+  host: string = DEFAULT_GITLAB_HOST,
+): string | undefined {
   // Strip glab's `!!null ` secret tag so the scalar parses as its string value.
   const cleaned = yamlContent.replace(/!!null\s+/g, "")
 
   let token: unknown
   try {
     const parsed = YAML.parse(cleaned, { logLevel: "silent" }) as GlabConfig | null
-    token = parsed?.hosts?.[GITLAB_HOST]?.token
+    token = parsed?.hosts?.[host]?.token
   } catch {
     return undefined
   }
@@ -226,10 +233,11 @@ export function parseGlabToken(yamlContent: string): string | undefined {
  * `glab auth login` does not export an environment variable; it writes the
  * token into glab's `config.yml`. This reads that file directly, so detection
  * still works when `glab auth token` yields nothing — e.g. the `glab` binary is
- * not on PATH (common inside Electron's spawn environment). Returns undefined if
- * no config file or gitlab.com token is found.
+ * not on PATH (common inside Electron's spawn environment). `host` defaults to
+ * gitlab.com; pass a self-hosted host to read its credentials. Returns undefined
+ * if no config file or matching-host token is found.
  */
-export const detectConfigCredentials = () =>
+export const detectConfigCredentials = (host: string = DEFAULT_GITLAB_HOST) =>
   Effect.gen(function* () {
     const env = yield* Environment
     const fs = yield* FileSystem
@@ -246,7 +254,7 @@ export const detectConfigCredentials = () =>
       const content = yield* fs
         .readFile(path)
         .pipe(Effect.orElseSucceed(() => ""))
-      const token = parseGlabToken(content)
+      const token = parseGlabToken(content, host)
       if (token) return token
     }
 

--- a/src/layers/GitCliClient.ts
+++ b/src/layers/GitCliClient.ts
@@ -19,6 +19,7 @@ import type {
 import { ProcessSpawner } from "../services/ProcessSpawner.ts"
 import { GitError } from "../errors/index.ts"
 import { injectTokenIntoUrl } from "../domain/git/url.ts"
+import { gitSpawnEnv } from "../domain/git/env.ts"
 
 /**
  * Run a git command, collect all output, and return stdout lines.
@@ -31,7 +32,7 @@ function runGit(
   stdin?: string,
 ) {
   return Effect.gen(function* () {
-    const proc = yield* spawner.spawn("git", args, { cwd, stdin })
+    const proc = yield* spawner.spawn("git", args, { cwd, stdin, env: gitSpawnEnv() })
     const chunks = yield* Stream.runCollect(proc.output)
     const lines = Chunk.toArray(chunks)
     const code = yield* proc.exitCode
@@ -82,6 +83,7 @@ function makeGitClient(spawner: ProcessSpawner["Type"]): GitClientShape {
 
           const proc = yield* spawner.spawn("git", args, {
             cwd: options?.repoPath,
+            env: gitSpawnEnv(),
           })
           const chunks = yield* Stream.runCollect(proc.output)
           const code = yield* proc.exitCode
@@ -283,6 +285,7 @@ function makeGitClient(spawner: ProcessSpawner["Type"]): GitClientShape {
         const proc = yield* spawner.spawn("git", ["check-ignore", "--stdin"], {
           cwd: repoPath,
           stdin,
+          env: gitSpawnEnv(),
         })
         const chunks = yield* Stream.runCollect(proc.output)
         // Ignore exit code — 1 just means "no ignored files found"

--- a/src/layers/GitLabHttpClient.test.ts
+++ b/src/layers/GitLabHttpClient.test.ts
@@ -247,6 +247,96 @@ describe("GitLabHttpClient.listLabels", () => {
   })
 })
 
+describe("GitLabHttpClient — self-hosted base URL", () => {
+  const SELF_HOSTED = "https://gitlab.example.com"
+
+  it("validateToken targets the supplied instance's /api/v4, not gitlab.com", async () => {
+    const urls: string[] = []
+    mockFetch((url) => {
+      urls.push(url)
+      if (url.endsWith("/api/v4/user")) {
+        return json({ username: "tanuki" })
+      }
+      if (url.endsWith("/api/v4/personal_access_tokens/self")) {
+        return json({ scopes: ["api"] })
+      }
+      return new Response("not found", { status: 404 })
+    })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* GitLabClient
+        return yield* client.validateToken("glpat-abc", SELF_HOSTED)
+      }).pipe(Effect.provide(GitLabHttpClientLive)),
+    )
+
+    expect(result.user.login).toBe("tanuki")
+    expect(urls).toContain("https://gitlab.example.com/api/v4/user")
+    expect(urls.every((u) => u.startsWith("https://gitlab.example.com/"))).toBe(true)
+  })
+
+  it("createMergeRequest posts to the instance from params.baseUrl", async () => {
+    let requestedUrl: string | null = null
+    mockFetch((url) => {
+      requestedUrl = url
+      return json({ iid: 7, web_url: `${SELF_HOSTED}/g/p/-/merge_requests/7`, source_branch: "b" })
+    })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* GitLabClient
+        return yield* client.createMergeRequest("glpat-abc", {
+          owner: "g",
+          repo: "p",
+          title: "t",
+          baseBranch: "main",
+          headBranch: "b",
+          baseUrl: SELF_HOSTED,
+        })
+      }).pipe(Effect.provide(GitLabHttpClientLive)),
+    )
+
+    expect(requestedUrl).toBe("https://gitlab.example.com/api/v4/projects/g%2Fp/merge_requests")
+    expect(result.url).toBe("https://gitlab.example.com/g/p/-/merge_requests/7")
+  })
+
+  it("listLabels reads from the instance's API base", async () => {
+    let requestedUrl: string | null = null
+    mockFetch((url) => {
+      requestedUrl = url
+      return json([{ name: "bug" }])
+    })
+
+    const labels = await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* GitLabClient
+        return yield* client.listLabels("glpat-abc", "g", "p", SELF_HOSTED)
+      }).pipe(Effect.provide(GitLabHttpClientLive)),
+    )
+
+    expect(requestedUrl).toContain("https://gitlab.example.com/api/v4/projects/g%2Fp/labels")
+    expect(labels).toEqual(["bug"])
+  })
+
+  it("defaults to gitlab.com when no base URL is given", async () => {
+    const urls: string[] = []
+    mockFetch((url) => {
+      urls.push(url)
+      if (url.endsWith("/api/v4/user")) return json({ username: "tanuki" })
+      return json({ scopes: [] })
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* GitLabClient
+        return yield* client.validateToken("glpat-abc")
+      }).pipe(Effect.provide(GitLabHttpClientLive)),
+    )
+
+    expect(urls).toContain("https://gitlab.com/api/v4/user")
+  })
+})
+
 describe("GitLabHttpClient.detectTokenType", () => {
   it("classifies glpat- tokens as pat, others as unknown", async () => {
     const types = await Effect.runPromise(

--- a/src/layers/GitLabHttpClient.ts
+++ b/src/layers/GitLabHttpClient.ts
@@ -1,10 +1,13 @@
 /**
  * Live implementation of the GitLabClient service using fetch.
  *
- * Mirrors GitHubHttpClient, but targets gitlab.com's REST API. Personal,
- * project, and group access tokens authenticate via the `PRIVATE-TOKEN` header;
- * OAuth tokens (e.g. from `glab auth login`'s web flow) are rejected by it and
- * require `Authorization: Bearer`, so we fall back to Bearer on an auth failure.
+ * Mirrors GitHubHttpClient, but targets GitLab's REST API. The instance origin
+ * is per-call (`baseUrl`, defaulting to gitlab.com) so a self-hosted GitLab is
+ * supported — the auth block supplies its instance URL, and operations on a
+ * cloned repo derive it from the repo's own remote. Personal, project, and
+ * group access tokens authenticate via the `PRIVATE-TOKEN` header; OAuth tokens
+ * (e.g. from `glab auth login`'s web flow) are rejected by it and require
+ * `Authorization: Bearer`, so we fall back to Bearer on an auth failure.
  * Unlike GitHub, `GET /user` exposes no scope header, so token scopes are
  * introspected with a second, best-effort call (`/oauth/token/info` for OAuth
  * tokens, `/personal_access_tokens/self` for PATs).
@@ -19,9 +22,7 @@ import type {
   MergeRequestResult,
 } from "../services/GitLabClient.ts"
 import { GitLabApiError } from "../errors/index.ts"
-
-const GITLAB_BASE = "https://gitlab.com"
-const API_BASE = `${GITLAB_BASE}/api/v4`
+import { DEFAULT_GITLAB_BASE_URL, gitlabApiBase } from "../domain/git/gitlab-host.ts"
 
 type AuthScheme = "private" | "bearer"
 
@@ -49,13 +50,14 @@ function toStringArray(value: unknown): string[] | undefined {
 async function fetchScopes(
   token: string,
   scheme: AuthScheme,
+  baseUrl: string,
 ): Promise<string[] | undefined> {
   // OAuth tokens expose scopes via /oauth/token/info (`scope`); PATs via
   // /api/v4/personal_access_tokens/self (`scopes`).
   const [url, field] =
     scheme === "bearer"
-      ? ([`${GITLAB_BASE}/oauth/token/info`, "scope"] as const)
-      : ([`${API_BASE}/personal_access_tokens/self`, "scopes"] as const)
+      ? ([`${baseUrl}/oauth/token/info`, "scope"] as const)
+      : ([`${gitlabApiBase(baseUrl)}/personal_access_tokens/self`, "scopes"] as const)
   try {
     const resp = await fetch(url, { headers: authHeaders(token, scheme) })
     if (!resp.ok) return undefined
@@ -119,16 +121,20 @@ async function paginateAll<T>(
   return results
 }
 
-async function validateUserToken(token: string): Promise<GitLabTokenValidation> {
+async function validateUserToken(
+  token: string,
+  baseUrl: string,
+): Promise<GitLabTokenValidation> {
+  const apiBase = gitlabApiBase(baseUrl)
   // PATs authenticate via PRIVATE-TOKEN, but OAuth tokens are rejected by it
   // (401) and require Authorization: Bearer (which also accepts PATs). Retry
   // with Bearer only on 401 — a 403 means the token authenticated but lacks the
   // scope to read /user, which Bearer (same token, same scopes) can't fix.
   let scheme: AuthScheme = "private"
-  let resp = await fetch(`${API_BASE}/user`, { headers: authHeaders(token, scheme) })
+  let resp = await fetch(`${apiBase}/user`, { headers: authHeaders(token, scheme) })
   if (resp.status === 401) {
     scheme = "bearer"
-    resp = await fetch(`${API_BASE}/user`, { headers: authHeaders(token, scheme) })
+    resp = await fetch(`${apiBase}/user`, { headers: authHeaders(token, scheme) })
   }
   if (!resp.ok) {
     const body = await resp.text().catch(() => "")
@@ -141,7 +147,7 @@ async function validateUserToken(token: string): Promise<GitLabTokenValidation> 
     email?: string
   }
   // GET /user exposes no scopes; introspect them with the scheme that validated.
-  const scopes = await fetchScopes(token, scheme)
+  const scopes = await fetchScopes(token, scheme, baseUrl)
   return {
     user: {
       login: data.username,
@@ -154,9 +160,9 @@ async function validateUserToken(token: string): Promise<GitLabTokenValidation> 
 }
 
 const impl: GitLabClientShape = {
-  validateToken: (token: string) =>
+  validateToken: (token: string, baseUrl: string = DEFAULT_GITLAB_BASE_URL) =>
     Effect.tryPromise({
-      try: (): Promise<GitLabTokenValidation> => validateUserToken(token),
+      try: (): Promise<GitLabTokenValidation> => validateUserToken(token, baseUrl),
       catch: (err) =>
         err instanceof GitLabApiError
           ? err
@@ -169,6 +175,7 @@ const impl: GitLabClientShape = {
   createMergeRequest: (token: string, params: CreateMRParams) =>
     Effect.tryPromise({
       try: async (): Promise<MergeRequestResult> => {
+        const apiBase = gitlabApiBase(params.baseUrl ?? DEFAULT_GITLAB_BASE_URL)
         // `:id` is the URL-encoded full project path; encodeURIComponent turns
         // the slashes of a nested group path (group/subgroup/project) into %2F.
         const projectId = encodeURIComponent(`${params.owner}/${params.repo}`)
@@ -184,7 +191,7 @@ const impl: GitLabClientShape = {
           body.labels = params.labels.join(",")
         }
         const resp = await gitlabFetch(
-          `${API_BASE}/projects/${projectId}/merge_requests`,
+          `${apiBase}/projects/${projectId}/merge_requests`,
           token,
           {
             method: "POST",
@@ -211,12 +218,13 @@ const impl: GitLabClientShape = {
           : new GitLabApiError({ status: 0, message: `${err}` }),
     }),
 
-  listLabels: (token: string, owner: string, repo: string) =>
+  listLabels: (token: string, owner: string, repo: string, baseUrl: string = DEFAULT_GITLAB_BASE_URL) =>
     Effect.tryPromise({
       try: async (): Promise<string[]> => {
+        const apiBase = gitlabApiBase(baseUrl)
         const projectId = encodeURIComponent(`${owner}/${repo}`)
         const labels = await paginateAll<{ name: string }>(
-          `${API_BASE}/projects/${projectId}/labels?include_ancestor_groups=true`,
+          `${apiBase}/projects/${projectId}/labels?include_ancestor_groups=true`,
           token,
         )
         return labels.map((l) => l.name)

--- a/src/remote-source.test.ts
+++ b/src/remote-source.test.ts
@@ -170,6 +170,16 @@ describe("parseRemoteSource", () => {
       expect(result.owner).toBe("group/subgroup")
       expect(result.repo).toBe("project")
     })
+
+    it("parses a plain repo URL on a self-hosted GitLab instance", () => {
+      const result = parse("https://gitlab.example.com/group/subgroup/project")
+      expect(result.host).toBe("gitlab.example.com")
+      expect(result.owner).toBe("group/subgroup")
+      expect(result.repo).toBe("project")
+      expect(result.cloneURL).toBe(
+        "https://gitlab.example.com/group/subgroup/project.git",
+      )
+    })
   })
 
   describe("invalid URLs", () => {
@@ -423,6 +433,19 @@ describe("getTokenForHost(gitlab.com)", () => {
       getTokenForHost("gitlab.com").pipe(Effect.provide(layer)),
     )
     expect(result).toBeUndefined()
+  })
+})
+
+describe("getTokenForHost(self-hosted GitLab)", () => {
+  it("resolves GITLAB_TOKEN for a self-hosted gitlab host", async () => {
+    const layer = Layer.mergeAll(
+      makeTestEnvironment({ GITLAB_TOKEN: "gl_self" }),
+      makeTestSpawner([]),
+    )
+    const result = await Effect.runPromise(
+      getTokenForHost("gitlab.example.com").pipe(Effect.provide(layer)),
+    )
+    expect(result).toBe("gl_self")
   })
 })
 

--- a/src/remote-source.ts
+++ b/src/remote-source.ts
@@ -8,6 +8,8 @@ import { ProcessSpawner } from "./services/ProcessSpawner.ts"
 import type { SpawnError } from "./errors/index.ts"
 import { Environment } from "./services/Environment.ts"
 import { RemoteSourceError } from "./errors/index.ts"
+import { gitSpawnEnv } from "./domain/git/env.ts"
+import { isGitLabHost } from "./domain/git/gitlab-host.ts"
 import type { ParsedRemoteSource } from "./types.ts"
 
 // ---------------------------------------------------------------------------
@@ -51,12 +53,14 @@ const PLAIN_GITHUB_REPO_REGEX =
   /^https?:\/\/github\.com\/([^/]+)\/([^/.]+?)(?:\.git)?$/
 
 /**
- * Plain GitLab repo URL: https://gitlab.com/group/.../repo
- * Supports nested groups — the last path segment is the repo (project) and
- * everything before it is the owner.
+ * Plain GitLab repo URL: https://<host>/group/.../repo
+ * Captures the host so self-hosted instances are supported; the caller only
+ * accepts it when the host is recognizably GitLab (isGitLabHost). Supports
+ * nested groups — the last path segment is the repo (project) and everything
+ * before it is the owner.
  */
 const PLAIN_GITLAB_REPO_REGEX =
-  /^https?:\/\/gitlab\.com\/(.+?)(?:\.git)?$/
+  /^https?:\/\/([^/]+)\/(.+?)(?:\.git)?$/
 
 /**
  * Split a slash-delimited `owner/.../repo` path into its owner and repo parts.
@@ -188,19 +192,24 @@ export const parseRemoteSource = (raw: string): Effect.Effect<ParsedRemoteSource
       }
     }
 
-    // 8) Plain GitLab repo URL (supports nested groups → last segment is the repo)
+    // 8) Plain GitLab repo URL (supports nested groups → last segment is the
+    //    repo). Accepts gitlab.com and self-hosted GitLab hosts recognizable by
+    //    name; other hosts (e.g. bitbucket.org) fall through to "unsupported".
     match = trimmed.match(PLAIN_GITLAB_REPO_REGEX)
     if (match) {
-      const { owner, repo } = splitOwnerRepo(match[1])
-      // A GitLab project always lives under at least one namespace, so a
-      // single-segment path (no owner) is not a valid repo URL.
-      if (owner) {
-        return {
-          host: "gitlab.com",
-          owner,
-          repo,
-          cloneURL: `https://gitlab.com/${owner}/${repo}.git`,
-          isBlobURL: false,
+      const [, host, ownerRepoPath] = match
+      if (isGitLabHost(host)) {
+        const { owner, repo } = splitOwnerRepo(ownerRepoPath)
+        // A GitLab project always lives under at least one namespace, so a
+        // single-segment path (no owner) is not a valid repo URL.
+        if (owner) {
+          return {
+            host,
+            owner,
+            repo,
+            cloneURL: `https://${host}/${owner}/${repo}.git`,
+            isBlobURL: false,
+          }
         }
       }
     }
@@ -244,8 +253,12 @@ export const resolveRef = (
   Effect.gen(function* () {
     const spawner = yield* ProcessSpawner
 
-    // Fetch all remote refs
-    const proc = yield* spawner.spawn("git", ["ls-remote", "--refs", cloneURL])
+    // Fetch all remote refs. gitSpawnEnv keeps ssh non-interactive so an
+    // ls-remote against an unknown SSH host fails fast instead of hanging on
+    // the host-key prompt.
+    const proc = yield* spawner.spawn("git", ["ls-remote", "--refs", cloneURL], {
+      env: gitSpawnEnv(),
+    })
     const lines: string[] = []
     yield* Stream.runForEach(proc.output, (line) => {
       if (line.source === "stdout" && line.line.trim()) {
@@ -307,7 +320,8 @@ export function adjustBlobPath(parsed: ParsedRemoteSource): ParsedRemoteSource {
  * Returns an auth token for the given git host.
  *
  * GitHub: checks GITHUB_TOKEN -> GH_TOKEN -> `gh auth token`
- * GitLab: checks GITLAB_TOKEN -> `glab auth token`
+ * GitLab (gitlab.com or a self-hosted host recognizable by name):
+ *   checks GITLAB_TOKEN -> `glab auth token`
  */
 export const getTokenForHost = (
   host: string,
@@ -326,7 +340,9 @@ export const getTokenForHost = (
       )
     }
 
-    if (host === "gitlab.com") {
+    // GITLAB_TOKEN is keyed by provider, so it serves any GitLab host —
+    // gitlab.com or a self-hosted instance recognizable by name.
+    if (isGitLabHost(host)) {
       const glToken = yield* env.get("GITLAB_TOKEN")
       if (glToken) return glToken
 

--- a/src/services/GitLabClient.ts
+++ b/src/services/GitLabClient.ts
@@ -38,6 +38,12 @@ export interface CreateMRParams {
   readonly baseBranch: string
   readonly headBranch: string
   readonly labels?: string[]
+  /**
+   * GitLab instance origin to target (e.g. `https://gitlab.example.com`).
+   * Defaults to gitlab.com when omitted. Lets a self-hosted instance receive
+   * the MR instead of gitlab.com.
+   */
+  readonly baseUrl?: string
 }
 
 /**
@@ -52,10 +58,15 @@ export interface MergeRequestResult {
 }
 
 export interface GitLabClientShape {
-  readonly validateToken: (token: string) => Effect.Effect<GitLabTokenValidation, GitLabApiError>
+  /**
+   * Validate a token against a GitLab instance. `baseUrl` is the instance
+   * origin (e.g. `https://gitlab.example.com`); defaults to gitlab.com.
+   */
+  readonly validateToken: (token: string, baseUrl?: string) => Effect.Effect<GitLabTokenValidation, GitLabApiError>
   readonly detectTokenType: (token: string) => GitLabTokenType
   readonly createMergeRequest: (token: string, params: CreateMRParams) => Effect.Effect<MergeRequestResult, GitLabApiError>
-  readonly listLabels: (token: string, owner: string, repo: string) => Effect.Effect<string[], GitLabApiError>
+  /** `baseUrl` is the instance origin; defaults to gitlab.com. */
+  readonly listLabels: (token: string, owner: string, repo: string, baseUrl?: string) => Effect.Effect<string[], GitLabApiError>
 }
 
 export class GitLabClient extends Context.Tag("GitLabClient")<GitLabClient, GitLabClientShape>() {}

--- a/web/src/components/mdx/GitAuth/GitAuth.tsx
+++ b/web/src/components/mdx/GitAuth/GitAuth.tsx
@@ -33,6 +33,7 @@ function GitAuthInteractive({
   description,
   provider: initialProvider = 'github',
   hideProviderSelect = false,
+  instanceUrl,
   oauthClientId,
   oauthScopes,
   detectCredentials,
@@ -79,6 +80,7 @@ function GitAuthInteractive({
   const auth = useGitAuth({
     id,
     provider: providerConfig,
+    instanceUrl,
     oauthClientId: useDefaultOAuth ? undefined : oauthClientId,
     oauthScopes: effectiveOAuthScopes,
     detectCredentials,
@@ -285,6 +287,8 @@ function GitAuthInteractive({
                     setShowPatToken={auth.setShowPatToken}
                     onSubmit={auth.handlePatSubmit}
                     provider={providerConfig}
+                    instanceUrl={auth.gitlabInstanceUrl}
+                    setInstanceUrl={auth.setGitlabInstanceUrl}
                   />
                   {/* Providers without OAuth (GitLab) surface the auto-detect
                       FAQ here, since there is no OAuth tab to carry it. */}

--- a/web/src/components/mdx/GitAuth/__tests__/GitAuth.test.tsx
+++ b/web/src/components/mdx/GitAuth/__tests__/GitAuth.test.tsx
@@ -78,6 +78,11 @@ describe("GitAuth", () => {
     expect(gitlabTab).toHaveAttribute("aria-selected", "true")
   })
 
+  it("forwards the instanceUrl prop to the auth hook (self-hosted GitLab)", () => {
+    renderGitAuth({ provider: "gitlab", instanceUrl: "https://gitlab.acme.com" })
+    expect(hookCalls[0].instanceUrl).toBe("https://gitlab.acme.com")
+  })
+
   it("hides the provider picker when hideProviderSelect is set", () => {
     renderGitAuth({ hideProviderSelect: true })
     expect(screen.queryByRole("tablist", { name: "Git provider" })).toBeNull()

--- a/web/src/components/mdx/GitAuth/__tests__/utils.test.ts
+++ b/web/src/components/mdx/GitAuth/__tests__/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest"
+import { normalizeInstanceBaseUrl } from "../utils"
+
+// Mirrors the backend's normalizeGitLabBaseUrl (src/domain/git/gitlab-host.ts),
+// but returns null (rather than the gitlab.com default) so the PAT form can fall
+// back to the provider's static create-token link.
+describe("normalizeInstanceBaseUrl", () => {
+  it("returns null for empty / whitespace / nullish input", () => {
+    expect(normalizeInstanceBaseUrl(undefined)).toBeNull()
+    expect(normalizeInstanceBaseUrl(null)).toBeNull()
+    expect(normalizeInstanceBaseUrl("")).toBeNull()
+    expect(normalizeInstanceBaseUrl("   ")).toBeNull()
+  })
+
+  it("keeps a full https origin and drops path/query/trailing slash", () => {
+    expect(normalizeInstanceBaseUrl("https://gitlab.acme.com")).toBe("https://gitlab.acme.com")
+    expect(normalizeInstanceBaseUrl("https://gitlab.acme.com/")).toBe("https://gitlab.acme.com")
+    expect(normalizeInstanceBaseUrl("https://gitlab.acme.com/-/foo?x=1")).toBe("https://gitlab.acme.com")
+  })
+
+  it("assumes https when the scheme is missing and preserves a port", () => {
+    expect(normalizeInstanceBaseUrl("gitlab.acme.com")).toBe("https://gitlab.acme.com")
+    expect(normalizeInstanceBaseUrl("gitlab.acme.com:8443")).toBe("https://gitlab.acme.com:8443")
+  })
+
+  it("preserves an explicit http scheme", () => {
+    expect(normalizeInstanceBaseUrl("http://gitlab.internal")).toBe("http://gitlab.internal")
+  })
+
+  it("returns null for a non-http(s) scheme rather than mangling it", () => {
+    // Guards the `https://ftp` foot-gun from naive scheme-prefixing.
+    expect(normalizeInstanceBaseUrl("ftp://gitlab.acme.com")).toBeNull()
+  })
+})

--- a/web/src/components/mdx/GitAuth/components/PatForm.tsx
+++ b/web/src/components/mdx/GitAuth/components/PatForm.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button"
 import { useState } from "react"
 import type { GitAuthStatus } from "../types"
 import type { ProviderConfig } from "../providers"
+import { normalizeInstanceBaseUrl } from "../utils"
 
 interface PatFormProps {
   authStatus: GitAuthStatus
@@ -12,6 +13,9 @@ interface PatFormProps {
   setShowPatToken: (value: boolean) => void
   onSubmit: () => void
   provider: ProviderConfig
+  /** GitLab self-hosted instance URL (GitLab only). */
+  instanceUrl?: string
+  setInstanceUrl?: (value: string) => void
 }
 
 export function PatForm({
@@ -22,9 +26,20 @@ export function PatForm({
   setShowPatToken,
   onSubmit,
   provider,
+  instanceUrl = '',
+  setInstanceUrl,
 }: PatFormProps) {
   const isAuthenticating = authStatus === 'authenticating'
   const [showSetupGuide, setShowSetupGuide] = useState(false)
+
+  // GitLab can run self-hosted, so let the user point the token at their own
+  // instance. The token-creation link follows that instance; everything else
+  // (GitHub, or a blank field) keeps the provider's gitlab.com default.
+  const showInstanceField = provider.id === 'gitlab' && setInstanceUrl !== undefined
+  const instanceBase = provider.id === 'gitlab' ? normalizeInstanceBaseUrl(instanceUrl) : null
+  const tokenCreateUrl = instanceBase
+    ? `${instanceBase}/-/user_settings/personal_access_tokens`
+    : provider.pat.tokenCreateUrl
 
   return (
     <div className="space-y-4">
@@ -33,6 +48,29 @@ export function PatForm({
           Enter a {provider.label} Personal Access Token.
         </p>
       </div>
+
+      {/* GitLab instance URL (self-hosted support) */}
+      {showInstanceField && (
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            GitLab Instance URL
+          </label>
+          <input
+            type="text"
+            value={instanceUrl}
+            onChange={(e) => setInstanceUrl?.(e.target.value)}
+            className="w-full px-3 py-2 border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring font-mono text-sm"
+            placeholder="https://gitlab.com"
+            disabled={isAuthenticating}
+            spellCheck={false}
+            autoCapitalize="none"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Leave blank for gitlab.com. Set this to validate a token for a
+            self-hosted instance (e.g. https://gitlab.example.com).
+          </p>
+        </div>
+      )}
 
       {/* Token input */}
       <div>
@@ -97,13 +135,13 @@ export function PatForm({
                 <div>
                   <p className="font-medium text-foreground">1. Create a personal access token:</p>
                   <a
-                    href={provider.pat.tokenCreateUrl}
+                    href={tokenCreateUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1 text-info hover:underline break-all"
                   >
                     <ExternalLink className="size-3 flex-shrink-0" />
-                    {provider.pat.tokenCreateUrl.replace(/^https?:\/\//, '')}
+                    {tokenCreateUrl.replace(/^https?:\/\//, '')}
                   </a>
                 </div>
 
@@ -129,13 +167,13 @@ export function PatForm({
                 <div>
                   <p className="font-medium text-foreground">1. Create a fine-grained token:</p>
                   <a
-                    href={provider.pat.tokenCreateUrl}
+                    href={tokenCreateUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1 text-info hover:underline"
                   >
                     <ExternalLink className="size-3" />
-                    {provider.pat.tokenCreateUrl.replace(/^https?:\/\//, '')}
+                    {tokenCreateUrl.replace(/^https?:\/\//, '')}
                   </a>
                 </div>
 

--- a/web/src/components/mdx/GitAuth/components/__tests__/PatForm.test.tsx
+++ b/web/src/components/mdx/GitAuth/components/__tests__/PatForm.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { TestWrapper } from "@/test/test-utils"
+import { PatForm } from "../PatForm"
+import { PROVIDERS } from "../../providers"
+
+function renderPatForm(props: Partial<React.ComponentProps<typeof PatForm>> = {}) {
+  const defaults: React.ComponentProps<typeof PatForm> = {
+    authStatus: "pending",
+    patToken: "",
+    setPatToken: vi.fn(),
+    showPatToken: false,
+    setShowPatToken: vi.fn(),
+    onSubmit: vi.fn(),
+    provider: PROVIDERS.gitlab,
+  }
+  return render(
+    <TestWrapper>
+      <PatForm {...defaults} {...props} />
+    </TestWrapper>,
+  )
+}
+
+describe("PatForm — GitLab self-hosted instance field", () => {
+  it("shows the Instance URL field for GitLab and reports edits", () => {
+    const setInstanceUrl = vi.fn()
+    renderPatForm({ instanceUrl: "", setInstanceUrl })
+
+    const field = screen.getByPlaceholderText("https://gitlab.com")
+    expect(field).toBeInTheDocument()
+
+    fireEvent.change(field, { target: { value: "https://gitlab.acme.com" } })
+    expect(setInstanceUrl).toHaveBeenCalledWith("https://gitlab.acme.com")
+  })
+
+  it("does not show the Instance URL field for GitHub", () => {
+    renderPatForm({ provider: PROVIDERS.github, instanceUrl: "", setInstanceUrl: vi.fn() })
+    expect(screen.queryByText("GitLab Instance URL")).toBeNull()
+  })
+
+  it("omits the field when no setInstanceUrl handler is wired", () => {
+    renderPatForm({ setInstanceUrl: undefined })
+    expect(screen.queryByText("GitLab Instance URL")).toBeNull()
+  })
+
+  it("points the create-token link at the self-hosted instance", () => {
+    renderPatForm({ instanceUrl: "https://gitlab.acme.com", setInstanceUrl: vi.fn() })
+
+    // The setup guide (with the token link) is collapsed by default.
+    fireEvent.click(screen.getByText("How do I create a token?"))
+
+    const link = screen.getByRole("link", {
+      name: /gitlab\.acme\.com\/-\/user_settings\/personal_access_tokens/,
+    })
+    expect(link).toHaveAttribute(
+      "href",
+      "https://gitlab.acme.com/-/user_settings/personal_access_tokens",
+    )
+  })
+
+  it("falls back to the gitlab.com create-token link when no instance is set", () => {
+    renderPatForm({ instanceUrl: "", setInstanceUrl: vi.fn() })
+    fireEvent.click(screen.getByText("How do I create a token?"))
+
+    const link = screen.getByRole("link", {
+      name: /gitlab\.com\/-\/user_settings\/personal_access_tokens/,
+    })
+    expect(link).toHaveAttribute(
+      "href",
+      "https://gitlab.com/-/user_settings/personal_access_tokens",
+    )
+  })
+})

--- a/web/src/components/mdx/GitAuth/hooks/__tests__/useGitAuth.test.ts
+++ b/web/src/components/mdx/GitAuth/hooks/__tests__/useGitAuth.test.ts
@@ -93,6 +93,94 @@ describe('useGitAuth — GitLab provider', () => {
     expect(result.current.scopeWarning).toBeNull()
   })
 
+  it('sends a self-hosted instanceUrl to gitlab:validate when supplying a token', async () => {
+    const invoke = installApi(async (channel) => {
+      if (channel === 'gitlab:validate') {
+        return { valid: true, user: { login: 'tanuki' }, tokenType: 'pat' }
+      }
+      if (channel === 'session:set-env') return { ok: true }
+      return { found: false }
+    })
+
+    const { result } = renderHook(() =>
+      useGitAuth({
+        id: 'git',
+        provider: PROVIDERS.gitlab,
+        instanceUrl: 'https://gitlab.acme.com',
+        detectCredentials: false,
+      }),
+    )
+
+    act(() => result.current.setPatToken('glpat-abc'))
+    await act(async () => {
+      await result.current.handlePatSubmit()
+    })
+
+    expect(invoke).toHaveBeenCalledWith('gitlab:validate', {
+      token: 'glpat-abc',
+      instanceUrl: 'https://gitlab.acme.com',
+    })
+  })
+
+  it('a runtime instance-URL edit overrides the seeded prop on validate', async () => {
+    const invoke = installApi(async (channel) => {
+      if (channel === 'gitlab:validate') {
+        return { valid: true, user: { login: 'tanuki' }, tokenType: 'pat' }
+      }
+      if (channel === 'session:set-env') return { ok: true }
+      return { found: false }
+    })
+
+    const { result } = renderHook(() =>
+      useGitAuth({
+        id: 'git',
+        provider: PROVIDERS.gitlab,
+        instanceUrl: 'https://seed.example.com',
+        detectCredentials: false,
+      }),
+    )
+
+    act(() => {
+      result.current.setGitlabInstanceUrl('https://edited.example.com')
+      result.current.setPatToken('glpat-abc')
+    })
+    await act(async () => {
+      await result.current.handlePatSubmit()
+    })
+
+    expect(invoke).toHaveBeenCalledWith('gitlab:validate', {
+      token: 'glpat-abc',
+      instanceUrl: 'https://edited.example.com',
+    })
+  })
+
+  it('threads the instanceUrl through env/cli credential detection', async () => {
+    const invoke = installApi(async (channel) => {
+      if (channel === 'gitlab:env-credentials') return { found: false }
+      if (channel === 'gitlab:cli-credentials') return { found: false }
+      return {}
+    })
+
+    renderHook(() =>
+      useGitAuth({
+        id: 'git',
+        provider: PROVIDERS.gitlab,
+        instanceUrl: 'https://gitlab.acme.com',
+      }),
+    )
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        'gitlab:env-credentials',
+        expect.objectContaining({ instanceUrl: 'https://gitlab.acme.com' }),
+      )
+      expect(invoke).toHaveBeenCalledWith(
+        'gitlab:cli-credentials',
+        expect.objectContaining({ instanceUrl: 'https://gitlab.acme.com' }),
+      )
+    })
+  })
+
   it('shows introspected scopes and does not warn when write_repository is present', async () => {
     installApi(async (channel) => {
       if (channel === 'gitlab:validate') {

--- a/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
+++ b/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
@@ -22,6 +22,8 @@ const DEFAULT_GITHUB_OAUTH_CLIENT_ID = "Ov23liDbtds8EmGws3np"
 interface UseGitAuthOptions {
   id: string
   provider: ProviderConfig
+  /** Self-hosted GitLab instance URL (GitLab only); seeds the editable field. */
+  instanceUrl?: string
   oauthClientId?: string
   oauthScopes?: string[]
   detectCredentials?: false | GitCredentialSource[]
@@ -30,6 +32,7 @@ interface UseGitAuthOptions {
 export function useGitAuth({
   id,
   provider,
+  instanceUrl,
   oauthClientId,
   oauthScopes = ['repo'],
   detectCredentials = ['env', 'cli'],
@@ -64,6 +67,17 @@ export function useGitAuth({
   // PAT form state
   const [patToken, setPatToken] = useState('')
   const [showPatToken, setShowPatToken] = useState(false)
+
+  // GitLab self-hosted instance URL, seeded from the prop and editable in the
+  // PAT form. Only meaningful for the GitLab provider; sent with the token so
+  // validation/detection targets the right instance (empty → gitlab.com).
+  const [gitlabInstanceUrl, setGitlabInstanceUrl] = useState(instanceUrl ?? '')
+
+  // The instance URL to send over IPC: only for GitLab, and only when non-empty
+  // (so GitHub and the gitlab.com default both send nothing).
+  const instanceUrlForIpc = provider.id === 'gitlab' && gitlabInstanceUrl.trim()
+    ? gitlabInstanceUrl.trim()
+    : undefined
 
   // OAuth state
   const [oauthUserCode, setOauthUserCode] = useState<string | null>(null)
@@ -145,7 +159,7 @@ export function useGitAuth({
   // Validate a token via the provider's API
   const validateToken = useCallback(async (token: string): Promise<{ valid: boolean; user?: GitUserInfo; scopes?: string[]; tokenType?: GitTokenType; error?: string }> => {
     try {
-      const data = await window.api.invoke(provider.channels.validate, { token })
+      const data = await window.api.invoke(provider.channels.validate, { token, instanceUrl: instanceUrlForIpc })
       return {
         valid: data.valid,
         user: data.user as GitUserInfo | undefined,
@@ -159,7 +173,7 @@ export function useGitAuth({
         error: error instanceof Error ? error.message : 'Failed to validate token'
       }
     }
-  }, [provider])
+  }, [provider, instanceUrlForIpc])
 
   // Try to detect credentials from environment variables
   const tryEnvCredentials = useCallback(async (options?: { prefix?: string }): Promise<{ success: boolean; user?: GitUserInfo; scopes?: string[]; tokenType?: GitTokenType; error?: string; foundButInvalid?: boolean }> => {
@@ -168,6 +182,7 @@ export function useGitAuth({
         envVar: '',
         prefix: options?.prefix || '',
         githubAuthId: id,
+        instanceUrl: instanceUrlForIpc,
       })
 
       if (!data.found) {
@@ -183,12 +198,12 @@ export function useGitAuth({
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to check env credentials' }
     }
-  }, [id, provider])
+  }, [id, provider, instanceUrlForIpc])
 
   // Try to detect credentials from the provider's CLI
   const tryCliCredentials = useCallback(async (): Promise<{ success: boolean; user?: GitUserInfo; scopes?: string[]; error?: string; foundButInvalid?: boolean }> => {
     try {
-      const data = await window.api.invoke(provider.channels.cliCredentials, {} as Record<string, never>) as unknown as GitCliCredentialsResponse
+      const data = await window.api.invoke(provider.channels.cliCredentials, { instanceUrl: instanceUrlForIpc }) as unknown as GitCliCredentialsResponse
 
       if (!isCliAuthFound(data)) {
         // Check if token was found but invalid (error contains "invalid")
@@ -201,7 +216,7 @@ export function useGitAuth({
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to check CLI credentials' }
     }
-  }, [provider])
+  }, [provider, instanceUrlForIpc])
 
   // Try to detect credentials from block outputs
   const tryBlockCredentials = useCallback(async (blockId: string): Promise<{ success: boolean; user?: GitUserInfo; error?: string }> => {
@@ -577,6 +592,8 @@ export function useGitAuth({
     showPatToken,
     setShowPatToken,
     handlePatSubmit,
+    gitlabInstanceUrl,
+    setGitlabInstanceUrl,
 
     // OAuth
     effectiveClientId,

--- a/web/src/components/mdx/GitAuth/types.ts
+++ b/web/src/components/mdx/GitAuth/types.ts
@@ -48,6 +48,12 @@ export interface GitAuthProps {
   provider?: GitProvider
   /** When true, the provider picker is hidden and the provider is locked. */
   hideProviderSelect?: boolean
+  /**
+   * Self-hosted GitLab instance URL (e.g. `https://gitlab.example.com`). GitLab
+   * only. Seeds the editable "Instance URL" field in the PAT form and is used to
+   * validate the token against that instance. Defaults to gitlab.com.
+   */
+  instanceUrl?: string
   /** GitHub OAuth App client ID (defaults to Gruntwork's app). GitHub only. */
   oauthClientId?: string
   /** OAuth scopes to request (GitHub default: ['repo']). */

--- a/web/src/components/mdx/GitAuth/utils.ts
+++ b/web/src/components/mdx/GitAuth/utils.ts
@@ -1,6 +1,29 @@
 import { CheckCircle, XCircle, Loader2, KeyRound } from "lucide-react"
 import type { GitAuthStatus } from "./types"
 
+/**
+ * Normalize a user-entered GitLab instance URL (or bare host) into a clean
+ * origin (`https://gitlab.example.com`), or null when empty/invalid. Mirrors the
+ * backend's normalizeGitLabBaseUrl; used to build the self-hosted
+ * token-creation link. A missing scheme is assumed https.
+ */
+export const normalizeInstanceBaseUrl = (input: string | undefined | null): string | null => {
+  const raw = (input ?? "").trim()
+  if (!raw) return null
+  // Reject a non-http(s) scheme rather than gluing https:// in front of it
+  // (which would turn `ftp://host` into the bogus `https://ftp`).
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)
+  if (hasScheme && !/^https?:\/\//i.test(raw)) return null
+  const withScheme = hasScheme ? raw : `https://${raw}`
+  try {
+    const u = new URL(withScheme)
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null
+    return `${u.protocol}//${u.host}`
+  } catch {
+    return null
+  }
+}
+
 // Get status-based styling for the container
 export const getStatusClasses = (authStatus: GitAuthStatus): string => {
   const statusMap: Record<GitAuthStatus, string> = {

--- a/web/src/components/mdx/GitPullRequest/GitPullRequest.tsx
+++ b/web/src/components/mdx/GitPullRequest/GitPullRequest.tsx
@@ -9,7 +9,7 @@ import { useGitWorkTree } from "@/contexts/useGitWorkTree"
 import { useRunbookContext, useTemplateContext, useAllOutputs } from "@/contexts/useRunbook"
 import { resolveTemplateReferences, computeUnmetInputDependencies, computeUnmetOutputDependencies, filterUnmetOutputDeps } from "@/lib/templateUtils"
 import { extractTemplateDependenciesFromString, splitDependencies } from "@/lib/extractTemplateDependencies"
-import { deriveProviderFromAuth, deriveProviderFromRepoUrl } from "@/components/mdx/_shared/lib/gitProvider"
+import { deriveProviderFromAuth, deriveProviderFromRepoUrl, hostFromRepoUrl } from "@/components/mdx/_shared/lib/gitProvider"
 import { useGitFileChanges } from "@/hooks/useGitFileChanges"
 import { PR_PROVIDERS } from "./providers"
 import { useGitPullRequest } from "./hooks/useGitPullRequest"
@@ -246,12 +246,17 @@ function GitPullRequestInteractive({
     return status
   }, [status, authMet, activeWorkTree, wrongProvider])
 
-  // Fetch labels when ready
+  // Fetch labels when ready. Pass the repo's host so a self-hosted GitLab's
+  // labels are fetched from its own instance, not gitlab.com.
   useEffect(() => {
     if (effectiveStatus === 'ready' && activeWorkTree?.gitInfo?.repoOwner && activeWorkTree?.gitInfo?.repoName) {
-      fetchLabels(activeWorkTree.gitInfo.repoOwner, activeWorkTree.gitInfo.repoName)
+      fetchLabels(
+        activeWorkTree.gitInfo.repoOwner,
+        activeWorkTree.gitInfo.repoName,
+        hostFromRepoUrl(activeWorkTree?.gitInfo?.repoUrl),
+      )
     }
-  }, [effectiveStatus, activeWorkTree?.gitInfo?.repoOwner, activeWorkTree?.gitInfo?.repoName, fetchLabels])
+  }, [effectiveStatus, activeWorkTree?.gitInfo?.repoOwner, activeWorkTree?.gitInfo?.repoName, activeWorkTree?.gitInfo?.repoUrl, fetchLabels])
 
   // Report configuration errors
   useEffect(() => {

--- a/web/src/components/mdx/GitPullRequest/hooks/useGitPullRequest.ts
+++ b/web/src/components/mdx/GitPullRequest/hooks/useGitPullRequest.ts
@@ -132,12 +132,13 @@ export function useGitPullRequest({ id, cfg, authId, authDerivedProvider }: UseG
     [authId, authDerivedProvider, cfg],
   )
 
-  // Fetch labels for a repo
-  const fetchLabels = useCallback(async (owner: string, repo: string) => {
+  // Fetch labels for a repo. `host` targets the repo's own GitLab instance
+  // (self-hosted or gitlab.com); GitHub's labels channel ignores it.
+  const fetchLabels = useCallback(async (owner: string, repo: string, host?: string) => {
     if (!owner || !repo) return
     setLabelsLoading(true)
     try {
-      const data = await api.invoke(cfg.channels.labels, { owner, repo })
+      const data = await api.invoke(cfg.channels.labels, { owner, repo, host })
       setLabels((data.labels ?? []).map(name => ({ name, color: '', description: undefined })))
     } catch {
       // Non-critical

--- a/web/src/components/mdx/_shared/lib/gitProvider.test.ts
+++ b/web/src/components/mdx/_shared/lib/gitProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveProviderFromAuth, deriveProviderFromRepoUrl } from './gitProvider'
+import { deriveProviderFromAuth, deriveProviderFromRepoUrl, hostFromRepoUrl } from './gitProvider'
 import type { BlockOutputs } from '@/contexts/RunbookContext'
 
 function outputs(id: string, values: Record<string, string>): Record<string, BlockOutputs> {
@@ -63,5 +63,32 @@ describe('deriveProviderFromRepoUrl', () => {
     expect(deriveProviderFromRepoUrl('https://gitlab.mycompany.com/g/p.git')).toBeUndefined()
     expect(deriveProviderFromRepoUrl('https://github.acme.internal/o/r.git')).toBeUndefined()
     expect(deriveProviderFromRepoUrl('git@git.example.org:o/r.git')).toBeUndefined()
+  })
+})
+
+describe('hostFromRepoUrl', () => {
+  it('returns undefined for empty input', () => {
+    expect(hostFromRepoUrl(undefined)).toBeUndefined()
+    expect(hostFromRepoUrl('')).toBeUndefined()
+  })
+
+  it('reads the host from an HTTPS clone URL', () => {
+    expect(hostFromRepoUrl('https://gitlab.example.com/group/sub/project.git')).toBe(
+      'gitlab.example.com',
+    )
+    expect(hostFromRepoUrl('gitlab.example.com/group/project')).toBe('gitlab.example.com')
+  })
+
+  it('preserves a non-standard port (self-hosted on a custom port)', () => {
+    expect(hostFromRepoUrl('https://gitlab.example.com:8443/group/project.git')).toBe(
+      'gitlab.example.com:8443',
+    )
+  })
+
+  it('reads the host from an SSH/SCP remote with any username', () => {
+    expect(hostFromRepoUrl('git@gitlab.example.com:group/project.git')).toBe('gitlab.example.com')
+    expect(hostFromRepoUrl('deploy@gitlab.example.com:group/project.git')).toBe(
+      'gitlab.example.com',
+    )
   })
 })

--- a/web/src/components/mdx/_shared/lib/gitProvider.ts
+++ b/web/src/components/mdx/_shared/lib/gitProvider.ts
@@ -49,6 +49,29 @@ function hostOf(rawUrl: string): string | undefined {
 }
 
 /**
+ * The host of a repo's clone/remote URL (HTTPS or SSH form), or undefined if it
+ * can't be parsed. Unlike deriveProviderFromRepoUrl this keeps the actual host
+ * (incl. self-hosted), so callers can target the repo's own GitLab instance —
+ * e.g. the label lookup, which must hit a self-hosted API base, not gitlab.com.
+ *
+ * Mirrors the backend's gitHostFromRemoteUrl: keeps the port (`.host`, not
+ * `.hostname`, so a custom-port instance resolves to the right API base) and
+ * accepts any SSH username (not just `git@`). hostOf above intentionally drops
+ * the port and assumes git@, since it's only used to match the SaaS hosts.
+ */
+export function hostFromRepoUrl(repoUrl: string | undefined): string | undefined {
+  if (!repoUrl) return undefined
+  const ssh = repoUrl.match(/^[^/@]+@([^:/]+):/)
+  if (ssh) return ssh[1]
+  try {
+    const host = new URL(repoUrl.includes('://') ? repoUrl : `https://${repoUrl}`).host
+    return host || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Best-effort provider guess from a clone URL's host. Only the public SaaS
  * hosts (github.com / gitlab.com) are recognized; self-hosted/Enterprise hosts
  * return `undefined` (we can't tell GitHub Enterprise from GitLab self-managed


### PR DESCRIPTION
Fixes a gap where self hosted gitlab instances wouldn't work- we were assuming gitlab.com.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for self-hosted GitLab instances throughout the application.
  * GitLab authentication form now allows specifying a custom instance URL for self-hosted GitLab servers.
  * Improved error messages for SSH host key verification failures during git operations, including guidance for configuration.

* **Bug Fixes**
  * Enhanced git subprocess environment handling to prevent hangs during non-interactive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->