### PR TITLE
feat: markdown checkboxes can be introduced

### DIFF
--- a/web/src/components/MDXContainer.tasklist.test.tsx
+++ b/web/src/components/MDXContainer.tasklist.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, waitFor, fireEvent } from '@testing-library/react'
+import { TestWrapper } from '@/test/test-utils'
+import MDXContainer from './MDXContainer'
+
+const TASK_MD = `# Tasks
+
+- [x] First task
+- [ ] Second task
+`
+
+// runbookPath's last segment ("tasklist") becomes the runbook name, which scopes
+// the persisted checkbox keys: task-checkbox:tasklist:<slug>.
+function renderRunbook(content = TASK_MD, runbookPath = 'testdata/demo/tasklist') {
+  return render(
+    <TestWrapper>
+      <MDXContainer content={content} runbookPath={runbookPath} />
+    </TestWrapper>,
+  )
+}
+
+function taskCheckboxes(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLInputElement>('.task-list-item-checkbox'),
+  )
+}
+
+async function findTaskCheckboxes(container: HTMLElement, count: number) {
+  await waitFor(() => expect(taskCheckboxes(container)).toHaveLength(count))
+  return taskCheckboxes(container)
+}
+
+describe('MDXContainer task-list checkboxes', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('renders GFM task-list checkboxes as enabled and reflecting the markdown initial state', async () => {
+    const { container } = renderRunbook()
+    const [first, second] = await findTaskCheckboxes(container, 2)
+    expect(first.disabled).toBe(false)
+    expect(second.disabled).toBe(false)
+    expect(first.checked).toBe(true) // - [x]
+    expect(second.checked).toBe(false) // - [ ]
+  })
+
+  it('toggles on click and persists the choice across a remount', async () => {
+    const { container, unmount } = renderRunbook()
+    const [, second] = await findTaskCheckboxes(container, 2)
+
+    fireEvent.click(second)
+    expect(second.checked).toBe(true)
+    expect(localStorage.getItem('task-checkbox:tasklist:second-task')).toBe('true')
+
+    unmount()
+    const { container: reopened } = renderRunbook()
+    const [, secondAgain] = await findTaskCheckboxes(reopened, 2)
+    expect(secondAgain.checked).toBe(true)
+  })
+
+  it('persists an un-check that overrides a markdown-checked default', async () => {
+    const { container, unmount } = renderRunbook()
+    const [first] = await findTaskCheckboxes(container, 2)
+
+    fireEvent.click(first) // uncheck a box the markdown marked as done
+    expect(first.checked).toBe(false)
+    expect(localStorage.getItem('task-checkbox:tasklist:first-task')).toBe('false')
+
+    unmount()
+    const { container: reopened } = renderRunbook()
+    const [firstAgain] = await findTaskCheckboxes(reopened, 2)
+    expect(firstAgain.checked).toBe(false)
+  })
+
+  it('scopes persisted state per runbook', async () => {
+    const { container, unmount } = renderRunbook(TASK_MD, 'testdata/demo/runbook-a')
+    const [, second] = await findTaskCheckboxes(container, 2)
+    fireEvent.click(second)
+    expect(localStorage.getItem('task-checkbox:runbook-a:second-task')).toBe('true')
+    unmount()
+
+    // A different runbook with identical markdown starts from the markdown state.
+    const { container: other } = renderRunbook(TASK_MD, 'testdata/demo/runbook-b')
+    const [, otherSecond] = await findTaskCheckboxes(other, 2)
+    expect(otherSecond.checked).toBe(false)
+  })
+})

--- a/web/src/components/MDXContainer.tsx
+++ b/web/src/components/MDXContainer.tsx
@@ -25,6 +25,7 @@ import { DirPicker } from '@/components/mdx/DirPicker'
 import { SmartLink } from '@/components/mdx/_shared/components/SmartLink'
 import { CodeBlock } from '@/components/mdx/_shared/components/CodeBlock'
 import { InstructionModeBanner } from '@/components/mdx/_shared/components/InstructionModeBanner'
