### PR TITLE
feat: add commit message field for PRs

### DIFF
--- a/docs/src/content/docs/authoring/blocks/GitHubPullRequest.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitHubPullRequest.mdx
@@ -50,7 +50,7 @@ You can pre-populate the PR title, description, labels, and branch name. Users c
 
 ### Template Expressions
 
-The `prefilledPullRequestTitle`, `prefilledPullRequestDescription`, and `prefilledBranchName` props support template expressions that reference inputs and outputs from other blocks. Escape sequences like `\n` are converted to real newlines, which is useful for multi-line PR descriptions:
+The `prefilledPullRequestTitle`, `prefilledPullRequestDescription`, `prefilledBranchName`, and `prefilledCommitMessage` props support template expressions that reference inputs and outputs from other blocks. Escape sequences like `\n` are converted to real newlines, which is useful for multi-line PR descriptions:
 
 ```mdx
 <GitHubPullRequest
@@ -76,6 +76,7 @@ Template expressions are resolved in real-time as upstream blocks produce output
 | `prefilledPullRequestDescription` | `string` | No | Pre-fills the PR description field. Supports template expressions, markdown, and `\n` for newlines. |
 | `prefilledPullRequestLabels` | `string[]` | No | Pre-selects labels by name. Labels must exist in the repository. |
 | `prefilledBranchName` | `string` | No | Pre-fills the branch name. Supports template expressions. Defaults to `runbook/<timestamp>`. |
+| `prefilledCommitMessage` | `string` | No | Pre-fills the commit message field. Supports template expressions. |
 
 ### Block Outputs
 

--- a/docs/src/content/docs/authoring/blocks/GitHubPullRequest.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitHubPullRequest.mdx
@@ -35,7 +35,7 @@ Pair with `<GitHubAuth>` and `<GitClone>` to create a complete workflow:
 
 ### Pre-filled Values
 
-You can pre-populate the PR title, description, labels, and branch name. Users can still edit these values before creating the PR.
+You can pre-populate the PR title, description, labels, branch name, and commit message. Users can still edit these values before creating the PR.
 
 ```mdx
 <GitHubPullRequest
@@ -45,8 +45,13 @@ You can pre-populate the PR title, description, labels, and branch name. Users c
   prefilledPullRequestDescription="## Changes\n- Added VPC module\n- Configured NAT gateway"
   prefilledPullRequestLabels={["enhancement", "terraform"]}
   prefilledBranchName="feature/add-vpc"
+  prefilledCommitMessage="Add VPC module configuration"
 />
 ```
+
+<Aside type="note">
+[`<GitLabMergeRequest>`](/authoring/blocks/gitlabmergerequest/) and `<GitPullRequest>` accept the same prefilled props, including `prefilledCommitMessage`.
+</Aside>
 
 ### Template Expressions
 
@@ -148,5 +153,7 @@ The block fetches available labels from the repository and presents them in a se
   title="Open Pull Request"
   prefilledPullRequestTitle="Update infrastructure configuration"
   prefilledPullRequestLabels={["infrastructure"]}
+  prefilledCommitMessage="Update infrastructure configuration"
 />
 ```
+

