### PR TITLE
add a selector for which gitlab instance to use 

### DIFF
--- a/electron/main/ipc/git.ts
+++ b/electron/main/ipc/git.ts
@@ -56,7 +56,8 @@ function errorMessage(err: unknown): string {
     const tag = (err as { _tag: string })._tag
     if (tag === "GitError") {
       const g = err as GitError
-      return g.stderr || `git ${g.command} failed (exit ${g.exitCode})`
+      // g.command already includes the "git " prefix (see GitCliClient.runGit).
+      return g.stderr || `${g.command} failed (exit ${g.exitCode})`
     }
     if (tag === "PathTraversalError") {
       return (err as PathTraversalError).message
@@ -92,8 +93,9 @@ async function runAndUnwrap<A, E extends { _tag: string }>(
     const err = failure.value as GitError | PathTraversalError | { _tag: string }
     if (err._tag === "GitError") {
       const gitErr = err as GitError
+      // gitErr.command already includes the "git " prefix (see GitCliClient.runGit).
       throw new Error(
-        gitErr.stderr || `git ${gitErr.command} failed (exit ${gitErr.exitCode})`,
+        gitErr.stderr || `${gitErr.command} failed (exit ${gitErr.exitCode})`,
       )
     }
     if (err._tag === "PathTraversalError") {
@@ -503,6 +505,11 @@ export function registerGitHandlers(): void {
         )
         console.log("[ipc git:merge-request] gitlab token resolved; starting git steps")
 
+        // The GitLab host the auth block authenticated against (gitlab.com when
+        // unset). The MR API call must hit the same instance as the token.
+        const session = yield* sessionManager.getSession()
+        const gitlabHost = session.env.get("GITLAB_HOST")
+
         const mrParams: CreatePullRequestParams = {
           owner: params.owner,
           repo: params.repo,
@@ -515,7 +522,7 @@ export function registerGitHandlers(): void {
           repoPath,
         }
 
-        return yield* createMergeRequest(token, mrParams, sendLog)
+        return yield* createMergeRequest(token, mrParams, sendLog, gitlabHost)
       })
 
       const exit = await runtime.runPromiseExit(program)

--- a/electron/main/ipc/github.ts
+++ b/electron/main/ipc/github.ts
@@ -38,7 +38,9 @@ const getSessionToken = () =>
 export function registerGitHubHandlers(): void {
   ipcMain.handle(
     "github:validate",
-    async (_event, params: { token: string }) => {
+    // `host` is part of the channel contract (GitHub is single-host, so it's
+    // accepted and ignored) — annotate it for parity with the channel type.
+    async (_event, params: { token: string; host?: string }) => {
       const tokenType = detectTokenType(params.token)
       try {
         const { user, scopes } = await runtime.runPromise(

--- a/electron/main/ipc/gitlab.ts
+++ b/electron/main/ipc/gitlab.ts
@@ -13,7 +13,7 @@
  * to gitlab.com. `gitlab:enumerate-hosts` lists the hosts glab is logged into to
  * drive the picker.
  */
-import { Effect } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import { ipcMain } from "electron"
 import { runtime, sessionManager, getSessionTokenForProvider } from "./runtime.ts"
 import { GitLabClient } from "../../../src/services/GitLabClient.ts"
@@ -25,12 +25,36 @@ import {
   detectCliCredentials,
   detectConfigCredentials,
   detectConfigHosts,
+  isEnvTokenHostAllowed,
 } from "../../../src/domain/gitlab/auth.ts"
 import { normalizeGitLabBaseUrl } from "../../../src/domain/git/gitlab-host.ts"
 
-/** HTTP status from a failed validation, when the failure was a GitLab API error. */
-const errorStatus = (err: unknown): number | undefined =>
-  err instanceof GitLabApiError ? err.status : undefined
+type ValidationResult<A> =
+  | { readonly ok: true; readonly value: A }
+  | { readonly ok: false; readonly message: string; readonly status: number | undefined }
+
+/**
+ * Run a token-validation effect and recover the typed GitLabApiError on failure.
+ *
+ * `runtime.runPromise` rejects with a FiberFailure *wrapper*, so a plain
+ * try/catch + `err instanceof GitLabApiError` never matches and the HTTP
+ * `status` is lost (the renderer needs it to distinguish 401/403 from other
+ * failures). `runPromiseExit` + `Cause.failureOption` recovers the real error —
+ * the same approach as git.ts's `runAndUnwrap`.
+ */
+const runValidation = async <A>(
+  program: Effect.Effect<A, GitLabApiError>,
+): Promise<ValidationResult<A>> => {
+  const exit = await runtime.runPromiseExit(program)
+  if (Exit.isSuccess(exit)) return { ok: true, value: exit.value }
+  const failure = Cause.failureOption(exit.cause)
+  const error = failure._tag === "Some" ? failure.value : undefined
+  return {
+    ok: false,
+    message: error?.message ?? Cause.pretty(exit.cause),
+    status: error instanceof GitLabApiError ? error.status : undefined,
+  }
+}
 
 export function registerGitLabHandlers(): void {
   // Enumerate the GitLab hosts the user is logged into via glab, so the GitAuth
@@ -46,18 +70,16 @@ export function registerGitLabHandlers(): void {
       // A manually-entered instance URL overrides the picked/authored host;
       // either a bare host or a full URL normalizes to the instance origin.
       const baseUrl = normalizeGitLabBaseUrl(params.instanceUrl ?? params.host)
-      try {
-        const { user, scopes } = await runtime.runPromise(
-          validateToken(params.token, baseUrl),
-        )
+      const result = await runValidation(validateToken(params.token, baseUrl))
+      if (result.ok) {
+        const { user, scopes } = result.value
         return { valid: true, user, scopes, tokenType }
-      } catch (err) {
-        return {
-          valid: false,
-          tokenType,
-          error: err instanceof Error ? err.message : String(err),
-          status: errorStatus(err),
-        }
+      }
+      return {
+        valid: false,
+        tokenType,
+        error: result.message,
+        status: result.status,
       }
     },
   )
@@ -84,34 +106,44 @@ export function registerGitLabHandlers(): void {
       const baseUrl = normalizeGitLabBaseUrl(params.instanceUrl ?? params.host)
       const host = new URL(baseUrl).host
 
-      try {
-        const { user, scopes } = await runtime.runPromise(validateToken(token, baseUrl))
+      // GITLAB_TOKEN is host-agnostic, and detection runs on mount, so an
+      // authored `host`/`instanceUrl` prop could otherwise make us POST the
+      // user's token to an arbitrary origin with no interaction. Only auto-send
+      // it to gitlab.com or a host the user has actually logged into via glab;
+      // any other host requires the explicit PAT flow.
+      const { hosts } = await runtime.runPromise(detectConfigHosts())
+      if (!isEnvTokenHostAllowed(host, hosts)) {
+        return { found: false as const }
+      }
 
-        // Inject the token + its host into the session environment (mirrors
-        // github.ts) so git operations can resolve the right credential.
-        await runtime.runPromise(
-          sessionManager.appendToEnv({ GITLAB_TOKEN: token, GITLAB_HOST: host }),
-        )
-
-        return {
-          found: true as const,
-          valid: true as const,
-          token,
-          user,
-          scopes,
-          tokenType,
-          host,
-        }
-      } catch (err) {
+      const result = await runValidation(validateToken(token, baseUrl))
+      if (!result.ok) {
         return {
           found: true as const,
           valid: false as const,
           token,
           tokenType,
-          error: err instanceof Error ? err.message : String(err),
-          status: errorStatus(err),
+          error: result.message,
+          status: result.status,
           host,
         }
+      }
+
+      const { user, scopes } = result.value
+      // Inject the token + its host into the session environment (mirrors
+      // github.ts) so git operations can resolve the right credential.
+      await runtime.runPromise(
+        sessionManager.appendToEnv({ GITLAB_TOKEN: token, GITLAB_HOST: host }),
+      )
+
+      return {
+        found: true as const,
+        valid: true as const,
+        token,
+        user,
+        scopes,
+        tokenType,
+        host,
       }
     },
   )
@@ -146,25 +178,25 @@ export function registerGitLabHandlers(): void {
 
       const tokenType = detectTokenType(token)
 
-      try {
-        const { user, scopes } = await runtime.runPromise(validateToken(token, baseUrl))
-
-        // Inject the token + its host into the session environment so git
-        // operations (e.g. git:clone) can resolve it server-side.
-        await runtime.runPromise(
-          sessionManager.appendToEnv({ GITLAB_TOKEN: token, GITLAB_HOST: host }),
-        )
-
-        return { found: true as const, token, user, scopes, tokenType, host }
-      } catch (err) {
+      const result = await runValidation(validateToken(token, baseUrl))
+      if (!result.ok) {
         return {
           found: true as const,
           tokenType,
-          error: err instanceof Error ? err.message : String(err),
-          status: errorStatus(err),
+          error: result.message,
+          status: result.status,
           host,
         }
       }
+
+      const { user, scopes } = result.value
+      // Inject the token + its host into the session environment so git
+      // operations (e.g. git:clone) can resolve it server-side.
+      await runtime.runPromise(
+        sessionManager.appendToEnv({ GITLAB_TOKEN: token, GITLAB_HOST: host }),
+      )
+
+      return { found: true as const, token, user, scopes, tokenType, host }
     },
   )
 

--- a/electron/main/ipc/gitlab.ts
+++ b/electron/main/ipc/gitlab.ts
@@ -13,22 +13,36 @@ import { Effect } from "effect"
 import { ipcMain } from "electron"
 import { runtime, sessionManager, getSessionTokenForProvider } from "./runtime.ts"
 import { GitLabClient } from "../../../src/services/GitLabClient.ts"
+import { GitLabApiError } from "../../../src/errors/index.ts"
 import {
   validateToken,
   detectTokenType,
   detectEnvCredentials,
   detectCliCredentials,
   detectConfigCredentials,
+  detectConfigHosts,
+  DEFAULT_GITLAB_HOST,
 } from "../../../src/domain/gitlab/auth.ts"
 
+/** HTTP status from a failed validation, when the failure was a GitLab API error. */
+const errorStatus = (err: unknown): number | undefined =>
+  err instanceof GitLabApiError ? err.status : undefined
+
 export function registerGitLabHandlers(): void {
+  // Enumerate the GitLab hosts the user is logged into via glab, so the GitAuth
+  // block can offer a host picker (gitlab.com vs a self-hosted instance).
+  ipcMain.handle("gitlab:enumerate-hosts", async () => {
+    return runtime.runPromise(detectConfigHosts())
+  })
+
   ipcMain.handle(
     "gitlab:validate",
-    async (_event, params: { token: string }) => {
+    async (_event, params: { token: string; host?: string }) => {
+      const host = params.host ?? DEFAULT_GITLAB_HOST
       const tokenType = detectTokenType(params.token)
       try {
         const { user, scopes } = await runtime.runPromise(
-          validateToken(params.token),
+          validateToken(params.token, host),
         )
         return { valid: true, user, scopes, tokenType }
       } catch (err) {
@@ -36,78 +50,101 @@ export function registerGitLabHandlers(): void {
           valid: false,
           tokenType,
           error: err instanceof Error ? err.message : String(err),
+          status: errorStatus(err),
         }
       }
     },
   )
 
-  ipcMain.handle("gitlab:env-credentials", async () => {
-    const token = await runtime.runPromise(detectEnvCredentials())
-    if (!token) {
-      return { found: false as const }
-    }
-
-    const tokenType = detectTokenType(token)
-
-    try {
-      const { user, scopes } = await runtime.runPromise(validateToken(token))
-
-      // Inject the token into the session environment (mirrors github.ts).
-      await runtime.runPromise(
-        sessionManager.appendToEnv({ GITLAB_TOKEN: token }),
-      )
-
-      return {
-        found: true as const,
-        valid: true as const,
-        token,
-        user,
-        scopes,
-        tokenType,
+  ipcMain.handle(
+    "gitlab:env-credentials",
+    async (_event, params: { host?: string } = {}) => {
+      const host = params.host ?? DEFAULT_GITLAB_HOST
+      const token = await runtime.runPromise(detectEnvCredentials())
+      if (!token) {
+        return { found: false as const }
       }
-    } catch (err) {
-      return {
-        found: true as const,
-        valid: false as const,
-        token,
-        tokenType,
-        error: err instanceof Error ? err.message : String(err),
+
+      const tokenType = detectTokenType(token)
+
+      try {
+        const { user, scopes } = await runtime.runPromise(validateToken(token, host))
+
+        // Inject the token + its host into the session environment (mirrors
+        // github.ts) so git operations can resolve the right credential.
+        await runtime.runPromise(
+          sessionManager.appendToEnv({ GITLAB_TOKEN: token, GITLAB_HOST: host }),
+        )
+
+        return {
+          found: true as const,
+          valid: true as const,
+          token,
+          user,
+          scopes,
+          tokenType,
+          host,
+        }
+      } catch (err) {
+        return {
+          found: true as const,
+          valid: false as const,
+          token,
+          tokenType,
+          error: err instanceof Error ? err.message : String(err),
+          status: errorStatus(err),
+          host,
+        }
       }
-    }
-  })
+    },
+  )
 
-  ipcMain.handle("gitlab:cli-credentials", async () => {
-    // Prefer the `glab` binary (it refreshes OAuth tokens); if it yields no
-    // token (not on PATH, not installed, not authenticated, or it timed out),
-    // read glab's config.yml directly, where `glab auth login` stores the token.
-    const token =
-      (await runtime.runPromise(detectCliCredentials())) ??
-      (await runtime.runPromise(detectConfigCredentials()))
-    if (!token) {
-      return { found: false as const }
-    }
+  ipcMain.handle(
+    "gitlab:cli-credentials",
+    async (_event, params: { host?: string } = {}) => {
+      // Resolve which host to detect: the caller's pick, else glab's default.
+      const { defaultHost } = await runtime.runPromise(detectConfigHosts())
+      const host = params.host ?? defaultHost
 
-    const tokenType = detectTokenType(token)
-
-    try {
-      const { user, scopes } = await runtime.runPromise(validateToken(token))
-
-      // Inject the token into the session environment so git operations
-      // (e.g. git:clone) can resolve it server-side, matching the
-      // env-credentials path.
-      await runtime.runPromise(
-        sessionManager.appendToEnv({ GITLAB_TOKEN: token }),
-      )
-
-      return { found: true as const, token, user, scopes, tokenType }
-    } catch (err) {
-      return {
-        found: true as const,
-        tokenType,
-        error: err instanceof Error ? err.message : String(err),
+      // `glab auth token` refreshes OAuth tokens, but it returns only glab's
+      // DEFAULT host's token and (in current glab versions) cannot target a host
+      // when several are configured. So only trust it for the default host;
+      // every other host reads glab's config.yml directly, where `glab auth
+      // login` stores the per-host token. config.yml is also the fallback when
+      // the `glab` binary is not on PATH.
+      const cliToken =
+        host === defaultHost
+          ? await runtime.runPromise(detectCliCredentials())
+          : undefined
+      const token =
+        cliToken ?? (await runtime.runPromise(detectConfigCredentials(host)))
+      if (!token) {
+        return { found: false as const }
       }
-    }
-  })
+
+      const tokenType = detectTokenType(token)
+
+      try {
+        const { user, scopes } = await runtime.runPromise(validateToken(token, host))
+
+        // Inject the token + its host into the session environment so git
+        // operations (e.g. git:clone) can resolve it server-side.
+        await runtime.runPromise(
+          sessionManager.appendToEnv({ GITLAB_TOKEN: token, GITLAB_HOST: host }),
+        )
+
+        return { found: true as const, token, user, scopes, tokenType, host }
+      } catch (err) {
+        return {
+          found: true as const,
+          tokenType,
+          error: err instanceof Error ? err.message : String(err),
+          status: errorStatus(err),
+          host,
+        }
+      }
+    },
+  )
 
   // List a GitLab project's labels for the MR label picker. Resolves the token
   // from the session env (populated by the GitAuth block), so the renderer
@@ -121,8 +158,12 @@ export function registerGitLabHandlers(): void {
           "gitlab",
           () => new Error("No GitLab token available in session"),
         )
+        // The host the auth block authenticated against (gitlab.com when unset),
+        // so labels are fetched from the same instance the token belongs to.
+        const session = yield* sessionManager.getSession()
+        const host = session.env.get("GITLAB_HOST")
         const client = yield* GitLabClient
-        return yield* client.listLabels(token, params.owner, params.repo)
+        return yield* client.listLabels(token, params.owner, params.repo, host)
       })
 
       try {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -11,7 +11,7 @@ const ALLOWED_INVOKE_CHANNELS: Set<string> = new Set<InvokeChannel>([
   "aws:env-credentials", "aws:env-credentials-confirm", "aws:profile-auth", "aws:check-region",
   "github:validate", "github:oauth-start", "github:oauth-poll", "github:env-credentials",
   "github:cli-credentials", "github:orgs", "github:repos", "github:refs", "github:labels",
-  "gitlab:validate", "gitlab:env-credentials", "gitlab:cli-credentials", "gitlab:labels",
+  "gitlab:validate", "gitlab:env-credentials", "gitlab:cli-credentials", "gitlab:labels", "gitlab:enumerate-hosts",
   "git:clone", "git:push", "git:pull-request", "git:merge-request", "git:delete-branch",
   "workspace:tree", "workspace:dirs", "workspace:file", "workspace:changes",
   "workspace:register", "workspace:set-active",

--- a/electron/shared/channels.ts
+++ b/electron/shared/channels.ts
@@ -138,8 +138,10 @@ export interface IpcChannelMap {
 
   // GitHub Authentication
   "github:validate": {
-    params: { token: string }
-    result: { valid: boolean; user?: GitHubUser; scopes?: string[]; tokenType?: string; error?: string }
+    // `host` is accepted for parity with gitlab:validate so the shared useGitAuth
+    // hook passes one payload shape; the GitHub handler ignores it.
+    params: { token: string; host?: string }
+    result: { valid: boolean; user?: GitHubUser; scopes?: string[]; tokenType?: string; error?: string; status?: number }
   }
   "github:oauth-start": {
     params: { clientId: string; scopes: string[] }
@@ -158,7 +160,7 @@ export interface IpcChannelMap {
     }
   }
   "github:env-credentials": {
-    params: { envVar?: string; prefix?: string; githubAuthId?: string }
+    params: { envVar?: string; prefix?: string; githubAuthId?: string; host?: string }
     result: {
       found: boolean
       valid?: boolean
@@ -167,10 +169,11 @@ export interface IpcChannelMap {
       scopes?: string[]
       tokenType?: string
       error?: string
+      status?: number
     }
   }
   "github:cli-credentials": {
-    params: Record<string, never>
+    params: { host?: string }
     result: {
       found: boolean
       token?: string
@@ -178,6 +181,7 @@ export interface IpcChannelMap {
       scopes?: string[]
       tokenType?: string
       error?: string
+      status?: number
     }
   }
   "github:orgs": { params: void; result: GitHubOrg[] }
@@ -186,15 +190,22 @@ export interface IpcChannelMap {
   "github:labels": { params: { owner: string; repo: string }; result: { labels?: string[] } }
 
   // GitLab Authentication
+  // Enumerate the GitLab hosts the user is logged into via glab (for the host
+  // picker). `defaultHost` is glab's configured default (falls back to gitlab.com).
+  "gitlab:enumerate-hosts": {
+    params: Record<string, never>
+    result: { hosts: string[]; defaultHost: string }
+  }
   "gitlab:validate": {
-    params: { token: string }
-    result: { valid: boolean; user?: GitHubUser; scopes?: string[]; tokenType?: string; error?: string }
+    // `host` selects the GitLab instance to validate against (default gitlab.com).
+    params: { token: string; host?: string }
+    result: { valid: boolean; user?: GitHubUser; scopes?: string[]; tokenType?: string; error?: string; status?: number }
   }
   "gitlab:env-credentials": {
     // Param keys mirror github:env-credentials so the shared useGitAuth hook can
     // call either channel with one payload shape; the gitlab handler ignores
-    // envVar/githubAuthId.
-    params: { envVar?: string; prefix?: string; githubAuthId?: string }
+    // envVar/githubAuthId. `host` selects the instance to validate against.
+    params: { envVar?: string; prefix?: string; githubAuthId?: string; host?: string }
     result: {
       found: boolean
       valid?: boolean
@@ -203,10 +214,14 @@ export interface IpcChannelMap {
       scopes?: string[]
       tokenType?: string
       error?: string
+      status?: number
+      host?: string
     }
   }
   "gitlab:cli-credentials": {
-    params: Record<string, never>
+    // `host` selects which glab-configured instance to detect (default: glab's
+    // own default host).
+    params: { host?: string }
     result: {
       found: boolean
       token?: string
@@ -214,6 +229,8 @@ export interface IpcChannelMap {
       scopes?: string[]
       tokenType?: string
       error?: string
+      status?: number
+      host?: string
     }
   }
   "gitlab:labels": { params: { owner: string; repo: string }; result: { labels?: string[] } }

--- a/src/domain/git/operations.ts
+++ b/src/domain/git/operations.ts
@@ -4,6 +4,7 @@
 import path from "path"
 import { Effect, Stream, Chunk } from "effect"
 import { GitClient } from "../../services/GitClient.ts"
+import type { GitIdentity } from "../../services/GitClient.ts"
 import { FileSystem } from "../../services/FileSystem.ts"
 import { GitHubClient } from "../../services/GitHubClient.ts"
 import type { CreatePRParams } from "../../services/GitHubClient.ts"
@@ -110,14 +111,56 @@ const detectEmbeddedRepos = (repoPath: string) =>
   }).pipe(Effect.catchAll(() => Effect.succeed<string[]>([])))
 
 /**
+ * Last-resort committer email used when the authenticated account exposes no
+ * public email (GitLab users commonly hide it). Keeps the commit attributable to
+ * a Runbooks-authored action without fabricating a real-looking address.
+ */
+const FALLBACK_COMMIT_EMAIL = "runbooks-noreply@gruntwork.io"
+
+/** Build a commit identity from a validated provider user, with safe fallbacks. */
+const toCommitIdentity = (user: {
+  readonly login: string
+  readonly name?: string
+  readonly email?: string
+}): GitIdentity => ({
+  name: user.name?.trim() || user.login || "Runbooks",
+  email: user.email?.trim() || FALLBACK_COMMIT_EMAIL,
+})
+
+/**
+ * Best-effort lookup of the authenticated GitHub user's identity. Used only as a
+ * fallback for the commit step when the machine has no git identity configured;
+ * never blocks PR creation. Any failure (network, invalid token) resolves to
+ * undefined, and the commit proceeds with whatever identity git already has.
+ */
+const resolveGitHubAuthor = (token: string) =>
+  Effect.gen(function* () {
+    const gh = yield* GitHubClient
+    const validation = yield* gh.validateToken(token)
+    return toCommitIdentity(validation.user)
+  }).pipe(Effect.catchAll(() => Effect.succeed<GitIdentity | undefined>(undefined)))
+
+/** GitLab equivalent of {@link resolveGitHubAuthor}; validates against the instance. */
+const resolveGitLabAuthor = (token: string, baseUrl: string) =>
+  Effect.gen(function* () {
+    const gl = yield* GitLabClient
+    const validation = yield* gl.validateToken(token, baseUrl)
+    return toCommitIdentity(validation.user)
+  }).pipe(Effect.catchAll(() => Effect.succeed<GitIdentity | undefined>(undefined)))
+
+/**
  * Shared local-git half of opening a PR/MR: create + switch to the head branch,
  * stage all changes, commit, and push to origin. Provider-neutral — the push
  * authenticates with whatever host token the caller resolved (GitHub or GitLab;
  * the clone flow's oauth2 handling makes the push itself host-agnostic).
+ *
+ * `author` is the authenticated user's identity, applied to the commit only as a
+ * fallback when the machine has no git identity configured (see CommitOptions).
  */
 const runGitSteps = (
   token: string,
   params: CreatePullRequestParams,
+  author: GitIdentity | undefined,
   onProgress?: (line: string) => void,
 ) =>
   Effect.gen(function* () {
@@ -145,7 +188,7 @@ const runGitSteps = (
     // Stage all changes and commit
     yield* report("Staging and committing changes…")
     yield* gitClient.stageAll(params.repoPath, embedded)
-    yield* gitClient.commit(params.repoPath, params.commitMessage)
+    yield* gitClient.commit(params.repoPath, params.commitMessage, { author })
 
     // Push the branch to origin
     yield* report(`Pushing ${params.headBranch} to origin…`)
@@ -171,7 +214,10 @@ export const createPullRequest = (
   onProgress?: (line: string) => void,
 ) =>
   Effect.gen(function* () {
-    yield* runGitSteps(token, params, onProgress)
+    // Resolve the authenticated user's identity up front so the commit can be
+    // attributed to them when the machine has no git identity configured.
+    const author = yield* resolveGitHubAuthor(token)
+    yield* runGitSteps(token, params, author, onProgress)
 
     const ghClient = yield* GitHubClient
     const report = (line: string) => Effect.sync(() => onProgress?.(line))
@@ -215,8 +261,6 @@ export const createMergeRequest = (
   onProgress?: (line: string) => void,
 ) =>
   Effect.gen(function* () {
-    yield* runGitSteps(token, params, onProgress)
-
     const gitClient = yield* GitClient
     const glClient = yield* GitLabClient
     const report = (line: string) => Effect.sync(() => onProgress?.(line))
@@ -224,11 +268,17 @@ export const createMergeRequest = (
     // Target the MR at the repo's own GitLab instance (self-hosted or
     // gitlab.com), derived from its remote rather than assumed to be gitlab.com.
     // Best-effort: if the remote can't be read, the client falls back to
-    // gitlab.com.
+    // gitlab.com. Resolved before the git steps so the commit's fallback author
+    // is validated against the same instance the token belongs to.
     const remoteUrl = yield* gitClient
       .getRemoteUrl(params.repoPath)
       .pipe(Effect.orElseSucceed(() => ""))
     const baseUrl = gitlabBaseUrlFromRemoteUrl(remoteUrl)
+
+    // Resolve the authenticated user's identity so the commit can be attributed
+    // to them when the machine has no git identity configured.
+    const author = yield* resolveGitLabAuthor(token, baseUrl)
+    yield* runGitSteps(token, params, author, onProgress)
 
     // Create the MR via GitLab API (labels applied inline)
     yield* report("Opening merge request…")

--- a/src/domain/git/operations.ts
+++ b/src/domain/git/operations.ts
@@ -211,6 +211,7 @@ export const createMergeRequest = (
   token: string,
   params: CreatePullRequestParams,
   onProgress?: (line: string) => void,
+  host?: string,
 ) =>
   Effect.gen(function* () {
     yield* runGitSteps(token, params, onProgress)
@@ -230,7 +231,7 @@ export const createMergeRequest = (
       labels: params.labels,
     }
 
-    return yield* glClient.createMergeRequest(token, mrParams)
+    return yield* glClient.createMergeRequest(token, mrParams, host)
   })
 
 // ---------------------------------------------------------------------------

--- a/src/domain/gitlab/auth.test.ts
+++ b/src/domain/gitlab/auth.test.ts
@@ -5,8 +5,10 @@ import {
   detectEnvCredentials,
   detectCliCredentials,
   detectConfigCredentials,
+  detectConfigHosts,
   resolveGlabConfigPaths,
   parseGlabToken,
+  enumerateGlabHosts,
 } from "./auth.ts"
 import { makeTestEnvironment } from "../../test-utils/TestEnvironment.ts"
 import { makeTestSpawner } from "../../test-utils/TestSpawner.ts"
@@ -240,5 +242,106 @@ describe("detectConfigCredentials", () => {
       detectConfigCredentials().pipe(Effect.provide(layer)),
     )
     expect(result).toBeUndefined()
+  })
+})
+
+// A config like the one `glab` writes for a user logged into gitlab.com (OAuth)
+// and a self-managed instance (PAT) at the same time.
+const multiHostYml =
+  "host: gitlab.com\n" +
+  "hosts:\n" +
+  "  gitlab.com:\n" +
+  "    token: !!null oauthdotcom0000\n" +
+  '    is_oauth2: "true"\n' +
+  "    user: odgrim\n" +
+  "  gitlab.gruntwork.io:\n" +
+  "    token: glpat-selfmanaged\n" +
+  "    api_host: gitlab.gruntwork.io\n" +
+  "    user: root\n"
+
+describe("parseGlabToken (multi-host)", () => {
+  it("reads the requested host's token, not just gitlab.com", () => {
+    expect(parseGlabToken(multiHostYml, "gitlab.gruntwork.io")).toBe("glpat-selfmanaged")
+  })
+
+  it("defaults to gitlab.com when no host is given", () => {
+    expect(parseGlabToken(multiHostYml)).toBe("oauthdotcom0000")
+  })
+
+  it("returns undefined for a host not present in the config", () => {
+    expect(parseGlabToken(multiHostYml, "gitlab.absent.io")).toBeUndefined()
+  })
+})
+
+describe("enumerateGlabHosts", () => {
+  it("lists every host and reports glab's declared default", () => {
+    expect(enumerateGlabHosts(multiHostYml)).toEqual({
+      hosts: ["gitlab.com", "gitlab.gruntwork.io"],
+      defaultHost: "gitlab.com",
+    })
+  })
+
+  it("falls back to the first host when the declared default is absent", () => {
+    const yaml =
+      "host: gitlab.absent.io\n" +
+      "hosts:\n  gitlab.gruntwork.io:\n    token: glpat-x\n"
+    expect(enumerateGlabHosts(yaml)).toEqual({
+      hosts: ["gitlab.gruntwork.io"],
+      defaultHost: "gitlab.gruntwork.io",
+    })
+  })
+
+  it("returns an empty list and the gitlab.com default for empty/malformed content", () => {
+    expect(enumerateGlabHosts("")).toEqual({ hosts: [], defaultHost: "gitlab.com" })
+    expect(enumerateGlabHosts("not: [valid")).toEqual({ hosts: [], defaultHost: "gitlab.com" })
+  })
+})
+
+describe("detectConfigCredentials (multi-host)", () => {
+  it("reads a self-managed host's token from the config file", async () => {
+    const home = "/home/tester"
+    const layer = Layer.merge(
+      makeTestFileSystem({
+        [`${home}/.config/glab-cli/config.yml`]: multiHostYml,
+      }),
+      makeTestEnvironment({ HOME: home }),
+    )
+
+    const result = await Effect.runPromise(
+      detectConfigCredentials("gitlab.gruntwork.io").pipe(Effect.provide(layer)),
+    )
+    expect(result).toBe("glpat-selfmanaged")
+  })
+})
+
+describe("detectConfigHosts", () => {
+  it("enumerates hosts and the default from the first glab config found", async () => {
+    const home = "/home/tester"
+    const layer = Layer.merge(
+      makeTestFileSystem({
+        [`${home}/.config/glab-cli/config.yml`]: multiHostYml,
+      }),
+      makeTestEnvironment({ HOME: home }),
+    )
+
+    const result = await Effect.runPromise(
+      detectConfigHosts().pipe(Effect.provide(layer)),
+    )
+    expect(result).toEqual({
+      hosts: ["gitlab.com", "gitlab.gruntwork.io"],
+      defaultHost: "gitlab.com",
+    })
+  })
+
+  it("returns an empty list with the gitlab.com default when no glab config exists", async () => {
+    const layer = Layer.merge(
+      makeTestFileSystem({}),
+      makeTestEnvironment({ HOME: "/home/tester" }),
+    )
+
+    const result = await Effect.runPromise(
+      detectConfigHosts().pipe(Effect.provide(layer)),
+    )
+    expect(result).toEqual({ hosts: [], defaultHost: "gitlab.com" })
   })
 })

--- a/src/domain/gitlab/auth.test.ts
+++ b/src/domain/gitlab/auth.test.ts
@@ -9,6 +9,7 @@ import {
   resolveGlabConfigPaths,
   parseGlabToken,
   enumerateGlabHosts,
+  isEnvTokenHostAllowed,
 } from "./auth.ts"
 import { makeTestEnvironment } from "../../test-utils/TestEnvironment.ts"
 import { makeTestSpawner } from "../../test-utils/TestSpawner.ts"
@@ -375,5 +376,24 @@ describe("detectConfigHosts", () => {
       detectConfigHosts().pipe(Effect.provide(layer)),
     )
     expect(result).toEqual({ hosts: [], defaultHost: "gitlab.com" })
+  })
+})
+
+describe("isEnvTokenHostAllowed", () => {
+  it("always allows gitlab.com (even with no glab config)", () => {
+    expect(isEnvTokenHostAllowed("gitlab.com", [])).toBe(true)
+  })
+
+  it("allows a host the user has logged into via glab", () => {
+    expect(
+      isEnvTokenHostAllowed("gitlab.gruntwork.io", ["gitlab.com", "gitlab.gruntwork.io"]),
+    ).toBe(true)
+  })
+
+  it("rejects an arbitrary author-controlled host not in glab config", () => {
+    // The credential-exfiltration guard: <GitAuth host="attacker.example"/>
+    // must NOT cause the env GITLAB_TOKEN to be sent there.
+    expect(isEnvTokenHostAllowed("attacker.example", ["gitlab.com"])).toBe(false)
+    expect(isEnvTokenHostAllowed("attacker.example", [])).toBe(false)
   })
 })

--- a/src/domain/gitlab/auth.ts
+++ b/src/domain/gitlab/auth.ts
@@ -139,6 +139,18 @@ export const detectCliCredentials = () =>
 export const DEFAULT_GITLAB_HOST = "gitlab.com"
 
 /**
+ * Whether the host-agnostic env `GITLAB_TOKEN` may be auto-validated against
+ * `host` during on-mount detection. Restricted to gitlab.com and hosts the user
+ * has actually logged into via glab, so an authored `host`/`instanceUrl` prop
+ * can't silently exfiltrate the env token to an arbitrary origin with no user
+ * interaction. Any other host must go through the explicit PAT flow.
+ */
+export const isEnvTokenHostAllowed = (
+  host: string,
+  configHosts: readonly string[],
+): boolean => host === DEFAULT_GITLAB_HOST || configHosts.includes(host)
+
+/**
  * Resolve the candidate paths to glab's `config.yml`, in glab's own lookup
  * order. glab (gitlab-org/cli, `internal/config/config_file.go`) resolves its
  * config directory via the `adrg/xdg` library as:

--- a/src/domain/gitlab/auth.ts
+++ b/src/domain/gitlab/auth.ts
@@ -28,10 +28,10 @@ const GLAB_CLI_TIMEOUT_MS = 5_000
 /**
  * Validate a GitLab token by calling the GitLab API (GET /user).
  */
-export const validateToken = (token: string) =>
+export const validateToken = (token: string, host?: string) =>
   Effect.gen(function* () {
     const glClient = yield* GitLabClient
-    return yield* glClient.validateToken(token)
+    return yield* glClient.validateToken(token, host)
   })
 
 // ---------------------------------------------------------------------------
@@ -126,11 +126,12 @@ export const detectCliCredentials = () =>
 // ---------------------------------------------------------------------------
 
 /**
- * The GitLab host this app authenticates against. The HTTP client targets
- * gitlab.com only, so we read the gitlab.com credentials out of glab's config
- * regardless of which host glab itself defaults to.
+ * The GitLab host used when a caller does not name one. The renderer resolves
+ * an explicit host (an authored `host` prop or the user's pick from the host
+ * picker) and threads it through; this is only the fallback for single-host
+ * setups and backward compatibility.
  */
-const GITLAB_HOST = "gitlab.com"
+export const DEFAULT_GITLAB_HOST = "gitlab.com"
 
 /**
  * Resolve the candidate paths to glab's `config.yml`, in glab's own lookup
@@ -148,9 +149,10 @@ const GITLAB_HOST = "gitlab.com"
  *        Linux:   ~/.config            (same as the legacy location)
  *
  * We probe these in glab's directory-precedence order and return the first
- * gitlab.com token found. (glab itself uses the first directory whose config.yml
- * exists; we instead skip a config that has no gitlab.com token, since our only
- * goal is to surface a usable gitlab.com credential the user already has.)
+ * config that holds a token for the requested host. (glab itself uses the first
+ * directory whose config.yml exists; we instead skip a config that lacks the
+ * requested host's token, since our goal is to surface a usable credential the
+ * user already has.)
  * Exported for testing.
  */
 export function resolveGlabConfigPaths(opts: {
@@ -188,27 +190,35 @@ export function resolveGlabConfigPaths(opts: {
 }
 
 interface GlabConfig {
+  /** glab's top-level default host (the `host:` key in config.yml). */
+  host?: unknown
   hosts?: Record<string, { token?: unknown } | undefined>
 }
 
 /**
- * Extract the gitlab.com access token from glab `config.yml` contents.
+ * Extract a host's access token from glab `config.yml` contents.
  *
  * glab obfuscates stored secrets by tagging them as `!!null`
  * (e.g. `token: !!null glpat-...`), which makes a naive YAML load return null.
  * We strip that tag before parsing so the value survives. OAuth logins store an
  * opaque access token here (no `glpat-` prefix); token logins store the PAT.
  *
+ * `host` selects which entry under `hosts:` to read (defaults to gitlab.com),
+ * so a user logged into several GitLab instances can surface the right one.
+ *
  * Exported for testing.
  */
-export function parseGlabToken(yamlContent: string): string | undefined {
+export function parseGlabToken(
+  yamlContent: string,
+  host: string = DEFAULT_GITLAB_HOST,
+): string | undefined {
   // Strip glab's `!!null ` secret tag so the scalar parses as its string value.
   const cleaned = yamlContent.replace(/!!null\s+/g, "")
 
   let token: unknown
   try {
     const parsed = YAML.parse(cleaned, { logLevel: "silent" }) as GlabConfig | null
-    token = parsed?.hosts?.[GITLAB_HOST]?.token
+    token = parsed?.hosts?.[host]?.token
   } catch {
     return undefined
   }
@@ -220,16 +230,51 @@ export function parseGlabToken(yamlContent: string): string | undefined {
   return undefined
 }
 
+export interface GlabHostsInfo {
+  /** Every host key present under `hosts:` in glab's config. */
+  readonly hosts: string[]
+  /**
+   * glab's configured default host (the top-level `host:` field) when it is one
+   * of the enumerated hosts; otherwise the first host, or gitlab.com when none.
+   */
+  readonly defaultHost: string
+}
+
+/**
+ * Enumerate the GitLab hosts a glab `config.yml` defines, plus glab's default
+ * host. Used to drive the GitAuth host picker when the user is logged into more
+ * than one instance (e.g. gitlab.com and a self-hosted gitlab.example.com).
+ *
+ * Exported for testing.
+ */
+export function enumerateGlabHosts(yamlContent: string): GlabHostsInfo {
+  const cleaned = yamlContent.replace(/!!null\s+/g, "")
+  try {
+    const parsed = YAML.parse(cleaned, { logLevel: "silent" }) as GlabConfig | null
+    const hosts = Object.keys(parsed?.hosts ?? {})
+    const declared = typeof parsed?.host === "string" ? parsed.host : undefined
+    const defaultHost =
+      declared && hosts.includes(declared)
+        ? declared
+        : (hosts[0] ?? DEFAULT_GITLAB_HOST)
+    return { hosts, defaultHost }
+  } catch {
+    return { hosts: [], defaultHost: DEFAULT_GITLAB_HOST }
+  }
+}
+
 /**
  * Detect a GitLab token from glab's CLI config file (`config.yml`).
  *
  * `glab auth login` does not export an environment variable; it writes the
  * token into glab's `config.yml`. This reads that file directly, so detection
  * still works when `glab auth token` yields nothing — e.g. the `glab` binary is
- * not on PATH (common inside Electron's spawn environment). Returns undefined if
- * no config file or gitlab.com token is found.
+ * not on PATH (common inside Electron's spawn environment), or `glab auth token`
+ * cannot disambiguate which host to use when several are configured. `host`
+ * selects the instance (defaults to gitlab.com). Returns undefined if no config
+ * file or token for that host is found.
  */
-export const detectConfigCredentials = () =>
+export const detectConfigCredentials = (host: string = DEFAULT_GITLAB_HOST) =>
   Effect.gen(function* () {
     const env = yield* Environment
     const fs = yield* FileSystem
@@ -246,9 +291,37 @@ export const detectConfigCredentials = () =>
       const content = yield* fs
         .readFile(path)
         .pipe(Effect.orElseSucceed(() => ""))
-      const token = parseGlabToken(content)
+      const token = parseGlabToken(content, host)
       if (token) return token
     }
 
     return undefined
+  })
+
+/**
+ * Enumerate the GitLab hosts the user is logged into via glab, reading the
+ * first glab `config.yml` (in glab's directory-precedence order) that defines
+ * any hosts. Returns an empty list and the gitlab.com default when no glab
+ * config is present. Powers the GitAuth host picker.
+ */
+export const detectConfigHosts = () =>
+  Effect.gen(function* () {
+    const env = yield* Environment
+    const fs = yield* FileSystem
+
+    const allEnv = yield* env.getAll()
+    const candidates = resolveGlabConfigPaths({
+      env: allEnv,
+      platform: process.platform,
+    })
+
+    for (const path of candidates) {
+      const content = yield* fs
+        .readFile(path)
+        .pipe(Effect.orElseSucceed(() => ""))
+      const info = enumerateGlabHosts(content)
+      if (info.hosts.length > 0) return info
+    }
+
+    return { hosts: [] as string[], defaultHost: DEFAULT_GITLAB_HOST }
   })

--- a/src/layers/GitCliClient.test.ts
+++ b/src/layers/GitCliClient.test.ts
@@ -35,13 +35,20 @@ const runStageAll = (repoPath: string, excludePaths: string[] = []) =>
     }).pipe(Effect.provide(layer)),
   )
 
-const runCommitEither = (repoPath: string, message: string) =>
+const runCommitEither = (
+  repoPath: string,
+  message: string,
+  options?: { allowEmpty?: boolean; author?: { name: string; email: string } },
+) =>
   Effect.runPromise(
     Effect.gen(function* () {
       const git = yield* GitClient
-      return yield* git.commit(repoPath, message)
+      return yield* git.commit(repoPath, message, options)
     }).pipe(Effect.provide(layer), Effect.either),
   )
+
+/** Stand-in for the authenticated GitLab/GitHub user threaded into commits. */
+const TEST_AUTHOR = { name: "Authed User", email: "authed@example.com" }
 
 /** git config args shared by the deterministic helpers below. */
 const GIT_CONFIG = [
@@ -62,6 +69,15 @@ function gitOut(repoPath: string, ...args: string[]): string {
     cwd: repoPath,
     stdio: ["pipe", "pipe", "pipe"],
   }).toString()
+}
+
+/** Restore (or delete) a process.env var captured before a test mutated it. */
+function restoreEnv(key: string, saved: string | undefined): void {
+  if (saved === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = saved
+  }
 }
 
 describe("GitCliClientLive.diff (real repo)", () => {
@@ -164,9 +180,23 @@ describe("GitCliClientLive.stageAll (real repo)", () => {
 
 describe("GitCliClientLive.commit (real repo)", () => {
   let repoPath: string
+  let savedConfigGlobal: string | undefined
+  let savedConfigSystem: string | undefined
 
   beforeEach(() => {
+    // Make git ignore any *ambient* (global/system) identity so these tests
+    // exercise the layer's own identity handling deterministically — the repo
+    // starts with NO resolvable identity on every machine, dev laptop or clean
+    // CI runner. (GitCliClientLive runs git via gitSpawnEnv(), which spreads
+    // process.env, so these reach the real commit too.)
+    savedConfigGlobal = process.env.GIT_CONFIG_GLOBAL
+    savedConfigSystem = process.env.GIT_CONFIG_SYSTEM
+    process.env.GIT_CONFIG_GLOBAL = "/dev/null"
+    process.env.GIT_CONFIG_SYSTEM = "/dev/null"
+
     repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "runbooks-gitcommit-"))
+    // The git() helper supplies identity per-invocation via -c, so the setup
+    // commit succeeds without persisting any identity into the repo.
     git(repoPath, "init")
     fs.writeFileSync(path.join(repoPath, "tracked.txt"), "one\n")
     git(repoPath, "add", "tracked.txt")
@@ -175,30 +205,80 @@ describe("GitCliClientLive.commit (real repo)", () => {
 
   afterEach(() => {
     fs.rmSync(repoPath, { recursive: true, force: true })
+    restoreEnv("GIT_CONFIG_GLOBAL", savedConfigGlobal)
+    restoreEnv("GIT_CONFIG_SYSTEM", savedConfigSystem)
   })
 
   it("surfaces git's stdout reason when there is nothing to commit (exit 1)", async () => {
     // `git commit` with a clean tree exits 1 and prints "nothing to commit,
     // working tree clean" to STDOUT (not stderr). The error must carry that
     // reason instead of a bare "exit 1" — this is exactly the MR-block failure.
-    const result = await runCommitEither(repoPath, "[skip ci] no-op commit")
+    // A fallback author is supplied so the failure is the clean-tree one, not
+    // "author identity unknown".
+    const result = await runCommitEither(repoPath, "[skip ci] no-op commit", {
+      author: TEST_AUTHOR,
+    })
 
     expect(result._tag).toBe("Left")
     if (result._tag === "Left") {
       expect(result.left.exitCode).not.toBe(0)
       expect(result.left.stderr.toLowerCase()).toContain("nothing to commit")
-      // command carries the "git " prefix exactly once.
+      // command carries the "git " prefix exactly once, and the injected
+      // identity is passed via env — never leaked into the command string.
       expect(result.left.command.startsWith("git commit")).toBe(true)
+      expect(result.left.command).not.toContain("authed@example.com")
     }
   })
 
-  it("commits successfully when there are staged changes", async () => {
+  it("commits as the fallback author when the repo has no configured identity", async () => {
+    // The MR/PR failure mode: a machine with no git identity. The layer must
+    // commit as the authenticated user instead of dying with "author identity
+    // unknown".
     fs.writeFileSync(path.join(repoPath, "tracked.txt"), "one\ntwo\n")
     await runStageAll(repoPath, [])
 
-    const result = await runCommitEither(repoPath, "add line two")
+    const result = await runCommitEither(repoPath, "add line two", {
+      author: TEST_AUTHOR,
+    })
 
     expect(result._tag).toBe("Right")
     expect(gitOut(repoPath, "log", "--oneline")).toContain("add line two")
+    expect(gitOut(repoPath, "log", "-1", "--format=%an <%ae>").trim()).toBe(
+      "Authed User <authed@example.com>",
+    )
+  })
+
+  it("respects the repo's configured identity over the fallback author", async () => {
+    // When the user HAS a git identity, theirs wins — the fallback is ignored.
+    git(repoPath, "config", "user.name", "Local Dev")
+    git(repoPath, "config", "user.email", "local@example.com")
+    fs.writeFileSync(path.join(repoPath, "tracked.txt"), "one\ntwo\n")
+    await runStageAll(repoPath, [])
+
+    const result = await runCommitEither(repoPath, "respect local identity", {
+      author: TEST_AUTHOR,
+    })
+
+    expect(result._tag).toBe("Right")
+    expect(gitOut(repoPath, "log", "-1", "--format=%an <%ae>").trim()).toBe(
+      "Local Dev <local@example.com>",
+    )
+  })
+
+  it("fails with 'author identity unknown' when no identity and no fallback author", async () => {
+    // Regression guard: without the fallback author, an unconfigured machine
+    // can't commit — exactly the bug the author option fixes. useConfigOnly
+    // disables git's gecos-based auto-detection so the failure is deterministic
+    // on dev machines too (CI runners have an empty gecos and fail anyway).
+    git(repoPath, "config", "user.useConfigOnly", "true")
+    fs.writeFileSync(path.join(repoPath, "tracked.txt"), "one\ntwo\n")
+    await runStageAll(repoPath, [])
+
+    const result = await runCommitEither(repoPath, "no identity available")
+
+    expect(result._tag).toBe("Left")
+    if (result._tag === "Left") {
+      expect(result.left.stderr.toLowerCase()).toContain("author identity unknown")
+    }
   })
 })

--- a/src/layers/GitCliClient.test.ts
+++ b/src/layers/GitCliClient.test.ts
@@ -35,6 +35,14 @@ const runStageAll = (repoPath: string, excludePaths: string[] = []) =>
     }).pipe(Effect.provide(layer)),
   )
 
+const runCommitEither = (repoPath: string, message: string) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const git = yield* GitClient
+      return yield* git.commit(repoPath, message)
+    }).pipe(Effect.provide(layer), Effect.either),
+  )
+
 /** git config args shared by the deterministic helpers below. */
 const GIT_CONFIG = [
   "-c", "user.email=test@example.com",
@@ -151,5 +159,46 @@ describe("GitCliClientLive.stageAll (real repo)", () => {
     // behavior the excludePaths argument exists to prevent.
     expect(staged).toContain("160000")
     expect(staged).toContain("sub")
+  })
+})
+
+describe("GitCliClientLive.commit (real repo)", () => {
+  let repoPath: string
+
+  beforeEach(() => {
+    repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "runbooks-gitcommit-"))
+    git(repoPath, "init")
+    fs.writeFileSync(path.join(repoPath, "tracked.txt"), "one\n")
+    git(repoPath, "add", "tracked.txt")
+    git(repoPath, "commit", "-m", "initial")
+  })
+
+  afterEach(() => {
+    fs.rmSync(repoPath, { recursive: true, force: true })
+  })
+
+  it("surfaces git's stdout reason when there is nothing to commit (exit 1)", async () => {
+    // `git commit` with a clean tree exits 1 and prints "nothing to commit,
+    // working tree clean" to STDOUT (not stderr). The error must carry that
+    // reason instead of a bare "exit 1" — this is exactly the MR-block failure.
+    const result = await runCommitEither(repoPath, "[skip ci] no-op commit")
+
+    expect(result._tag).toBe("Left")
+    if (result._tag === "Left") {
+      expect(result.left.exitCode).not.toBe(0)
+      expect(result.left.stderr.toLowerCase()).toContain("nothing to commit")
+      // command carries the "git " prefix exactly once.
+      expect(result.left.command.startsWith("git commit")).toBe(true)
+    }
+  })
+
+  it("commits successfully when there are staged changes", async () => {
+    fs.writeFileSync(path.join(repoPath, "tracked.txt"), "one\ntwo\n")
+    await runStageAll(repoPath, [])
+
+    const result = await runCommitEither(repoPath, "add line two")
+
+    expect(result._tag).toBe("Right")
+    expect(gitOut(repoPath, "log", "--oneline")).toContain("add line two")
   })
 })

--- a/src/layers/GitCliClient.ts
+++ b/src/layers/GitCliClient.ts
@@ -15,6 +15,7 @@ import type {
   DiffEntry,
   StatusEntry,
   GitInfo,
+  CommitOptions,
 } from "../services/GitClient.ts"
 import { ProcessSpawner } from "../services/ProcessSpawner.ts"
 import { GitError } from "../errors/index.ts"
@@ -24,15 +25,20 @@ import { gitSpawnEnv } from "../domain/git/env.ts"
 /**
  * Run a git command, collect all output, and return stdout lines.
  * Fails with GitError if the exit code is non-zero.
+ *
+ * `env` overrides the spawn environment; defaults to `gitSpawnEnv()`. Callers
+ * that need extra variables (e.g. a fallback committer identity) build on top of
+ * `gitSpawnEnv()` so PATH/HOME/SSH_AUTH_SOCK and the no-prompt guards survive.
  */
 function runGit(
   spawner: ProcessSpawner["Type"],
   args: string[],
   cwd: string,
   stdin?: string,
+  env?: Record<string, string | undefined>,
 ) {
   return Effect.gen(function* () {
-    const proc = yield* spawner.spawn("git", args, { cwd, stdin, env: gitSpawnEnv() })
+    const proc = yield* spawner.spawn("git", args, { cwd, stdin, env: env ?? gitSpawnEnv() })
     const chunks = yield* Stream.runCollect(proc.output)
     const lines = Chunk.toArray(chunks)
     const code = yield* proc.exitCode
@@ -57,6 +63,23 @@ function runGit(
     }
 
     return lines.filter((l) => l.source === "stdout").map((l) => l.line)
+  })
+}
+
+/**
+ * Whether the repo can resolve a committer identity from git config in *any*
+ * scope (local, global, or system). `git config <key>` exits non-zero when the
+ * key is unset, which `runGit` surfaces as a GitError — caught here as "not
+ * configured". Used to decide whether a fallback author identity is needed.
+ */
+function hasConfiguredIdentity(spawner: ProcessSpawner["Type"], repoPath: string) {
+  return Effect.gen(function* () {
+    const isSet = (key: string) =>
+      runGit(spawner, ["config", key], repoPath).pipe(
+        Effect.map((lines) => lines.join("").trim().length > 0),
+        Effect.catchAll(() => Effect.succeed(false)),
+      )
+    return (yield* isSet("user.name")) && (yield* isSet("user.email"))
   })
 }
 
@@ -321,13 +344,32 @@ function makeGitClient(spawner: ProcessSpawner["Type"]): GitClientShape {
         yield* runGit(spawner, ["add", "-A", "--", ".", ...excludes], repoPath)
       }),
 
-    commit: (repoPath: string, message: string, allowEmpty?: boolean) =>
+    commit: (repoPath: string, message: string, options?: CommitOptions) =>
       Effect.gen(function* () {
         const args = ["commit", "-m", message]
-        if (allowEmpty) {
+        if (options?.allowEmpty) {
           args.push("--allow-empty")
         }
-        yield* runGit(spawner, args, repoPath)
+
+        // Respect the user's own git identity when one is configured. Only when
+        // the repo can resolve no identity at all (fresh machine / clean CI) do
+        // we fall back to the authenticated user's identity so the commit — and
+        // therefore MR/PR creation — doesn't die with "author identity unknown".
+        // Inject it via env (not `-c`) so the GitError command string stays
+        // "git commit …" and the values never leak into error output.
+        let env: Record<string, string | undefined> | undefined
+        if (options?.author && !(yield* hasConfiguredIdentity(spawner, repoPath))) {
+          const { name, email } = options.author
+          env = {
+            ...gitSpawnEnv(),
+            GIT_AUTHOR_NAME: name,
+            GIT_AUTHOR_EMAIL: email,
+            GIT_COMMITTER_NAME: name,
+            GIT_COMMITTER_EMAIL: email,
+          }
+        }
+
+        yield* runGit(spawner, args, repoPath, undefined, env)
       }),
   }
 }

--- a/src/layers/GitCliClient.ts
+++ b/src/layers/GitCliClient.ts
@@ -37,10 +37,15 @@ function runGit(
     const code = yield* proc.exitCode
 
     if (code !== 0) {
-      const stderr = lines
-        .filter((l) => l.source === "stderr")
-        .map((l) => l.line)
-        .join("\n")
+      const pick = (source: "stderr" | "stdout") =>
+        lines
+          .filter((l) => l.source === source)
+          .map((l) => l.line)
+          .join("\n")
+      // Some git failures report only on stdout — notably `git commit` printing
+      // "nothing to commit, working tree clean" and exiting 1. Fall back to
+      // stdout so the real reason surfaces instead of a bare "exit 1".
+      const stderr = pick("stderr") || pick("stdout")
       return yield* Effect.fail(
         new GitError({
           command: `git ${args.join(" ")}`,

--- a/src/layers/GitLabHttpClient.test.ts
+++ b/src/layers/GitLabHttpClient.test.ts
@@ -21,10 +21,10 @@ const json = (body: unknown, status = 200) =>
     headers: { "Content-Type": "application/json" },
   })
 
-const validate = (token: string) =>
+const validate = (token: string, host?: string) =>
   Effect.gen(function* () {
     const client = yield* GitLabClient
-    return yield* client.validateToken(token)
+    return yield* client.validateToken(token, host)
   }).pipe(Effect.provide(GitLabHttpClientLive))
 
 describe("GitLabHttpClient.validateToken", () => {
@@ -137,6 +137,24 @@ describe("GitLabHttpClient.validateToken", () => {
       expect(result.left.status).toBe(401)
       expect(result.left.message).toContain("401")
     }
+  })
+
+  it("targets a self-managed host's API when one is given", async () => {
+    const urls: string[] = []
+    mockFetch((url) => {
+      urls.push(url)
+      if (url.endsWith("/api/v4/user")) return json({ username: "root" })
+      if (url.endsWith("/personal_access_tokens/self")) return json({ scopes: ["api"] })
+      return new Response("not found", { status: 404 })
+    })
+
+    const result = await Effect.runPromise(validate("glpat-self", "gitlab.gruntwork.io"))
+
+    expect(result.user.login).toBe("root")
+    // Every request must hit the self-managed instance, not gitlab.com.
+    expect(urls.length).toBeGreaterThan(0)
+    expect(urls.every((u) => u.startsWith("https://gitlab.gruntwork.io/"))).toBe(true)
+    expect(urls).toContain("https://gitlab.gruntwork.io/api/v4/user")
   })
 })
 

--- a/src/layers/GitLabHttpClient.ts
+++ b/src/layers/GitLabHttpClient.ts
@@ -1,7 +1,8 @@
 /**
  * Live implementation of the GitLabClient service using fetch.
  *
- * Mirrors GitHubHttpClient, but targets gitlab.com's REST API. Personal,
+ * Mirrors GitHubHttpClient, but targets a GitLab REST API. The host defaults to
+ * gitlab.com and can be overridden per call (e.g. a self-hosted instance). Personal,
  * project, and group access tokens authenticate via the `PRIVATE-TOKEN` header;
  * OAuth tokens (e.g. from `glab auth login`'s web flow) are rejected by it and
  * require `Authorization: Bearer`, so we fall back to Bearer on an auth failure.
@@ -20,8 +21,15 @@ import type {
 } from "../services/GitLabClient.ts"
 import { GitLabApiError } from "../errors/index.ts"
 
-const GITLAB_BASE = "https://gitlab.com"
-const API_BASE = `${GITLAB_BASE}/api/v4`
+const DEFAULT_GITLAB_BASE = "https://gitlab.com"
+
+/**
+ * Build the API origin for a bare GitLab hostname (e.g. "gitlab.example.com").
+ * Defaults to gitlab.com so existing single-host callers are unaffected.
+ */
+function baseFor(host?: string): string {
+  return host ? `https://${host}` : DEFAULT_GITLAB_BASE
+}
 
 type AuthScheme = "private" | "bearer"
 
@@ -49,13 +57,14 @@ function toStringArray(value: unknown): string[] | undefined {
 async function fetchScopes(
   token: string,
   scheme: AuthScheme,
+  base: string = DEFAULT_GITLAB_BASE,
 ): Promise<string[] | undefined> {
   // OAuth tokens expose scopes via /oauth/token/info (`scope`); PATs via
   // /api/v4/personal_access_tokens/self (`scopes`).
   const [url, field] =
     scheme === "bearer"
-      ? ([`${GITLAB_BASE}/oauth/token/info`, "scope"] as const)
-      : ([`${API_BASE}/personal_access_tokens/self`, "scopes"] as const)
+      ? ([`${base}/oauth/token/info`, "scope"] as const)
+      : ([`${base}/api/v4/personal_access_tokens/self`, "scopes"] as const)
   try {
     const resp = await fetch(url, { headers: authHeaders(token, scheme) })
     if (!resp.ok) return undefined
@@ -119,16 +128,20 @@ async function paginateAll<T>(
   return results
 }
 
-async function validateUserToken(token: string): Promise<GitLabTokenValidation> {
+async function validateUserToken(
+  token: string,
+  base: string = DEFAULT_GITLAB_BASE,
+): Promise<GitLabTokenValidation> {
+  const apiBase = `${base}/api/v4`
   // PATs authenticate via PRIVATE-TOKEN, but OAuth tokens are rejected by it
   // (401) and require Authorization: Bearer (which also accepts PATs). Retry
   // with Bearer only on 401 — a 403 means the token authenticated but lacks the
   // scope to read /user, which Bearer (same token, same scopes) can't fix.
   let scheme: AuthScheme = "private"
-  let resp = await fetch(`${API_BASE}/user`, { headers: authHeaders(token, scheme) })
+  let resp = await fetch(`${apiBase}/user`, { headers: authHeaders(token, scheme) })
   if (resp.status === 401) {
     scheme = "bearer"
-    resp = await fetch(`${API_BASE}/user`, { headers: authHeaders(token, scheme) })
+    resp = await fetch(`${apiBase}/user`, { headers: authHeaders(token, scheme) })
   }
   if (!resp.ok) {
     const body = await resp.text().catch(() => "")
@@ -141,7 +154,7 @@ async function validateUserToken(token: string): Promise<GitLabTokenValidation> 
     email?: string
   }
   // GET /user exposes no scopes; introspect them with the scheme that validated.
-  const scopes = await fetchScopes(token, scheme)
+  const scopes = await fetchScopes(token, scheme, base)
   return {
     user: {
       login: data.username,
@@ -154,9 +167,9 @@ async function validateUserToken(token: string): Promise<GitLabTokenValidation> 
 }
 
 const impl: GitLabClientShape = {
-  validateToken: (token: string) =>
+  validateToken: (token: string, host?: string) =>
     Effect.tryPromise({
-      try: (): Promise<GitLabTokenValidation> => validateUserToken(token),
+      try: (): Promise<GitLabTokenValidation> => validateUserToken(token, baseFor(host)),
       catch: (err) =>
         err instanceof GitLabApiError
           ? err
@@ -166,9 +179,10 @@ const impl: GitLabClientShape = {
   detectTokenType: (token: string): GitLabTokenType =>
     token.startsWith("glpat-") ? "pat" : "unknown",
 
-  createMergeRequest: (token: string, params: CreateMRParams) =>
+  createMergeRequest: (token: string, params: CreateMRParams, host?: string) =>
     Effect.tryPromise({
       try: async (): Promise<MergeRequestResult> => {
+        const apiBase = `${baseFor(host)}/api/v4`
         // `:id` is the URL-encoded full project path; encodeURIComponent turns
         // the slashes of a nested group path (group/subgroup/project) into %2F.
         const projectId = encodeURIComponent(`${params.owner}/${params.repo}`)
@@ -184,7 +198,7 @@ const impl: GitLabClientShape = {
           body.labels = params.labels.join(",")
         }
         const resp = await gitlabFetch(
-          `${API_BASE}/projects/${projectId}/merge_requests`,
+          `${apiBase}/projects/${projectId}/merge_requests`,
           token,
           {
             method: "POST",
@@ -211,12 +225,13 @@ const impl: GitLabClientShape = {
           : new GitLabApiError({ status: 0, message: `${err}` }),
     }),
 
-  listLabels: (token: string, owner: string, repo: string) =>
+  listLabels: (token: string, owner: string, repo: string, host?: string) =>
     Effect.tryPromise({
       try: async (): Promise<string[]> => {
+        const apiBase = `${baseFor(host)}/api/v4`
         const projectId = encodeURIComponent(`${owner}/${repo}`)
         const labels = await paginateAll<{ name: string }>(
-          `${API_BASE}/projects/${projectId}/labels?include_ancestor_groups=true`,
+          `${apiBase}/projects/${projectId}/labels?include_ancestor_groups=true`,
           token,
         )
         return labels.map((l) => l.name)

--- a/src/services/GitClient.ts
+++ b/src/services/GitClient.ts
@@ -44,6 +44,26 @@ export interface GitInfo {
   readonly commitSha?: string
 }
 
+/** A git author/committer identity (name + email). */
+export interface GitIdentity {
+  readonly name: string
+  readonly email: string
+}
+
+export interface CommitOptions {
+  readonly allowEmpty?: boolean
+  /**
+   * Fallback author identity, used ONLY when the repo can resolve no git
+   * identity of its own (no user.name/user.email in any config scope). This is
+   * what lets MR/PR creation succeed on a machine where the user never ran
+   * `git config` — the commit is attributed to the authenticated GitLab/GitHub
+   * user instead of failing with "author identity unknown". When the user HAS
+   * configured an identity (local or global), theirs is respected and this is
+   * ignored.
+   */
+  readonly author?: GitIdentity
+}
+
 export interface GitClientShape {
   readonly cloneSimple: (url: string, dest: string, options?: CloneOptions) => Effect.Effect<CloneResult, GitError>
   readonly push: (repoPath: string, remote: string, branch: string, options?: PushOptions) => Effect.Effect<void, GitError>
@@ -58,7 +78,7 @@ export interface GitClientShape {
   readonly checkIgnored: (repoPath: string, paths: string[]) => Effect.Effect<Set<string>, GitError>
   readonly createBranch: (repoPath: string, branch: string) => Effect.Effect<void, GitError>
   readonly stageAll: (repoPath: string, excludePaths?: string[]) => Effect.Effect<void, GitError>
-  readonly commit: (repoPath: string, message: string, allowEmpty?: boolean) => Effect.Effect<void, GitError>
+  readonly commit: (repoPath: string, message: string, options?: CommitOptions) => Effect.Effect<void, GitError>
 }
 
 export class GitClient extends Context.Tag("GitClient")<GitClient, GitClientShape>() {}

--- a/src/services/GitLabClient.ts
+++ b/src/services/GitLabClient.ts
@@ -52,10 +52,14 @@ export interface MergeRequestResult {
 }
 
 export interface GitLabClientShape {
-  readonly validateToken: (token: string) => Effect.Effect<GitLabTokenValidation, GitLabApiError>
+  /**
+   * Validate a token against `host`'s API (defaults to gitlab.com). `host` is a
+   * bare hostname (e.g. "gitlab.example.com"); the client builds `https://<host>`.
+   */
+  readonly validateToken: (token: string, host?: string) => Effect.Effect<GitLabTokenValidation, GitLabApiError>
   readonly detectTokenType: (token: string) => GitLabTokenType
-  readonly createMergeRequest: (token: string, params: CreateMRParams) => Effect.Effect<MergeRequestResult, GitLabApiError>
-  readonly listLabels: (token: string, owner: string, repo: string) => Effect.Effect<string[], GitLabApiError>
+  readonly createMergeRequest: (token: string, params: CreateMRParams, host?: string) => Effect.Effect<MergeRequestResult, GitLabApiError>
+  readonly listLabels: (token: string, owner: string, repo: string, host?: string) => Effect.Effect<string[], GitLabApiError>
 }
 
 export class GitLabClient extends Context.Tag("GitLabClient")<GitLabClient, GitLabClientShape>() {}

--- a/src/test-utils/TestLayer.ts
+++ b/src/test-utils/TestLayer.ts
@@ -114,7 +114,7 @@ const makeStubGitClient = (overrides: Partial<GitClientShape> = {}): GitClientSh
     Effect.fail(new GitError({ command: "checkout -b", stderr: notConfigured("GitClient", "createBranch"), exitCode: 1 })),
   stageAll: (_repoPath) =>
     Effect.fail(new GitError({ command: "add", stderr: notConfigured("GitClient", "stageAll"), exitCode: 1 })),
-  commit: (_repoPath, _message, _allowEmpty) =>
+  commit: (_repoPath, _message, _options) =>
     Effect.fail(new GitError({ command: "commit", stderr: notConfigured("GitClient", "commit"), exitCode: 1 })),
   ...overrides,
 })

--- a/web/src/components/mdx/GitAuth/GitAuth.tsx
+++ b/web/src/components/mdx/GitAuth/GitAuth.tsx
@@ -18,6 +18,7 @@ import { PROVIDERS } from "./providers"
 import { useGitAuth } from "./hooks/useGitAuth"
 import { getStatusClasses, getStatusIcon, getStatusIconClasses } from "./utils"
 import { ProviderSelect } from "./components/ProviderSelect"
+import { HostSelect } from "./components/HostSelect"
 import { AuthTabs } from "./components/AuthTabs"
 import { AuthSuccess } from "./components/AuthSuccess"
 import { PatForm } from "./components/PatForm"
@@ -36,6 +37,7 @@ function GitAuthInteractive({
   oauthClientId,
   oauthScopes,
   detectCredentials,
+  host,
   inputsId,
   __registryType = 'GitAuth',
 }: GitAuthInternalProps) {
@@ -82,6 +84,7 @@ function GitAuthInteractive({
     oauthClientId: useDefaultOAuth ? undefined : oauthClientId,
     oauthScopes: effectiveOAuthScopes,
     detectCredentials,
+    host,
   })
 
   // Switch providers: cancel any in-flight OAuth poll, drop the prior
@@ -194,6 +197,21 @@ function GitAuthInteractive({
             <ProviderSelect provider={provider} onSelect={handleSelectProvider} />
           )}
 
+          {/* GitLab host picker + config reload. Auto-detection lands on glab's
+              default host first, so the switcher stays visible after
+              authenticating whenever more than one host is available — that's
+              how the user moves from gitlab.com to a self-managed instance. */}
+          {providerConfig.supportsHostSelection &&
+            ((auth.availableHosts?.length ?? 0) > 1 || auth.authStatus !== 'authenticated') && (
+            <HostSelect
+              hosts={auth.availableHosts}
+              value={auth.selectedHost}
+              onChange={auth.changeHost}
+              onReload={auth.reloadDetection}
+              disabled={auth.detectionStatus === 'pending'}
+            />
+          )}
+
           {/* Detection pending state - waiting for block or checking credentials */}
           {auth.detectionStatus === 'pending' && (
             <div className="mb-4 text-info text-sm flex items-center gap-2">
@@ -216,6 +234,7 @@ function GitAuthInteractive({
               detectedTokenType={auth.detectedTokenType}
               scopeWarning={auth.scopeWarning}
               sessionEnvWarning={auth.sessionEnvWarning}
+              host={auth.selectedHost}
               onReAuthenticate={auth.resetAuth}
             />
           )}

--- a/web/src/components/mdx/GitAuth/GitAuth.tsx
+++ b/web/src/components/mdx/GitAuth/GitAuth.tsx
@@ -203,9 +203,10 @@ function GitAuthInteractive({
               default host first, so the switcher stays visible after
               authenticating whenever more than one host is available — that's
               how the user moves from gitlab.com to a self-managed instance. */}
-          {providerConfig.supportsHostSelection &&
+          {auth.hostSelectable &&
             ((auth.availableHosts?.length ?? 0) > 1 || auth.authStatus !== 'authenticated') && (
             <HostSelect
+              id={id}
               hosts={auth.availableHosts}
               value={auth.selectedHost}
               onChange={auth.changeHost}

--- a/web/src/components/mdx/GitAuth/__tests__/GitAuth.switch.test.tsx
+++ b/web/src/components/mdx/GitAuth/__tests__/GitAuth.switch.test.tsx
@@ -50,6 +50,56 @@ describe('GitAuth — provider switch (real hook)', () => {
     expect(screen.queryByText(/redirected to authorize/i)).toBeNull()
   })
 
+  it('keeps the host switcher visible after auto-authenticating, so you can move to a self-managed host', async () => {
+    // Reproduces the reported issue: auto-detection lands on glab's default host
+    // (gitlab.com), and the user still needs to reach their private instance.
+    const invoke = vi.fn(async (channel: string, args?: { host?: string }) => {
+      if (channel === 'gitlab:enumerate-hosts') {
+        return { hosts: ['gitlab.com', 'gitlab.gruntwork.io'], defaultHost: 'gitlab.com' }
+      }
+      if (channel === 'gitlab:env-credentials') return { found: false }
+      if (channel === 'gitlab:cli-credentials') {
+        const host = args?.host
+        return {
+          found: true,
+          user: { login: host === 'gitlab.gruntwork.io' ? 'root' : 'odgrim' },
+          host,
+        }
+      }
+      if (channel === 'session:set-env') return { ok: true }
+      return {}
+    })
+    window.api = {
+      invoke,
+      on: vi.fn(() => () => {}),
+      once: vi.fn(),
+    } as unknown as typeof window.api
+
+    render(
+      <TestWrapper>
+        <GitAuth id="git" provider="gitlab" />
+      </TestWrapper>,
+    )
+
+    // Auto-detects against glab's default host first.
+    await waitFor(() => {
+      expect(screen.getByText(/Authenticated to GitLab \(gitlab\.com\)/i)).toBeInTheDocument()
+    })
+
+    // The host switcher must still be on screen (it was previously hidden once
+    // authenticated), offering the private instance.
+    const select = screen.getByRole('combobox')
+    expect(screen.getByRole('option', { name: 'gitlab.gruntwork.io' })).toBeInTheDocument()
+
+    // Switching hosts re-detects against the chosen instance.
+    fireEvent.change(select, { target: { value: 'gitlab.gruntwork.io' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Authenticated to GitLab \(gitlab\.gruntwork\.io\)/i)).toBeInTheDocument()
+    })
+    expect(invoke).toHaveBeenCalledWith('gitlab:cli-credentials', { host: 'gitlab.gruntwork.io' })
+  })
+
   it('GitLab→GitHub switch restores the GitHub OAuth flow', async () => {
     render(
       <TestWrapper>

--- a/web/src/components/mdx/GitAuth/components/AuthSuccess.tsx
+++ b/web/src/components/mdx/GitAuth/components/AuthSuccess.tsx
@@ -12,6 +12,8 @@ interface AuthSuccessProps {
   detectedTokenType?: GitTokenType | null
   scopeWarning?: string | null
   sessionEnvWarning?: string | null
+  /** The host authenticated against (GitLab); shown so multi-host users see which instance. */
+  host?: string
   onReAuthenticate?: () => void
 }
 
@@ -39,8 +41,13 @@ export function AuthSuccess({
   detectedTokenType,
   scopeWarning,
   sessionEnvWarning,
+  host,
   onReAuthenticate,
 }: AuthSuccessProps) {
+  // For multi-host providers (GitLab), name the instance the token belongs to so
+  // a user logged into several hosts can tell gitlab.com from a self-managed one.
+  const authTarget =
+    provider.supportsHostSelection && host ? `${provider.label} (${host})` : provider.label
   const [showPermissions, setShowPermissions] = useState(false)
   // Avatars are hot-linked, so a CSP-blocked host (e.g. a self-hosted GitLab
   // instance, or a Gravatar host not in img-src) makes the <img> fire `error`
@@ -115,7 +122,7 @@ export function AuthSuccess({
   return (
     <div className="mb-4">
       <div className="text-success font-semibold text-sm mb-2 flex items-center gap-2">
-        <span>✓ Authenticated to {provider.label}</span>
+        <span>✓ Authenticated to {authTarget}</span>
         {detectionSource && (
           <span className="text-xs bg-info-muted text-info px-2 py-0.5 rounded font-normal">
             {detectionSource === 'env' && 'From Environment'}

--- a/web/src/components/mdx/GitAuth/components/HostSelect.tsx
+++ b/web/src/components/mdx/GitAuth/components/HostSelect.tsx
@@ -1,0 +1,59 @@
+import { RefreshCw } from "lucide-react"
+
+interface HostSelectProps {
+  /** All GitLab hosts the user is logged into via glab. */
+  hosts: string[]
+  /** The currently selected host. */
+  value: string
+  /** Called when the user picks a different host. */
+  onChange: (host: string) => void
+  /** Re-read glab's config and re-run detection. */
+  onReload: () => void
+  /** Disable controls while a check is in flight. */
+  disabled?: boolean
+}
+
+/**
+ * GitLab host picker. Shows a dropdown only when the user is logged into more
+ * than one instance (e.g. gitlab.com and a self-managed host); otherwise it just
+ * surfaces a "Reload" control so the user can re-check after a `glab auth login`.
+ * The parent hides this entirely for GitHub or when the author pinned a `host`.
+ */
+export function HostSelect({ hosts = [], value, onChange, onReload, disabled }: HostSelectProps) {
+  const hasChoice = hosts.length > 1
+
+  return (
+    <div className="mb-4 flex items-center gap-2 text-sm">
+      {hasChoice && (
+        <>
+          <label htmlFor="gitlab-host" className="text-muted-foreground">
+            GitLab host:
+          </label>
+          <select
+            id="gitlab-host"
+            value={value}
+            disabled={disabled}
+            onChange={(e) => onChange(e.target.value)}
+            className="rounded border border-border bg-background px-2 py-1 text-foreground disabled:opacity-50"
+          >
+            {hosts.map((h) => (
+              <option key={h} value={h}>
+                {h}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
+      <button
+        type="button"
+        onClick={onReload}
+        disabled={disabled}
+        title="Re-read glab config and re-check credentials"
+        className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 cursor-pointer"
+      >
+        <RefreshCw className={`size-3.5 ${disabled ? 'animate-spin' : ''}`} />
+        Reload
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/mdx/GitAuth/components/HostSelect.tsx
+++ b/web/src/components/mdx/GitAuth/components/HostSelect.tsx
@@ -1,6 +1,8 @@
 import { RefreshCw } from "lucide-react"
 
 interface HostSelectProps {
+  /** Owning block id, used to derive a unique DOM id for the select. */
+  id: string
   /** All GitLab hosts the user is logged into via glab. */
   hosts: string[]
   /** The currently selected host. */
@@ -19,18 +21,21 @@ interface HostSelectProps {
  * surfaces a "Reload" control so the user can re-check after a `glab auth login`.
  * The parent hides this entirely for GitHub or when the author pinned a `host`.
  */
-export function HostSelect({ hosts = [], value, onChange, onReload, disabled }: HostSelectProps) {
+export function HostSelect({ id, hosts = [], value, onChange, onReload, disabled }: HostSelectProps) {
   const hasChoice = hosts.length > 1
+  // Unique per block so two GitLab GitAuth blocks on one page don't emit
+  // duplicate DOM ids (which break label association and are invalid HTML).
+  const selectId = `gitlab-host-${id}`
 
   return (
     <div className="mb-4 flex items-center gap-2 text-sm">
       {hasChoice && (
         <>
-          <label htmlFor="gitlab-host" className="text-muted-foreground">
+          <label htmlFor={selectId} className="text-muted-foreground">
             GitLab host:
           </label>
           <select
-            id="gitlab-host"
+            id={selectId}
             value={value}
             disabled={disabled}
             onChange={(e) => onChange(e.target.value)}

--- a/web/src/components/mdx/GitAuth/hooks/__tests__/useGitAuth.test.ts
+++ b/web/src/components/mdx/GitAuth/hooks/__tests__/useGitAuth.test.ts
@@ -76,7 +76,8 @@ describe('useGitAuth — GitLab provider', () => {
       await result.current.handlePatSubmit()
     })
 
-    expect(invoke).toHaveBeenCalledWith('gitlab:validate', { token: 'glpat-abc' })
+    // Validation targets the selected host (gitlab.com by default).
+    expect(invoke).toHaveBeenCalledWith('gitlab:validate', { token: 'glpat-abc', host: 'gitlab.com' })
     // GIT_PROVIDER is registered as a block output so downstream PR/MR blocks can
     // derive the linked instance...
     expect(registerOutputs).toHaveBeenCalledWith('git', {
@@ -85,8 +86,9 @@ describe('useGitAuth — GitLab provider', () => {
       GIT_PROVIDER: 'gitlab',
     })
     // ...but it is NOT written to the session env (it's metadata, not a credential).
+    // The credential is paired with GITLAB_HOST so git/API ops target the right instance.
     expect(invoke).toHaveBeenCalledWith('session:set-env', {
-      env: { GITLAB_TOKEN: 'glpat-abc', GITLAB_USER: 'tanuki' },
+      env: { GITLAB_TOKEN: 'glpat-abc', GITLAB_USER: 'tanuki', GITLAB_HOST: 'gitlab.com' },
     })
     expect(result.current.authStatus).toBe('authenticated')
     // No scopes returned (introspection unavailable) → no claim about missing scopes.
@@ -184,6 +186,82 @@ describe('useGitAuth — GitLab provider', () => {
       expect(result.current.detectionWarning).toContain('GITLAB_TOKEN')
     })
     expect(result.current.detectionWarning).not.toContain('GITHUB_TOKEN')
+  })
+
+  it('enumerates glab hosts and detects against glab\'s default host', async () => {
+    const invoke = installApi(async (channel, args) => {
+      if (channel === 'gitlab:enumerate-hosts') {
+        return { hosts: ['gitlab.com', 'gitlab.gruntwork.io'], defaultHost: 'gitlab.gruntwork.io' }
+      }
+      if (channel === 'gitlab:env-credentials') return { found: false }
+      if (channel === 'gitlab:cli-credentials') {
+        const host = (args as { host?: string }).host
+        return host === 'gitlab.gruntwork.io'
+          ? { found: true, user: { login: 'root' }, scopes: ['api'], host }
+          : { found: false }
+      }
+      if (channel === 'session:set-env') return { ok: true }
+      return {}
+    })
+
+    const { result } = renderHook(() => useGitAuth({ id: 'git', provider: PROVIDERS.gitlab }))
+
+    await waitFor(() => expect(result.current.authStatus).toBe('authenticated'))
+    expect(result.current.availableHosts).toEqual(['gitlab.com', 'gitlab.gruntwork.io'])
+    expect(result.current.selectedHost).toBe('gitlab.gruntwork.io')
+    // Detection targeted the self-managed default host, not gitlab.com.
+    expect(invoke).toHaveBeenCalledWith('gitlab:cli-credentials', { host: 'gitlab.gruntwork.io' })
+  })
+
+  it('changeHost re-runs detection against the newly selected host', async () => {
+    const invoke = installApi(async (channel, args) => {
+      if (channel === 'gitlab:enumerate-hosts') {
+        return { hosts: ['gitlab.com', 'gitlab.gruntwork.io'], defaultHost: 'gitlab.com' }
+      }
+      if (channel === 'gitlab:env-credentials') return { found: false }
+      if (channel === 'gitlab:cli-credentials') {
+        const host = (args as { host?: string }).host
+        return host === 'gitlab.gruntwork.io'
+          ? { found: true, user: { login: 'root' }, host }
+          : { found: false }
+      }
+      if (channel === 'session:set-env') return { ok: true }
+      return {}
+    })
+
+    const { result } = renderHook(() => useGitAuth({ id: 'git', provider: PROVIDERS.gitlab }))
+
+    // Initial detection targets glab's default (gitlab.com) and finds nothing.
+    await waitFor(() => expect(result.current.detectionStatus).toBe('done'))
+    expect(result.current.authStatus).not.toBe('authenticated')
+
+    await act(async () => {
+      result.current.changeHost('gitlab.gruntwork.io')
+    })
+
+    await waitFor(() => expect(result.current.authStatus).toBe('authenticated'))
+    expect(invoke).toHaveBeenCalledWith('gitlab:cli-credentials', { host: 'gitlab.gruntwork.io' })
+  })
+
+  it('flags a found-but-invalid CLI token even when the error is a bare 401', async () => {
+    // Regression for the silent-failure bug: an expired OAuth token validates as
+    // "401 Unauthorized" (no "invalid"/"expired" keyword), so detection must rely
+    // on `found`/`status` to surface it instead of looking like "no credentials".
+    installApi(async (channel) => {
+      if (channel === 'gitlab:enumerate-hosts') return { hosts: ['gitlab.com'], defaultHost: 'gitlab.com' }
+      if (channel === 'gitlab:env-credentials') return { found: false }
+      if (channel === 'gitlab:cli-credentials') {
+        return { found: true, error: '401 Unauthorized', status: 401, host: 'gitlab.com' }
+      }
+      return {}
+    })
+
+    const { result } = renderHook(() => useGitAuth({ id: 'git', provider: PROVIDERS.gitlab }))
+
+    await waitFor(() => expect(result.current.detectionStatus).toBe('done'))
+    expect(result.current.authStatus).not.toBe('authenticated')
+    expect(result.current.detectionWarning).toContain('glab CLI')
+    expect(result.current.detectionWarning).toContain('gitlab.com')
   })
 })
 

--- a/web/src/components/mdx/GitAuth/hooks/__tests__/useGitAuth.test.ts
+++ b/web/src/components/mdx/GitAuth/hooks/__tests__/useGitAuth.test.ts
@@ -124,6 +124,38 @@ describe('useGitAuth — GitLab provider', () => {
     })
   })
 
+  it('pairs the PAT with the entered instance host (not the default) in session env and banner', async () => {
+    // Regression for the token<->host mismatch: when a self-managed instance URL
+    // is supplied, GITLAB_HOST in the session env and the success banner must
+    // match that instance — not the picker's gitlab.com default.
+    const invoke = installApi(async (channel) => {
+      if (channel === 'gitlab:validate') {
+        return { valid: true, user: { login: 'tanuki' }, tokenType: 'pat' }
+      }
+      if (channel === 'session:set-env') return { ok: true }
+      return { found: false }
+    })
+
+    const { result } = renderHook(() =>
+      useGitAuth({
+        id: 'git',
+        provider: PROVIDERS.gitlab,
+        instanceUrl: 'https://gitlab.acme.com',
+        detectCredentials: false,
+      }),
+    )
+
+    act(() => result.current.setPatToken('glpat-abc'))
+    await act(async () => {
+      await result.current.handlePatSubmit()
+    })
+
+    expect(invoke).toHaveBeenCalledWith('session:set-env', {
+      env: { GITLAB_TOKEN: 'glpat-abc', GITLAB_USER: 'tanuki', GITLAB_HOST: 'gitlab.acme.com' },
+    })
+    expect(result.current.selectedHost).toBe('gitlab.acme.com')
+  })
+
   it('a runtime instance-URL edit overrides the seeded prop on validate', async () => {
     const invoke = installApi(async (channel) => {
       if (channel === 'gitlab:validate') {

--- a/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
+++ b/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
@@ -25,7 +25,11 @@ interface UseGitAuthOptions {
   oauthClientId?: string
   oauthScopes?: string[]
   detectCredentials?: false | GitCredentialSource[]
+  /** GitLab only: an authored host that pins the instance and hides the picker. */
+  host?: string
 }
+
+const DEFAULT_GITLAB_HOST = 'gitlab.com'
 
 export function useGitAuth({
   id,
@@ -33,6 +37,7 @@ export function useGitAuth({
   oauthClientId,
   oauthScopes = ['repo'],
   detectCredentials = ['env', 'cli'],
+  host,
 }: UseGitAuthOptions) {
   const { registerOutputs, blockOutputs } = useRunbookContext()
   const { isReady: sessionReady } = useSession()
@@ -57,6 +62,29 @@ export function useGitAuth({
   const [detectionWarning, setDetectionWarning] = useState<string | null>(null)
   const [sessionEnvWarning, setSessionEnvWarning] = useState<string | null>(null)
   const detectionAttemptedRef = useRef(false)
+
+  // ---------------------------------------------------------------------------
+  // Host selection (GitLab can be logged into several instances via glab).
+  // For providers without host selection (GitHub) or when the author pinned a
+  // `host`, there is nothing to enumerate and we are "ready" immediately.
+  // ---------------------------------------------------------------------------
+  const hostSelectable = Boolean(provider.supportsHostSelection && !host)
+  const [availableHosts, setAvailableHosts] = useState<string[]>(host ? [host] : [])
+  const [selectedHost, setSelectedHost] = useState<string>(host ?? DEFAULT_GITLAB_HOST)
+  const [hostsReady, setHostsReady] = useState<boolean>(!hostSelectable)
+  // Bumped to force the detection effect to re-run (host change / manual reload).
+  const [detectionNonce, setDetectionNonce] = useState(0)
+  // Bumped to force re-enumeration of glab hosts (manual "reload config").
+  const [hostsReloadNonce, setHostsReloadNonce] = useState(0)
+  // True once the user explicitly picks a host, so a config reload preserves it
+  // instead of snapping back to glab's default.
+  const userPickedHostRef = useRef(false)
+
+  // The host threaded into provider IPC calls. Held in a ref so the credential
+  // callbacks don't need it as a dependency (which would churn the detect loop).
+  const effectiveHost = provider.supportsHostSelection ? (host ?? selectedHost) : undefined
+  const effectiveHostRef = useRef<string | undefined>(effectiveHost)
+  effectiveHostRef.current = effectiveHost
 
   // For block-based detection, track which block we're waiting for
   const [waitingForBlockId, setWaitingForBlockId] = useState<string | null>(null)
@@ -121,9 +149,16 @@ export function useGitAuth({
     // metadata, not a credential, and nothing shell-side consumes it.
     registerOutputs(id, { ...outputs, GIT_PROVIDER: provider.id })
 
+    // Pair the token with the GitLab host it belongs to, so server-side git/API
+    // operations target the right instance (e.g. a manually-pasted PAT for a
+    // self-managed host). Omitted for providers without host selection (GitHub).
+    const sessionEnv = effectiveHostRef.current
+      ? { ...outputs, GITLAB_HOST: effectiveHostRef.current }
+      : outputs
+
     // Also set in session environment for blocks that don't reference this block
     try {
-      await window.api.invoke('session:set-env', { env: outputs })
+      await window.api.invoke('session:set-env', { env: sessionEnv })
       setSessionEnvWarning(null)
       return { authenticated: true, sessionEnvSynced: true }
     } catch (error) {
@@ -145,7 +180,7 @@ export function useGitAuth({
   // Validate a token via the provider's API
   const validateToken = useCallback(async (token: string): Promise<{ valid: boolean; user?: GitUserInfo; scopes?: string[]; tokenType?: GitTokenType; error?: string }> => {
     try {
-      const data = await window.api.invoke(provider.channels.validate, { token })
+      const data = await window.api.invoke(provider.channels.validate, { token, host: effectiveHostRef.current })
       return {
         valid: data.valid,
         user: data.user as GitUserInfo | undefined,
@@ -168,6 +203,7 @@ export function useGitAuth({
         envVar: '',
         prefix: options?.prefix || '',
         githubAuthId: id,
+        host: effectiveHostRef.current,
       })
 
       if (!data.found) {
@@ -186,18 +222,28 @@ export function useGitAuth({
   }, [id, provider])
 
   // Try to detect credentials from the provider's CLI
-  const tryCliCredentials = useCallback(async (): Promise<{ success: boolean; user?: GitUserInfo; scopes?: string[]; error?: string; foundButInvalid?: boolean }> => {
+  const tryCliCredentials = useCallback(async (): Promise<{ success: boolean; user?: GitUserInfo; scopes?: string[]; error?: string; foundButInvalid?: boolean; host?: string }> => {
     try {
-      const data = await window.api.invoke(provider.channels.cliCredentials, {} as Record<string, never>) as unknown as GitCliCredentialsResponse
+      const data = await window.api.invoke(provider.channels.cliCredentials, { host: effectiveHostRef.current }) as unknown as GitCliCredentialsResponse
 
       if (!isCliAuthFound(data)) {
-        // Check if token was found but invalid (error contains "invalid")
-        const foundButInvalid = data.error?.toLowerCase().includes('invalid') ||
-                                data.error?.toLowerCase().includes('expired')
-        return { success: false, error: data.error, foundButInvalid }
+        // A token WAS found but did not validate (expired OAuth token, wrong
+        // host, etc.). The backend signals this with `found: true` and/or an
+        // HTTP status; rely on those rather than fragile error-string matching
+        // (a GitLab 401 body reads "401 Unauthorized", not "invalid"/"expired").
+        const error = data.error?.toLowerCase()
+        const foundButInvalid =
+          data.found === true ||
+          data.status === 401 ||
+          data.status === 403 ||
+          error?.includes('invalid') ||
+          error?.includes('expired') ||
+          error?.includes('unauthorized') ||
+          error?.includes('forbidden')
+        return { success: false, error: data.error, foundButInvalid, host: data.host }
       }
 
-      return { success: true, user: data.user, scopes: data.scopes }
+      return { success: true, user: data.user, scopes: data.scopes, host: data.host }
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to check CLI credentials' }
     }
@@ -223,6 +269,48 @@ export function useGitAuth({
     return { success: true, user: validation.user }
   }, [getBlockCredentials, validateToken, registerCredentials])
 
+  // Discover which GitLab hosts the user is logged into via glab, to drive the
+  // host picker. Skipped for GitHub and when the author pinned a `host`. Re-runs
+  // on a manual config reload (hostsReloadNonce).
+  useEffect(() => {
+    if (!hostSelectable || !provider.channels.enumerateHosts) {
+      setAvailableHosts(host ? [host] : [])
+      setSelectedHost(host ?? DEFAULT_GITLAB_HOST)
+      setHostsReady(true)
+      return
+    }
+    if (!sessionReady) return
+
+    let cancelled = false
+    setHostsReady(false)
+    const channel = provider.channels.enumerateHosts
+    void (async () => {
+      try {
+        const data = await window.api.invoke(channel, {})
+        if (cancelled) return
+        const hosts = data.hosts ?? []
+        setAvailableHosts(hosts)
+        // Honor glab's default on first load; preserve a user's explicit pick
+        // (if still present) across a config reload.
+        setSelectedHost((prev) =>
+          userPickedHostRef.current && hosts.includes(prev)
+            ? prev
+            : (data.defaultHost || hosts[0] || DEFAULT_GITLAB_HOST),
+        )
+      } catch {
+        if (!cancelled) {
+          setAvailableHosts([])
+          setSelectedHost(DEFAULT_GITLAB_HOST)
+        }
+      } finally {
+        if (!cancelled) setHostsReady(true)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [hostSelectable, provider, host, sessionReady, hostsReloadNonce])
+
   // Run credential detection when session is ready
   useEffect(() => {
     // Skip if detection is disabled or already attempted
@@ -232,6 +320,12 @@ export function useGitAuth({
 
     // Wait for session to be ready before making API calls
     if (!sessionReady) {
+      return
+    }
+
+    // Wait until the available hosts are known so detection targets the right
+    // GitLab instance instead of the gitlab.com default.
+    if (!hostsReady) {
       return
     }
 
@@ -306,7 +400,8 @@ export function useGitAuth({
             return
           }
           if (result.foundButInvalid) {
-            warnings.push(`${provider.cli.label} token is invalid or expired`)
+            const where = result.host ? ` for ${result.host}` : ''
+            warnings.push(`${provider.cli.label} token${where} is invalid or expired`)
           }
         }
         // Check for { block: 'id' } - block outputs
@@ -340,7 +435,7 @@ export function useGitAuth({
     }
 
     runDetection()
-  }, [detectCredentials, id, provider, sessionReady, shouldWarnMissingScope, tryEnvCredentials, tryCliCredentials, tryBlockCredentials, getBlockCredentials, registerOutputs])
+  }, [detectCredentials, id, provider, sessionReady, hostsReady, detectionNonce, shouldWarnMissingScope, tryEnvCredentials, tryCliCredentials, tryBlockCredentials, getBlockCredentials, registerOutputs])
 
   // Watch for block outputs when waiting for a block
   useEffect(() => {
@@ -552,6 +647,38 @@ export function useGitAuth({
     setDetectionStatus(detectCredentials === false ? 'done' : 'pending')
   }, [detectCredentials])
 
+  // Clear transient auth/detection state and arm the detection effect to fire
+  // again. Shared by host switching and the manual config reload.
+  const beginRedetect = useCallback(() => {
+    detectionAttemptedRef.current = false
+    setAuthStatus('pending')
+    setUserInfo(null)
+    setDetectionSource(null)
+    setDetectedScopes(null)
+    setDetectedTokenType(null)
+    setScopeWarning(null)
+    setDetectionWarning(null)
+    setWaitingForBlockId(null)
+    setDetectionStatus(detectCredentials === false ? 'done' : 'pending')
+  }, [detectCredentials])
+
+  // Switch the selected GitLab host and re-detect against it.
+  const changeHost = useCallback((nextHost: string) => {
+    if (nextHost === selectedHost) return
+    userPickedHostRef.current = true
+    setSelectedHost(nextHost)
+    beginRedetect()
+    setDetectionNonce((n) => n + 1)
+  }, [selectedHost, beginRedetect])
+
+  // Re-read glab's config (hosts may have changed after a `glab auth login`) and
+  // re-run detection for the current host. Backs the "Reload" button.
+  const reloadDetection = useCallback(() => {
+    beginRedetect()
+    setHostsReloadNonce((n) => n + 1)
+    setDetectionNonce((n) => n + 1)
+  }, [beginRedetect])
+
   return {
     // Auth state
     authMethod,
@@ -570,6 +697,13 @@ export function useGitAuth({
     sessionEnvWarning,
     waitingForBlockId,
     detectionAttemptedRef,
+
+    // Host selection (GitLab)
+    hostSelectable,
+    availableHosts,
+    selectedHost: effectiveHost ?? selectedHost,
+    changeHost,
+    reloadDetection,
 
     // PAT form
     patToken,

--- a/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
+++ b/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
@@ -33,6 +33,24 @@ interface UseGitAuthOptions {
 
 const DEFAULT_GITLAB_HOST = 'gitlab.com'
 
+/**
+ * Extract the bare host from a user-entered GitLab instance URL (bare host or
+ * full URL, scheme optional). Returns undefined for unparseable input so the
+ * caller can fall back to the picked/default host. Keeps the renderer's notion
+ * of "which instance" in sync with the URL the token is actually validated
+ * against on the backend (which normalizes the same way).
+ */
+function hostFromInstanceUrl(raw: string): string | undefined {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  try {
+    return new URL(withScheme).host || undefined
+  } catch {
+    return undefined
+  }
+}
+
 export function useGitAuth({
   id,
   provider,
@@ -83,12 +101,6 @@ export function useGitAuth({
   // instead of snapping back to glab's default.
   const userPickedHostRef = useRef(false)
 
-  // The host threaded into provider IPC calls. Held in a ref so the credential
-  // callbacks don't need it as a dependency (which would churn the detect loop).
-  const effectiveHost = provider.supportsHostSelection ? (host ?? selectedHost) : undefined
-  const effectiveHostRef = useRef<string | undefined>(effectiveHost)
-  effectiveHostRef.current = effectiveHost
-
   // For block-based detection, track which block we're waiting for
   const [waitingForBlockId, setWaitingForBlockId] = useState<string | null>(null)
 
@@ -106,6 +118,17 @@ export function useGitAuth({
   const instanceUrlForIpc = provider.id === 'gitlab' && gitlabInstanceUrl.trim()
     ? gitlabInstanceUrl.trim()
     : undefined
+
+  // The host threaded into provider IPC calls. Held in a ref so the credential
+  // callbacks don't need it as a dependency (which would churn the detect loop).
+  // A manually-entered instance URL wins over the picked/authored host (matching
+  // the backend's `instanceUrl ?? host` rule), so the session GITLAB_HOST and the
+  // success banner agree with the instance the token was validated against.
+  const effectiveHost = provider.supportsHostSelection
+    ? ((instanceUrlForIpc ? hostFromInstanceUrl(instanceUrlForIpc) : undefined) ?? host ?? selectedHost)
+    : undefined
+  const effectiveHostRef = useRef<string | undefined>(effectiveHost)
+  effectiveHostRef.current = effectiveHost
 
   // OAuth state
   const [oauthUserCode, setOauthUserCode] = useState<string | null>(null)
@@ -700,10 +723,16 @@ export function useGitAuth({
 
   // Re-read glab's config (hosts may have changed after a `glab auth login`) and
   // re-run detection for the current host. Backs the "Reload" button.
+  //
+  // Only bump hostsReloadNonce — NOT detectionNonce. Re-enumeration flips
+  // hostsReady false→true, and that transition (with detectionAttemptedRef
+  // already cleared by beginRedetect) drives a single detection against the
+  // freshly-resolved host. Bumping detectionNonce too would fire detection
+  // immediately against the *pre-reload* host and then lock detectionAttemptedRef,
+  // so a changed glab default would never be re-detected.
   const reloadDetection = useCallback(() => {
     beginRedetect()
     setHostsReloadNonce((n) => n + 1)
-    setDetectionNonce((n) => n + 1)
   }, [beginRedetect])
 
   return {

--- a/web/src/components/mdx/GitAuth/providers/gitlab.ts
+++ b/web/src/components/mdx/GitAuth/providers/gitlab.ts
@@ -26,7 +26,10 @@ export const gitlabProviderConfig: ProviderConfig = {
     validate: 'gitlab:validate',
     envCredentials: 'gitlab:env-credentials',
     cliCredentials: 'gitlab:cli-credentials',
+    enumerateHosts: 'gitlab:enumerate-hosts',
   },
+  // GitLab users can be logged into gitlab.com and/or self-managed instances.
+  supportsHostSelection: true,
   env: {
     tokenVar: 'GITLAB_TOKEN',
     userVar: 'GITLAB_USER',

--- a/web/src/components/mdx/GitAuth/providers/index.ts
+++ b/web/src/components/mdx/GitAuth/providers/index.ts
@@ -30,7 +30,14 @@ export interface ProviderConfig {
     validate: 'github:validate' | 'gitlab:validate'
     envCredentials: 'github:env-credentials' | 'gitlab:env-credentials'
     cliCredentials: 'github:cli-credentials' | 'gitlab:cli-credentials'
+    /** Enumerate available hosts for the host picker (GitLab only). */
+    enumerateHosts?: 'gitlab:enumerate-hosts'
   }
+  /**
+   * Whether this provider supports choosing among multiple hosts/instances
+   * (GitLab self-managed vs gitlab.com). GitHub is single-host here, so false.
+   */
+  supportsHostSelection?: boolean
   /** Session/output env var names this provider writes. */
   env: {
     tokenVar: 'GITHUB_TOKEN' | 'GITLAB_TOKEN'

--- a/web/src/components/mdx/GitAuth/types.ts
+++ b/web/src/components/mdx/GitAuth/types.ts
@@ -54,6 +54,13 @@ export interface GitAuthProps {
   oauthScopes?: string[]
   /** Credential detection configuration (default: ['env', 'cli']). */
   detectCredentials?: false | GitCredentialSource[]
+  /**
+   * GitLab only: pin the GitLab instance to authenticate against (e.g.
+   * "gitlab.gruntwork.io"). When set, the host picker is hidden and detection
+   * targets this host. When omitted, the block enumerates the hosts the user is
+   * logged into via glab and shows a picker if there is more than one.
+   */
+  host?: string
   /** Reference to one or more Inputs by ID for template expressions in props */
   inputsId?: string | string[]
 }
@@ -92,9 +99,17 @@ export interface GitEnvCredentialsResponse {
 }
 
 export interface GitCliCredentialsResponse {
+  found?: boolean
+  valid?: boolean
+  token?: string
   user?: GitUserInfo
   scopes?: string[]
+  tokenType?: GitTokenType
   error?: string
+  /** HTTP status when validation failed (e.g. 401/403) — used to flag found-but-invalid. */
+  status?: number
+  /** The GitLab host this credential was detected/validated against. */
+  host?: string
 }
 
 // Helper functions for CLI credentials response

--- a/web/src/components/mdx/GitAuth/types.ts
+++ b/web/src/components/mdx/GitAuth/types.ts
@@ -93,6 +93,8 @@ export interface GitValidateResponse {
   scopes?: string[]
   tokenType?: GitTokenType
   error?: string
+  /** HTTP status when validation failed (e.g. 401/403). */
+  status?: number
 }
 
 export interface GitEnvCredentialsResponse {
@@ -102,6 +104,10 @@ export interface GitEnvCredentialsResponse {
   scopes?: string[]
   tokenType?: GitTokenType
   error?: string
+  /** HTTP status when validation failed (e.g. 401/403). */
+  status?: number
+  /** The GitLab host this credential was detected/validated against. */
+  host?: string
 }
 
 export interface GitCliCredentialsResponse {


### PR DESCRIPTION
…n glab config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-host GitLab support: enumerate hosts, host-aware validation, and session env now includes selected instance.
  * UI host selection: host dropdown, host-aware auth flow, and success messages showing the target instance.
  * PR/MR commits can use resolved provider identity when local git identity is missing.

* **Bug Fixes**
  * Git error messages no longer prepend a hardcoded "git " prefix; command text preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->