+import { TaskListCheckbox } from '@/components/mdx/_shared/components/TaskListCheckbox'
 
 /**
  * This component renders a markdown/MDX document.
@@ -224,6 +225,62 @@ function rehypeTransformAssetPaths() {
   }
 }
 
+// Custom rehype plugin that gives every GitHub-flavored-markdown task-list
+// checkbox a stable identity so the TaskListCheckbox override can persist its
+// toggled state. GFM renders `- [ ]` / `- [x]` as a disabled
+// `<input type="checkbox">` with no inherent identity; here we derive a key from
+// the item's label text (with an ordinal suffix to disambiguate duplicate or
+// empty labels) and attach it as `data-task-key`. Deriving from text — rather
+// than a bare render index — keeps a checkbox's saved state aligned with its
+// step even if other items are added or reordered.
+function rehypeTaskListIds() {
+  return (tree: RehypeNode) => {
+    const slugCounts = new Map<string, number>()
+
+    const getText = (node: RehypeNode): string => {
+      if (node.type === 'text') return (node.value as string) || ''
+      if (node.children) return node.children.map(getText).join('')
+      return ''
+    }
+
+    const slugify = (text: string): string =>
+      text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 64)
+
+    // Walk the tree, tracking each node's parent so we can read a checkbox's
+    // sibling label text (the checkbox is the first child of its paragraph).
+    const visit = (node: RehypeNode, parent: RehypeNode | undefined) => {
+      if (
+        node.type === 'element' &&
+        node.tagName === 'input' &&
+        node.properties?.type === 'checkbox'
+      ) {
+        const labelText = parent
+          ? parent.children
+              ?.filter((child) => child !== node)
+              .map(getText)
+              .join('')
+              .trim() ?? ''
+          : ''
+        const slug = slugify(labelText) || 'task'
+        const ordinal = slugCounts.get(slug) ?? 0
+        slugCounts.set(slug, ordinal + 1)
+        node.properties = node.properties || {}
+        node.properties['data-task-key'] = ordinal === 0 ? slug : `${slug}-${ordinal}`
+      }
+
+      if (node.children) {
+        node.children.forEach((child) => visit(child, node))
+      }
+    }
+
+    visit(tree, undefined)
+  }
+}
+
 // Strips YAML front matter from MDX content.
 // Front matter is YAML metadata between --- delimiters at the start of the file.
 // Example:
@@ -276,6 +333,7 @@ export const MDX_COMPONENTS = {
   Admonition,
   a: SmartLink, // Handle links intelligently (external open in new tab, anchors smooth scroll)
   pre: CodeBlock, // Code blocks with copy-on-hover button
+  input: TaskListCheckbox, // Make GFM task-list checkboxes interactive + persistent
 } as const
 
 // Compiles MDX content into a custom React component that can render the MDX content.
@@ -289,7 +347,7 @@ const compileMDX = async (content: string): Promise<React.ComponentType> => {
     development: false, // Keep development false to avoid jsxDEV issues
     baseUrl: import.meta.url,
     remarkPlugins: [remarkGfm], // Enable GitHub Flavored Markdown (strikethrough, tables, etc.)
-    rehypePlugins: [rehypeTransformAssetPaths],
+    rehypePlugins: [rehypeTransformAssetPaths, rehypeTaskListIds],
     useMDXComponents: () => MDX_COMPONENTS,
   })
 

--- a/web/src/components/mdx/__tests__/instructionModeRegistry.test.ts
+++ b/web/src/components/mdx/__tests__/instructionModeRegistry.test.ts
@@ -53,7 +53,8 @@ const ALIAS_SOURCE: Record<string, string> = {
 const PASSTHROUGH_BLOCKS = ['Inputs', 'Admonition'] as const
 
 // Non-block element overrides (not runbook blocks).
-const ELEMENT_OVERRIDES = ['a', 'pre'] as const
+// - `input` makes GFM task-list checkboxes interactive (no instruction-mode behavior).
+const ELEMENT_OVERRIDES = ['a', 'pre', 'input'] as const
 
 describe('instruction mode — MDX registry coverage', () => {
   it('every registry entry is classified (a new block forces a decision)', () => {

--- a/web/src/components/mdx/_shared/components/TaskListCheckbox.tsx
+++ b/web/src/components/mdx/_shared/components/TaskListCheckbox.tsx
@@ -1,0 +1,47 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import { useTaskCheckbox } from '../hooks/useTaskCheckbox'
+
+/**
+ * The interactive checkbox rendered in place of a markdown task-list item's
+ * read-only checkbox. Owns its checked state via {@link useTaskCheckbox} so the
+ * user can toggle it and have the choice persist across reloads.
+ */
+function InteractiveTaskCheckbox({
+  taskKey,
+  initialChecked,
+}: {
+  taskKey: string
+  initialChecked: boolean
+}) {
+  const { checked, toggle } = useTaskCheckbox(taskKey, initialChecked)
+  return (
+    <input
+      type="checkbox"
+      className="task-list-item-checkbox cursor-pointer"
+      checked={checked}
+      onChange={toggle}
+    />
+  )
+}
+
+/**
+ * Override for the `input` element produced when MDX renders markdown. GitHub
+ * Flavored Markdown turns `- [ ]` / `- [x]` into a disabled `<input
+ * type="checkbox">`; the `rehypeTaskListIds` plugin tags each of those with a
+ * stable `data-task-key`. When we see that tag we swap in an interactive,
+ * persisted checkbox so users can tick steps off as they work through a runbook.
+ *
+ * Any other `<input>` (e.g. raw HTML embedded in MDX) passes through unchanged.
+ */
+export function TaskListCheckbox(props: ComponentPropsWithoutRef<'input'>) {
+  const taskKey = (props as Record<string, unknown>)['data-task-key']
+  if (props.type === 'checkbox' && typeof taskKey === 'string') {
+    return (
+      <InteractiveTaskCheckbox
+        taskKey={taskKey}
+        initialChecked={Boolean(props.checked ?? props.defaultChecked)}
+      />
+    )
+  }
+  return <input {...props} />
+}