--- a/docs/src/content/docs/authoring/blocks/GitLabMergeRequest.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitLabMergeRequest.mdx
@@ -1,0 +1,53 @@
+---
+title: <GitLabMergeRequest>
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The `<GitLabMergeRequest>` block creates a GitLab merge request from changes made during a runbook. It is a GitLab-locked alias of [`<GitPullRequest>`](/authoring/blocks/githubpullrequest/) — equivalent to `<GitPullRequest provider="gitlab" />` — and accepts the same props, including `prefilledCommitMessage`.
+
+### Basic Usage
+
+```mdx
+<GitLabAuth
+  id="gl-auth"
+  title="Connect to GitLab"
+/>
+
+<GitClone
+  id="clone-repo"
+  gitAuthId="gl-auth"
+  title="Clone Repository"
+  prefilledUrl="https://gitlab.com/acme-corp/infrastructure"
+/>
+
+<GitLabMergeRequest
+  id="create-mr"
+  gitAuthId="gl-auth"
+  title="Create Merge Request"
+  prefilledBranchName="upgrade-pipelines-v4"
+  prefilledCommitMessage="Upgrade Gruntwork Pipelines from v3 to v4 [skip ci]"
+  prefilledPullRequestTitle="[skip ci] Upgrade Gruntwork Pipelines from v3 to v4"
+  prefilledPullRequestDescription="Upgrades Pipelines configuration from v3 to v4."
+/>
+```
+
+### Pre-filled Values
+
+You can pre-populate the MR title, description, labels, branch name, and commit message. Users can still edit these values before creating the MR.
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | Unique block identifier. |
+| `title` | `string` | No | Display title. Defaults to `Create Merge Request`. |
+| `description` | `string` | No | Description text below the title. |
+| `gitAuthId` | `string` | No | Reference to a [`<GitAuth>`](/authoring/blocks/gitauth) or [`<GitLabAuth>`](/authoring/blocks/gitlabauth) block. |
+| `prefilledPullRequestTitle` | `string` | No | Pre-fills the MR title field. Supports template expressions. |
+| `prefilledPullRequestDescription` | `string` | No | Pre-fills the MR description field. Supports template expressions. |
+| `prefilledPullRequestLabels` | `string[]` | No | Pre-selects labels by name. |
+| `prefilledBranchName` | `string` | No | Pre-fills the branch name. Supports template expressions. |
+| `prefilledCommitMessage` | `string` | No | Pre-fills the commit message used when committing changes before opening the MR. Supports template expressions. |
+
+<Aside type="note">
+The prop names use `PullRequest` for historical reasons (shared with the GitHub block), but they apply to merge requests the same way — including `prefilledCommitMessage`.
+</Aside>

--- a/docs/src/content/docs/authoring/blocks/index.md
+++ b/docs/src/content/docs/authoring/blocks/index.md
@@ -18,6 +18,7 @@ Blocks are special React components that you can use in your `runbook.mdx` files
 - [GitHubAuth](/authoring/blocks/githubauth)
 - [GitHubPullRequest](/authoring/blocks/githubpullrequest)
 - [GitLabAuth](/authoring/blocks/gitlabauth)
+- [GitLabMergeRequest](/authoring/blocks/gitlabmergerequest)
 - [Inputs](/authoring/blocks/inputs)
 - [Template](/authoring/blocks/template)
 - [TemplateInline](/authoring/blocks/templateinline)

