### PR TITLE
fix: squash bug where children of killed processes were not killed

### DIFF
--- a/electron/main/ipc/exec.ts
+++ b/electron/main/ipc/exec.ts
@@ -59,26 +59,50 @@ function shellEscapeDeep(obj: Record<string, unknown>): Record<string, unknown> 
 // Active execution tracking for cancellation support
 // ---------------------------------------------------------------------------
 
-let activeAbortController: AbortController | null = null
+// Active executions keyed by the renderer-supplied executionId, so a later
+// exec:cancel can interrupt a *specific* run. Aborting a controller interrupts
+// the Effect fiber (the signal is passed to runPromise below), which closes the
+// execution scope and runs the child-process kill finalizer in executor.ts.
+const activeExecutions = new Map<string, AbortController>()
+// Fallback target for exec:cancel calls that don't name an executionId.
+let mostRecentExecutionId: string | null = null
+// Counter for synthesizing an id when a caller doesn't supply one.
+let execSeq = 0
+
+function abortExecution(id: string): boolean {
+  const controller = activeExecutions.get(id)
+  if (!controller) return false
+  controller.abort()
+  activeExecutions.delete(id)
+  if (mostRecentExecutionId === id) mostRecentExecutionId = null
+  return true
+}
 
 export function registerExecHandlers(): void {
   ipcMain.handle(
     "exec:run",
     async (event, params: ExecRequest) => {
       log.debug("handler called for:", params.executableId || params.componentId)
-      // Cancel any existing execution
-      if (activeAbortController) {
-        activeAbortController.abort()
-        activeAbortController = null
-      }
+      // Only one execution runs at a time: cancel (interrupt + kill) any others.
+      for (const controller of activeExecutions.values()) controller.abort()
+      activeExecutions.clear()
 
+      const executionId = params.executionId ?? `main-${++execSeq}`
       const abortController = new AbortController()
-      activeAbortController = abortController
+      activeExecutions.set(executionId, abortController)
+      mostRecentExecutionId = executionId
 
       try {
         // Run execution directly (no forkDaemon). The IPC handler awaits
         // the result, which is exactly the same as forkDaemon + Fiber.await
         // but without the scope/fiber lifecycle issues that caused hangs.
+        //
+        // The abort signal is passed to runPromise: when exec:cancel aborts it,
+        // Effect interrupts this fiber, which closes the scope and runs the
+        // process.kill finalizer (executor.ts) — that's what actually stops the
+        // running child (and its process group). The signal.aborted checks below
+        // are a belt-and-suspenders guard against a stray send in the small
+        // window before interruption takes effect at the next yield point.
         return await runtime.runPromise(
           Effect.scoped(
             Effect.gen(function* () {
@@ -189,6 +213,7 @@ export function registerExecHandlers(): void {
               return { status: finalStatus }
             }),
           ),
+          { signal: abortController.signal },
         )
       } catch (err) {
         log.debug("caught error:", err)
@@ -197,18 +222,16 @@ export function registerExecHandlers(): void {
         }
         throw err
       } finally {
-        if (activeAbortController === abortController) {
-          activeAbortController = null
-        }
+        activeExecutions.delete(executionId)
+        if (mostRecentExecutionId === executionId) mostRecentExecutionId = null
       }
     },
   )
 
-  ipcMain.handle("exec:cancel", async () => {
-    if (activeAbortController) {
-      activeAbortController.abort()
-      activeAbortController = null
-    }
+  ipcMain.handle("exec:cancel", async (_event, params?: { executionId?: string }) => {
+    // Target a specific run when named; otherwise fall back to the most recent.
+    const id = params?.executionId ?? mostRecentExecutionId
+    if (id) abortExecution(id)
     return { ok: true as const }
   })
 }

--- a/electron/shared/channels.ts
+++ b/electron/shared/channels.ts
@@ -36,8 +36,10 @@ export interface IpcChannelMap {
   "session:set-env": { params: { env: Record<string, string> }; result: { ok: true } }
 
   // Execution
-  "exec:run": { params: ExecRequest; result: { status: { status: string; exitCode: number } | null } }
-  "exec:cancel": { params: void; result: { ok: true } }
+  "exec:run": { params: ExecRequest; result: { status: { status: string; exitCode: number } | null; cancelled?: boolean } }
+  // `executionId` targets a specific run; when omitted, the most-recent active
+  // execution is cancelled (back-compat).
+  "exec:cancel": { params: { executionId?: string }; result: { ok: true } }
 
   // Boilerplate
   "boilerplate:variables": {

--- a/src/domain/exec/executor.kill.test.ts
+++ b/src/domain/exec/executor.kill.test.ts
@@ -1,0 +1,142 @@
+/**
+ * End-to-end cancellation test for a long-running script block.
+ *
+ * Unlike executor.test.ts (which stubs the spawner), this drives the REAL layer
+ * stack — NodeFileSystem + ProcessEnvironment + ChildProcessSpawner — exactly as
+ * the exec:run IPC handler does: an `Effect.scoped` program that spawns the
+ * process and drains its output. We then interrupt the fiber, which is precisely
+ * what `exec:cancel` does when it aborts the run's AbortController (the signal is
+ * wired into runPromise, and aborting interrupts the fiber). Interruption closes
+ * the scope, which runs the `process.kill` finalizer.
+ *
+ * The script spawns a long-lived *grandchild* (`sleep`) in the background and
+ * records its PID. The wrapper bash process is the spawner's direct child; the
+ * sleeper is its child. Crucially, the wrapper traps EXIT but not SIGTERM, so on
+ * termination bash dies WITHOUT reaping its background job. The grandchild
+ * therefore survives unless the whole process group is signaled. Asserting the
+ * grandchild is dead is what proves the process-group kill works — killing only
+ * the direct child (the old `proc.kill()` behavior) would leave it orphaned and
+ * running, which is the real-world failure where terragrunt/tofu kept running
+ * after "Stop".
+ */
+import { describe, it, expect, afterEach } from "bun:test"
+import { Effect, Fiber, Layer, Stream } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { executeScript } from "./executor.ts"
+import { NodeFileSystemLive } from "../../layers/NodeFileSystem.ts"
+import { ProcessEnvironmentLive } from "../../layers/ProcessEnvironment.ts"
+import { ChildProcessSpawnerLive } from "../../layers/ChildProcessSpawner.ts"
+
+const liveLayer = Layer.mergeAll(
+  NodeFileSystemLive,
+  ProcessEnvironmentLive,
+  ChildProcessSpawnerLive,
+)
+
+/** True if a process with `pid` is still alive (signal 0 = existence probe). */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    // ESRCH → gone. EPERM → exists but owned by another user (still "alive").
+    return (err as NodeJS.ErrnoException).code === "EPERM"
+  }
+}
+
+/** Poll `pred` until it's true or the deadline passes. */
+async function waitUntil(pred: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (pred()) return true
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  return pred()
+}
+
+describe("executeScript cancellation (e2e, real process tree)", () => {
+  let grandchildPid: number | null = null
+  let pidFile: string | null = null
+
+  afterEach(() => {
+    // Safety net: never leak a real `sleep` if an assertion failed mid-test.
+    if (grandchildPid !== null && isAlive(grandchildPid)) {
+      try {
+        process.kill(grandchildPid, "SIGKILL")
+      } catch {
+        /* already gone */
+      }
+    }
+    if (pidFile && fs.existsSync(pidFile)) {
+      try {
+        fs.rmSync(pidFile)
+      } catch {
+        /* best effort */
+      }
+    }
+    grandchildPid = null
+    pidFile = null
+  })
+
+  it(
+    "interrupting a running block kills the whole process group, not just the direct child",
+    async () => {
+      pidFile = path.join(
+        os.tmpdir(),
+        `runbook-killtest-${process.pid}-${Math.random().toString(36).slice(2)}.pid`,
+      )
+
+      // Background a long-lived grandchild, record its PID, then block forever so
+      // the "block" stays running until we cancel it.
+      const script = [
+        "sleep 600 &",
+        `echo $! > '${pidFile}'`,
+        "wait",
+        "",
+      ].join("\n")
+
+      const program = Effect.scoped(
+        Effect.gen(function* () {
+          const { logStream, completionEffect } = yield* executeScript(
+            script,
+            "bash",
+            {},
+            { env: { PATH: process.env.PATH ?? "/usr/bin:/bin" }, workDir: os.tmpdir() },
+            "",
+            "",
+          )
+          // Draining the log stream parks the fiber while the process runs —
+          // this is the interruptible point cancellation acts on.
+          yield* Stream.runForEach(logStream, () => Effect.void)
+          yield* completionEffect
+        }),
+      ).pipe(Effect.provide(liveLayer))
+
+      const fiber = Effect.runFork(program)
+
+      // Wait for the grandchild to come up and publish its PID.
+      const started = await waitUntil(
+        () => fs.existsSync(pidFile!) && fs.readFileSync(pidFile!, "utf8").trim() !== "",
+        8000,
+      )
+      expect(started).toBe(true)
+
+      grandchildPid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10)
+      expect(Number.isInteger(grandchildPid)).toBe(true)
+      expect(grandchildPid).toBeGreaterThan(0)
+      expect(isAlive(grandchildPid)).toBe(true)
+
+      // Cancel: interrupting the fiber mirrors exec:cancel aborting the signal.
+      // This awaits the scope's finalizers, so the kill has been issued on return.
+      await Effect.runPromise(Fiber.interrupt(fiber))
+
+      // The grandchild must die. SIGTERM to the group is enough for `sleep`; the
+      // generous window also covers the SIGKILL escalation path.
+      const died = await waitUntil(() => !isAlive(grandchildPid!), 10000)
+      expect(died).toBe(true)
+    },
+    20000,
+  )
+})

--- a/src/layers/ChildProcessSpawner.ts
+++ b/src/layers/ChildProcessSpawner.ts
@@ -18,6 +18,12 @@ const impl: ProcessSpawnerShape = {
           cwd: options?.cwd,
           env: options?.env as NodeJS.ProcessEnv | undefined,
           stdio: [needsStdin ? "pipe" : "ignore", "pipe", "pipe"],
+          // Run the child as its own process-group leader (POSIX: pid === pgid).
+          // Scripts here spawn a tree — bash → terragrunt → tofu → providers —
+          // and `kill` below signals the whole group via the negative pid. Without
+          // this, terminating only the direct child would orphan the grandchildren
+          // (terraform/tofu would keep running and hold state locks).
+          detached: true,
         })
 
         // Write stdin if provided, then close
@@ -104,8 +110,34 @@ const impl: ProcessSpawnerShape = {
           catch: () => new SpawnError({ command, cause: new Error("Process failed") }),
         }) as unknown as Effect.Effect<number>
 