--- a/web/src/components/mdx/_shared/hooks/useTaskCheckbox.ts
+++ b/web/src/components/mdx/_shared/hooks/useTaskCheckbox.ts
@@ -1,0 +1,51 @@
+import { useState, useCallback, useContext } from 'react'
+import { RunbookContext } from '@/contexts/RunbookContext'
+
+/**
+ * localStorage key for a markdown task-list checkbox's state. Scoped to the
+ * runbook (when available) so the same checkbox key in different runbooks
+ * doesn't share state.
+ */
+function storageKey(runbookName: string | undefined, taskKey: string): string {
+  return `task-checkbox:${runbookName ?? 'default'}:${taskKey}`
+}
+
+/**
+ * Tracks the checked state of a GitHub-flavored-markdown task-list checkbox
+ * (`- [ ]` / `- [x]`). The markdown supplies the *initial* state; once the user
+ * toggles a box we persist their explicit choice to localStorage (storing both
+ * `true` and `false` so a user un-check overrides a markdown default), keyed by
+ * runbook + a stable per-checkbox key, so progress survives reloads.
+ *
+ * Reads the runbook name directly from RunbookContext (non-throwing) so it also
+ * works in lightweight test renders.
+ */
+export function useTaskCheckbox(taskKey: string, initialChecked: boolean) {
+  const runbookName = useContext(RunbookContext)?.runbookName
+  const key = storageKey(runbookName, taskKey)
+
+  const [checked, setChecked] = useState<boolean>(() => {
+    try {
+      const stored = localStorage.getItem(key)
+      if (stored === 'true') return true
+      if (stored === 'false') return false
+    } catch {
+      /* localStorage unavailable — fall back to the markdown's initial state */
+    }
+    return initialChecked
+  })
+
+  const toggle = useCallback(() => {
+    setChecked((prev) => {
+      const next = !prev
+      try {
+        localStorage.setItem(key, String(next))
+      } catch {
+        /* localStorage unavailable — toggle won't persist across launches */
+      }
+      return next
+    })
+  }, [key])
+
+  return { checked, toggle }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task-list checkboxes are now interactive; users can click to toggle completion states.
  * Checkbox states automatically persist across sessions and are restored when revisiting documents.
  * Checkbox persistence is scoped per document, ensuring separate tracking for different runbooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->