### PR TITLE
Fix #177 GFM table rendering and WCAG AA contrast failures in docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,6 +5,14 @@ import starlight from '@astrojs/starlight';
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://runbooks.gruntwork.io',
+	// Astro 6.4.x regression (withastro/astro#16971): markdown.gfm no longer
+	// defaults to true for .mdx files, so GFM tables silently stop rendering
+	// (they fall back through as raw pipe text instead of <table>). Must be
+	// set explicitly at this top level — setting it via a remark/unified
+	// option does not work around the regression.
+	markdown: {
+		gfm: true,
+	},
 	integrations: [
 		starlight({
 			title: 'Gruntwork Runbooks',

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -52,7 +52,7 @@ import Default from '@astrojs/starlight/components/Footer.astro';
   }
 
   .gruntwork-footer-separator {
-    color: var(--sl-color-gray-5);
+    color: var(--sl-color-gray-3);
   }
 
   .gruntwork-footer-link {

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -64,10 +64,15 @@ html {
   --sl-color-white: #fafafa;
   --sl-color-gray-1: #e4e4e7;
   --sl-color-gray-2: #a1a1aa;
-  --sl-color-gray-3: #71717a;
+  --sl-color-gray-3: #909099;  /* Lightened from #71717a — 3.66:1 on --sl-color-bg failed WCAG AA (4.5:1) for footer/edit-link/TOC text; this hits ~4.7:1+ against both --sl-color-bg and --sl-color-gray-7 */
   --sl-color-gray-4: #52525b;
   --sl-color-gray-5: #52525b;  /* Increased from #3f3f46 for better borders */
-  --sl-color-gray-6: #3f3f46;  /* Increased from #27272a for better backgrounds */
+  --sl-color-gray-6: #27272a;  /* Reverted from #3f3f46: that lighter value became the Expressive Code
+                                   editor background, and the built-in Night Owl syntax theme's comment/
+                                   keyword/string colors (tuned for a ~#23262f bg) dropped to ~3.8:1 against
+                                   it — below WCAG AA. #27272a is close to the theme's own reference bg and
+                                   restores ~5.4:1+ for those tokens; all other consumers (borders, hover
+                                   backgrounds) still pass comfortably at this value too. */
   --sl-color-gray-7: #27272a;  /* Adjusted for code blocks */
   --sl-color-black: #09090b;
   
@@ -201,9 +206,12 @@ header.header {
   color: #93c5fd;
 }
 
-/* Code within links - better contrast */
+/* Code within links - better contrast. Inline code's background is
+   Starlight's --sl-color-bg-inline-code (= gray-6); --sl-color-accent text
+   on top of that only hits 4.38:1 in light mode, just under WCAG AA, so use
+   the darker accent-high tone here instead (6.78:1). */
 .sl-markdown-content a code {
-  color: var(--sl-color-accent);
+  color: var(--sl-color-accent-high);
   text-decoration: none;
   border-bottom: 1px solid transparent;
   transition: border-color 0.15s ease;
@@ -285,6 +293,19 @@ header.header {
 .starlight-aside {
   border-radius: 0.5rem;
   border-left-width: 3px;
+}
+
+/* Our link accent is tuned against a neutral page background, but note/tip/
+   caution/danger asides tint the background per-variant. In some variants
+   (tip, caution in dark mode; note, danger in light mode) that drops link
+   contrast below 4.5:1. Use colors already in the palette that pass against
+   all four variant backgrounds in both themes. */
+.starlight-aside a {
+  color: var(--sl-color-accent-high);
+}
+
+:root[data-theme='dark'] .starlight-aside a {
+  color: #93c5fd;
 }
 
 /* ============================================
@@ -418,6 +439,15 @@ html[data-has-hero] {
   filter: brightness(1.15);
 }
 
+/* Dark-mode accent (#3b82f6) only gives white text 3.68:1 here — fails WCAG
+   AA (4.5:1). Use a darker blue for this button only; --sl-color-accent
+   itself stays untouched since it passes contrast everywhere else it's used
+   as foreground text/link color. */
+:root[data-theme='dark'][data-has-hero] .hero .sl-link-button.primary {
+  background: #2563eb !important;
+  border-color: #2563eb !important;
+}
+
 [data-has-hero] .hero .sl-link-button.minimal {
   color: #cbd5e1 !important;
   background: transparent !important;
@@ -520,6 +550,12 @@ html[data-has-hero] {
 [data-has-hero] .source-link:hover {
   color: var(--sl-color-gray-2) !important;
   text-decoration: none !important;
+}
+
+/* Dark-mode gray-4 (#52525b) is tuned for borders, not text — only 2.29:1 on
+   --sl-color-bg. Use gray-3 here instead so the link stays readable. */
+:root[data-theme='dark'][data-has-hero] .source-link {
+  color: var(--sl-color-gray-3) !important;
 }
 
 /* Block list rows on splash page */


### PR DESCRIPTION
## Summary
- Restore GFM table rendering in `.mdx` docs — Astro 6.4.x regression (withastro/astro#16971) drops the `markdown.gfm` default specifically for `.mdx` files, so every table in the block docs (e.g. GitAuth's Providers table) silently rendered as raw pipe text instead of an HTML table.
- Resolve WCAG AA color-contrast failures across the docs theme (light + dark), found via an axe-core audit of all 41 pages. See individual commit messages for the per-issue detail (gray-3 token, hero button, code-block syntax colors, aside links, inline code in links, footer separator).

## Test plan
- [x] `astro dev` + curl: confirmed GitAuth's Providers/Props/Usage tables render as `<table>` instead of raw `| a | b |` text
- [x] axe-core (WCAG 2 AA, color-contrast rule) run against all 41 docs pages in both light and dark themes: 0 violations
- [x] Verified fixes against actual computed styles in a headless browser (not just the CSS source) after catching a selector bug (`[data-theme] [data-has-hero]` needs to be compound, not descendant-combinator, since both attributes live on `<html>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enabled GitHub-Flavored Markdown support in documentation.
  * Added configuration guidance for improved Markdown compatibility.

* **Style**
  * Improved dark-theme contrast across separators, links, inline code, callouts, and source links.
  * Updated the splash-page hero button color for better dark-mode visibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->