+        // Kill the entire process group, not just the direct child. `detached`
+        // above makes `proc` a group leader, so a negative pid signals every
+        // descendant that hasn't started its own group (bash, terragrunt, tofu,
+        // providers all stay in this group).
+        const killGroup = (signal: NodeJS.Signals): void => {
+          const pid = proc.pid
+          if (pid === undefined) return
+          try {
+            process.kill(-pid, signal)
+          } catch {
+            // Group already gone, or the platform lacks group signals (Windows):
+            // fall back to the direct child. A second failure means it's dead.
+            try {
+              proc.kill(signal)
+            } catch {
+              /* already exited — nothing to do */
+            }
+          }
+        }
+
         const kill: Effect.Effect<void> = Effect.sync(() => {
-          proc.kill()
+          // Ask politely first so the tree can clean up (e.g. tofu releases its
+          // state lock), then force-kill whatever is still alive a few seconds
+          // later. The escalation timer is best-effort and unref'd so it can
+          // never, on its own, keep the parent process alive.
+          killGroup("SIGTERM")
+          const escalate = setTimeout(() => killGroup("SIGKILL"), 5000)
+          escalate.unref?.()
         })
 
         return { output, exitCode, kill }

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,6 +207,13 @@ export interface ExecRequest {
   usePty?: boolean
   /** Per-execution timeout in milliseconds. Falls back to the executor's default when omitted. */
   timeoutMs?: number
+  /**
+   * Renderer-generated unique id for this execution. The renderer holds onto it
+   * so a later `exec:cancel` can target *this specific* run (rather than whatever
+   * happens to be active), and the main process registers the run's
+   * AbortController under it. Omitted by callers that don't support cancellation.
+   */
+  executionId?: string
 }
 
 export interface ExecLogEvent {

--- a/web/src/hooks/useApiExec.test.ts
+++ b/web/src/hooks/useApiExec.test.ts
@@ -23,12 +23,17 @@ type EventCallback = (...args: unknown[]) => void
  */
 function createMockWindowApi() {
   const listeners = new Map<string, Set<EventCallback>>()
-  let invokeResolve: (() => void) | null = null
+  let invokeResolve: ((value?: unknown) => void) | null = null
   let invokeReject: ((err: Error) => void) | null = null
 
   const api = {
-    invoke: vi.fn((_channel: string, ..._args: unknown[]) => {
-      return new Promise<void>((resolve, reject) => {
+    invoke: vi.fn((channel: string, ..._args: unknown[]) => {
+      // Fire-and-forget channels (e.g. exec:cancel) resolve immediately so they
+      // don't clobber the pending exec:run resolver the tests drive by hand.
+      if (channel !== 'exec:run') {
+        return Promise.resolve({ ok: true })
+      }
+      return new Promise<unknown>((resolve, reject) => {
         invokeResolve = resolve
         invokeReject = reject
       })
@@ -54,9 +59,9 @@ function createMockWindowApi() {
         for (const cb of cbs) cb(data)
       }
     },
-    /** Resolve the pending invoke('exec:run') call */
-    resolveInvoke() {
-      invokeResolve?.()
+    /** Resolve the pending invoke('exec:run') call, optionally with a result */
+    resolveInvoke(value?: unknown) {
+      invokeResolve?.(value)
     },
     /** Reject the pending invoke('exec:run') call */
     rejectInvoke(err: Error) {
@@ -100,13 +105,14 @@ describe('useApiExec state machine', () => {
     // Should transition to running immediately
     expect(result.current.state.status).toBe('running')
 
-    // Verify invoke was called with correct payload
+    // Verify invoke was called with correct payload (plus a generated executionId)
     expect(mock.api.invoke).toHaveBeenCalledWith('exec:run', {
       executableId: 'test-executable',
       templateVarValues: { region: 'us-west-2' },
       envVarsOverride: undefined,
       usePty: undefined,
       timeoutMs: undefined,
+      executionId: expect.any(String),
     })
 
     // Simulate IPC events from main process
@@ -178,6 +184,46 @@ describe('useApiExec state machine', () => {
     expect(result.current.state.status).toBe('pending')
     const lastLog = result.current.state.logs[result.current.state.logs.length - 1]
     expect(lastLog.line).toContain('cancelled')
+  })
+
+  it('cancel sends exec:cancel targeting the running execution id', async () => {
+    const { result } = renderHook(() => useApiExec())
+
+    act(() => {
+      result.current.execute('long-running-script')
+    })
+    expect(result.current.state.status).toBe('running')
+
+    act(() => {
+      result.current.cancel()
+    })
+
+    // Cancel must name an executionId so the backend interrupts *this* run,
+    // rather than blindly cancelling whatever is currently active.
+    expect(mock.api.invoke).toHaveBeenCalledWith('exec:cancel', {
+      executionId: expect.any(String),
+    })
+    expect(result.current.state.status).toBe('pending')
+  })
+
+  it('reconciles final status from the invoke result when the status event is dropped', async () => {
+    const { result } = renderHook(() => useApiExec())
+
+    act(() => {
+      result.current.execute('long-running-script')
+    })
+    expect(result.current.state.status).toBe('running')
+
+    // No exec:status event is emitted (it was dropped: detached listeners, a
+    // newer run claimed activeExecId, or the main process suppressed sends). The
+    // invoke still resolves with the authoritative result, which must move the UI
+    // off "running" — this is the fix for a finished block stuck on "running".
+    await act(async () => {
+      mock.resolveInvoke({ status: { status: 'success', exitCode: 0 } })
+    })
+
+    await waitFor(() => expect(result.current.state.status).toBe('success'))
+    expect(result.current.state.exitCode).toBe(0)
   })
 
   it('reset: clears all state back to initial', async () => {

--- a/web/src/hooks/useApiExec.ts
+++ b/web/src/hooks/useApiExec.ts
@@ -105,13 +105,19 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
 
   const cleanupRef = useRef<(() => void) | null>(null)
   const executionGenRef = useRef(0)
+  // The id of the currently-running execution, or null when nothing is running.
+  // Tracked independently of `cleanupRef` (the IPC listeners) so that Stop can
+  // still cancel a run whose listeners have already been detached — and so the
+  // decision to cancel doesn't depend on listener lifecycle timing.
+  const runningExecIdRef = useRef<string | null>(null)
 
   const cancel = useCallback(() => {
-    const hadActiveExecution = cleanupRef.current !== null
+    const execId = runningExecIdRef.current
 
-    // Signal the backend to cancel the active execution (kill child process)
-    if (hadActiveExecution) {
-      window.api.invoke('exec:cancel').catch(() => {})
+    // Signal the backend to interrupt + kill *this* run's child process group.
+    if (execId !== null) {
+      window.api.invoke('exec:cancel', { executionId: execId }).catch(() => {})
+      runningExecIdRef.current = null
     }
 
     // Clean up IPC event subscriptions
@@ -121,7 +127,7 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
     }
 
     // Only add cancellation log and update state if there was actually an active execution
-    if (hadActiveExecution) {
+    if (execId !== null) {
       setState((prev) => ({
         ...prev,
         status: 'pending',
@@ -160,6 +166,10 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
     // Claim global ownership so that listeners from previously-run blocks
     // (which are still subscribed) will silently discard our events.
     const execId = ++activeExecId
+    // Stable string id for this run, sent to the backend so a later exec:cancel
+    // can target this specific execution. Held in a ref for cancel() to read.
+    const executionId = String(execId)
+    runningExecIdRef.current = executionId
 
     // Reset state for new execution
     setState({
@@ -233,8 +243,26 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
     cleanupRef.current = cleanup
 
     try {
-      await window.api.invoke('exec:run', payload)
-      // The invoke resolved — the main process has sent all events.
+      const result = await window.api.invoke('exec:run', { ...payload, executionId })
+      // The invoke resolved — this run is finished and no longer cancellable.
+      if (generation === executionGenRef.current) {
+        runningExecIdRef.current = null
+
+        // Reconcile the final status from the invoke's return value. The streamed
+        // `exec:status` event can be silently dropped — listeners get detached, a
+        // newer run claims activeExecId, or the main process suppressed sends after
+        // an abort — which would otherwise leave a *finished* block stuck showing
+        // "running". The invoke result is the source of truth, so apply it whenever
+        // the UI is still in a non-terminal state.
+        if (result?.status) {
+          const finalStatus = result.status
+          setState((prev) =>
+            prev.status === 'running' || prev.status === 'pending'
+              ? { ...prev, status: finalStatus.status as ExecState['status'], exitCode: finalStatus.exitCode }
+              : prev,
+          )
+        }
+      }
       // Schedule listener cleanup on the next macrotask so any IPC events
       // still queued in the renderer's event loop are dispatched first.
       setTimeout(() => {
@@ -246,6 +274,7 @@ export function useApiExec(options?: UseApiExecOptions): UseApiExecReturn {
     } catch (error) {
       // Only update state if this execution is still current
       if (generation === executionGenRef.current) {
+        runningExecIdRef.current = null
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
         setState((prev) => ({
           ...prev,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution cancellation to reliably terminate spawned background processes.
  * Enhanced execution tracking to prevent UI state from becoming stuck during cancellation.
  * Fixed process cleanup to properly signal entire process groups, not just direct children.

* **Tests**
  * Added end-to-end tests for execution cancellation with real processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->