--- a/web/src/components/mdx/GitLabMergeRequest/__tests__/GitLabMergeRequest.test.tsx
+++ b/web/src/components/mdx/GitLabMergeRequest/__tests__/GitLabMergeRequest.test.tsx
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi } from "vitest"
 import { useEffect } from "react"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { TestWrapper } from "@/test/test-utils"
 import { useRunbookContext } from "@/contexts/useRunbook"
 
 vi.mock("@/contexts/useGitWorkTree", () => ({
   useGitWorkTree: () => ({
-    activeWorkTree: null,
+    activeWorkTree: {
+      id: "wt-1",
+      localPath: "/tmp/repo",
+      gitInfo: {
+        repoOwner: "acme",
+        repoName: "infra",
+        repoUrl: "https://gitlab.com/acme/infra.git",
+        ref: "main",
+      },
+    },
     workTrees: [],
     registerWorkTree: vi.fn(),
     unregisterWorkTree: vi.fn(),
@@ -40,6 +50,23 @@ describe("GitLabMergeRequest (gitlab-locked wrapper)", () => {
     expect(screen.getAllByText(/Create Merge Request/).length).toBeGreaterThanOrEqual(1)
   })
 
+  it("prefills the commit message from prefilledCommitMessage", async () => {
+    const user = userEvent.setup()
+    render(
+      <TestWrapper>
+        <Seed id="auth" values={{ GIT_PROVIDER: "gitlab", GITLAB_TOKEN: "tok", __AUTHENTICATED: "true" }} />
+        <GitLabMergeRequest
+          id="mr"
+          gitAuthId="auth"
+          prefilledCommitMessage="Upgrade Pipelines from v3 to v4 [skip ci]"
+        />
+      </TestWrapper>,
+    )
+
+    await user.click(screen.getByText("Customize commit"))
+    expect(screen.getByDisplayValue("Upgrade Pipelines from v3 to v4 [skip ci]")).toBeInTheDocument()
+  })
+
   it("shows a blocking wrong-provider error when linked to a GitHub auth block", async () => {
     render(
       <TestWrapper>
@@ -55,3 +82,4 @@ describe("GitLabMergeRequest (gitlab-locked wrapper)", () => {
     expect(block.textContent).toContain("can only be used with a GitLab auth block")
   })
 })
+

--- a/web/src/components/mdx/GitPullRequest/GitPullRequest.tsx
+++ b/web/src/components/mdx/GitPullRequest/GitPullRequest.tsx
@@ -46,6 +46,7 @@ function GitPullRequestInteractive({
   prefilledPullRequestDescription = '',
   prefilledPullRequestLabels = [],
   prefilledBranchName = '',
+  prefilledCommitMessage = '',
   inputsId,
   githubAuthId,
   gitAuthId,
@@ -88,12 +89,13 @@ function GitPullRequestInteractive({
   const descriptionText = description ?? `Open a ${cfg.noun.lower} with your changes`
 
   // Extract and check template dependencies from props that support template expressions
-  // Blocking dependencies (functional props): prefilledPullRequestTitle, prefilledPullRequestDescription, prefilledBranchName
+  // Blocking dependencies (functional props): prefilledPullRequestTitle, prefilledPullRequestDescription, prefilledBranchName, prefilledCommitMessage
   const blockingDeps = useMemo(() => [
     ...extractTemplateDependenciesFromString(prefilledPullRequestTitle ?? ''),
     ...extractTemplateDependenciesFromString(prefilledPullRequestDescription ?? ''),
     ...extractTemplateDependenciesFromString(prefilledBranchName ?? ''),
-  ], [prefilledPullRequestTitle, prefilledPullRequestDescription, prefilledBranchName])
+    ...extractTemplateDependenciesFromString(prefilledCommitMessage ?? ''),
+  ], [prefilledPullRequestTitle, prefilledPullRequestDescription, prefilledBranchName, prefilledCommitMessage])
 
   // Non-blocking dependencies (display props): title, description
   const nonBlockingDeps = useMemo(() => [
@@ -175,6 +177,10 @@ function GitPullRequestInteractive({
     prefilledBranchName ? resolveAndUnescape(prefilledBranchName, templateCtx) : '',
     [prefilledBranchName, templateCtx]
   )
+  const resolvedCommitMessage = useMemo(() =>
+    prefilledCommitMessage ? resolveAndUnescape(prefilledCommitMessage, templateCtx) : '',
+    [prefilledCommitMessage, templateCtx]
+  )
 
   // Resolve display props (title and description support template expressions too)
   const resolvedDisplayTitle = useMemo(() =>
@@ -186,10 +192,9 @@ function GitPullRequestInteractive({
     [descriptionText, templateCtx]
   )
 
-  // Default commit message includes the runbook name when available
-  const defaultCommitMessage = runbookName
-    ? `Changes from runbook "${runbookName}"`
-    : "Changes from runbook"
+  // Prefer an author-provided commit message; otherwise include the runbook name.
+  const defaultCommitMessage = resolvedCommitMessage
+    || (runbookName ? `Changes from runbook "${runbookName}"` : "Changes from runbook")
 
   // Form state
   const [prTitle, setPRTitle] = useState(resolvedTitle)

--- a/web/src/components/mdx/GitPullRequest/types.ts
+++ b/web/src/components/mdx/GitPullRequest/types.ts
@@ -16,6 +16,8 @@ export interface GitPullRequestProps {
   prefilledPullRequestLabels?: string[]
   /** Pre-populated branch name (supports template expressions) */
   prefilledBranchName?: string
+  /** Pre-populated commit message (supports template expressions) */
+  prefilledCommitMessage?: string
   /** Reference to one or more Inputs by ID for template expressions in props */
   inputsId?: string | string[]
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for prefilled commit messages in GitHub pull request workflows.
  * Commit messages can include template expressions and override automatically generated messages.

* **Documentation**
  * Documented the new `prefilledCommitMessage` option and its supported template expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->