### PR TITLE
feat(GitClone): select an existing local checkout instead of cloning

### DIFF
--- a/cli/test/executor.test.ts
+++ b/cli/test/executor.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { execFileSync } from "node:child_process"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import * as os from "node:os"
@@ -72,5 +73,61 @@ describe("TestExecutor — config-error surfacing", () => {
     // init() should succeed; the validator records the error internally so
     // runTest can surface it. We assert init does not throw.
     await executor.init()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GitClone with source="local": adopt a checkout that already exists instead
+// of cloning it.
+// ---------------------------------------------------------------------------
+
+describe("TestExecutor — GitClone local checkout", () => {
+  let tmp: string
+
+  const runLocalGitClone = async (repoDir: string) => {
+    const rb = path.join(tmp, "runbook.mdx")
+    fs.writeFileSync(
+      rb,
+      `# Local checkout\n\n<GitClone id="repo" source="local" prefilledRepoDir="${repoDir}" />\n`,
+    )
+    const executor = new TestExecutor(rb, tmp, "generated", { timeout: 30_000, verbose: false })
+    await executor.init()
+    return executor.runTest({
+      name: "local",
+      steps: [{ block: "repo", expect: "success" }],
+    })
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rb-exec-local-"))
+  })
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it("adopts an existing checkout and emits clone_path", async () => {
+    const repo = path.join(tmp, "checkout")
+    fs.mkdirSync(repo)
+    execFileSync("git", ["init", "-q"], { cwd: repo })
+    fs.writeFileSync(path.join(repo, "main.tf"), "# tf\n")
+    execFileSync("git", ["add", "."], { cwd: repo })
+
+    const result = await runLocalGitClone(repo)
+
+    expect(result.stepResults[0]?.actualStatus).toBe("success")
+    // git init resolves through symlinks on macOS (/var → /private/var), so
+    // compare against the repo's own resolved path.
+    expect(result.stepResults[0]?.outputs?.clone_path).toBe(fs.realpathSync(repo))
+    expect(result.stepResults[0]?.outputs?.file_count).toBe("1")
+  })
+
+  it("fails when the directory is not a git repository", async () => {
+    const notARepo = path.join(tmp, "notes")
+    fs.mkdirSync(notARepo)
+
+    const result = await runLocalGitClone(notARepo)
+
+    expect(result.stepResults[0]?.actualStatus).toBe("fail")
+    expect(result.stepResults[0]?.error).toMatch(/Not a git repository/)
   })
 })

--- a/cli/test/executor.ts
+++ b/cli/test/executor.ts
@@ -1271,6 +1271,14 @@ export class TestExecutor {
   private runGitClone(block: ParsedComponent, step: TestStep, start: number): StepResult {
     const result = makeStepResult(`gitClone:${block.id}`, step.expect)
 
+    // A block pointed at an existing checkout clones nothing — it just adopts
+    // the directory, mirroring the app's "Use local checkout" source.
+    const repoDir = extractProp(block.props, "prefilledRepoDir")
+    const source = extractProp(block.props, "source")
+    if (source === "local" || (!source && repoDir)) {
+      return this.runGitCloneLocal(block, step, start, result, repoDir)
+    }
+
     const cloneURL = extractProp(block.props, "prefilledUrl")
     const ref = extractProp(block.props, "prefilledRef")
     const repoPath = extractProp(block.props, "prefilledRepoPath")
@@ -1377,6 +1385,78 @@ export class TestExecutor {
 
     if (this.options.verbose) {
       console.log(`--- Clone complete: ${fileCount} files ---`)
+      console.log("--- Result: ✓ success ---")
+    }
+
+    return result
+  }
+
+  /**
+   * GitClone with `source="local"`: adopt an existing checkout instead of
+   * cloning it. Emits the same `clone_path` output and becomes the active
+   * worktree, so the rest of the runbook behaves identically either way.
+   */
+  private runGitCloneLocal(
+    block: ParsedComponent,
+    step: TestStep,
+    start: number,
+    result: StepResult,
+    repoDir: string | undefined,
+  ): StepResult {
+    if (!repoDir) {
+      this.blockStates.set(block.id, "skipped")
+      result.actualStatus = "skipped"
+      result.passed = this.matchesExpectedStatus(step.expect, "skipped")
+      result.duration = Date.now() - start
+      if (this.options.verbose) console.log("--- No prefilledRepoDir specified ---")
+      return result
+    }
+
+    const resolved = path.isAbsolute(repoDir) ? repoDir : path.join(this.workingDir, repoDir)
+
+    let repoRoot: string
+    try {
+      repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+        cwd: resolved,
+        timeout: 30000,
+        stdio: "pipe",
+      })
+        .toString()
+        .trim()
+    } catch (e: unknown) {
+      result.passed = this.matchesExpectedStatus(step.expect, "fail")
+      result.actualStatus = "fail"
+      result.error = `Not a git repository: ${resolved} (${String(e)})`
+      result.duration = Date.now() - start
+      return result
+    }
+
+    // Count TRACKED files, as the app does for a local checkout: walking the
+    // directory would count .git internals and ignored build output, which say
+    // nothing about the repo the user picked.
+    let fileCount = 0
+    try {
+      const tracked = execFileSync("git", ["ls-files"], {
+        cwd: repoRoot,
+        timeout: 30000,
+        stdio: "pipe",
+      }).toString()
+      fileCount = tracked.split("\n").filter((line) => line.trim() !== "").length
+    } catch {
+      // Best-effort: a repo with no commits still counts as usable.
+    }
+
+    result.outputs = { clone_path: repoRoot, file_count: String(fileCount) }
+    this.blockOutputs.set(block.id, new Map(Object.entries(result.outputs)))
+
+    this.activeWorkTreePath = repoRoot
+    this.blockStates.set(block.id, "success")
+    result.actualStatus = "success"
+    result.passed = this.matchesExpectedStatus(step.expect, "success")
+    result.duration = Date.now() - start
+
+    if (this.options.verbose) {
+      console.log(`--- Using local checkout ${repoRoot}: ${fileCount} files ---`)
       console.log("--- Result: ✓ success ---")
     }
 

--- a/docs/src/content/docs/authoring/blocks/GitClone.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitClone.mdx
@@ -4,7 +4,7 @@ title: <GitClone>
 
 import { Aside } from '@astrojs/starlight/components';
 
-The `<GitClone>` block provides a streamlined way to clone git repositories. It works with any git upstream, and includes optional GitHub integration for browsing organizations, repositories, and branches when a GitHub token is available.
+The `<GitClone>` block provides a streamlined way to bring a git repository into a runbook: clone it fresh, or point at a checkout the user already has on disk. It works with any git upstream, and includes optional GitHub integration for browsing organizations, repositories, and branches when a GitHub token is available.
 
 Compared to using the [Command](/authoring/blocks/command/) block to clone a git repository, the GitClone block provides a purpose-built UI for cloning a git repository, the ability to search the GitHub API for orgs, repos, branches, and tags, and automatically shows the [file workspace](/authoring/workspace), where users can see the contents of the cloned repository, along with any changes to it.
 
@@ -39,6 +39,36 @@ When paired with a `<GitHubAuth>` block, the GitClone block enables a "Browse Gi
 />
 ```
 
+### Using a Local Checkout
+
+Users often already have the repository cloned — a long-lived `infrastructure-live` checkout, a work in progress branch, a monorepo they never want to re-download. The block's source picker lets them choose **Use local checkout** and select that directory instead of cloning.
+
+Selecting a directory reads it only: the block resolves the repository root (so any subdirectory of the checkout works), reads the `origin` remote and current branch, and registers the repo exactly as a clone would. Nothing is fetched, pulled, or modified, and no credentials are needed — the files are already there.
+
+```mdx
+<GitClone
+  id="repo"
+  title="Select Your Infrastructure Repo"
+  prefilledRepoDir="~/dev/infrastructure-live"
+/>
+```
+
+Setting `prefilledRepoDir` starts the block on the local source. Use `source` to choose the starting source explicitly, and `hideSourceSelect` to remove the choice altogether:
+
+```mdx
+{/* Local checkouts only — no cloning offered */}
+<GitClone id="repo" source="local" hideSourceSelect />
+
+{/* Cloning only, as before */}
+<GitClone id="repo" source="clone" hideSourceSelect prefilledUrl="https://github.com/acme/infra" />
+```
+
+Everything downstream behaves the same either way: the same `clone_path`, `repo_owner`, and `repo_name` outputs, the same `$REPO_FILES` variable, the same workspace file tree, and the same [`<GitPullRequest>`](/authoring/blocks/gitpullrequest) integration — a pull request opens against the checkout's `origin` remote and current branch.
+
+<Aside type="caution">
+A checkout with no `origin` remote can still be selected, but blocks that open a pull request need one. The block says so inline when it finds no remote.
+</Aside>
+
 ### Pre-filled Values
 
 You can pre-populate the URL, ref, sparse checkout path, and local path fields. Users can still edit these values before cloning. This follows the same pattern as the `prefilledVariables` prop on the [Inputs](/authoring/blocks/inputs) block.
@@ -68,6 +98,9 @@ You can pre-populate the URL, ref, sparse checkout path, and local path fields. 
 | `prefilledLocalPath` | `string` | No | Pre-fills the local path (relative to the current working directory) where files will be cloned. Defaults to the repository name if empty. |
 | `usePty` | `boolean` | No | Whether to use a pseudo-terminal (PTY) for the git clone process. Defaults to `true`. PTY enables rich output like progress bars and colors. Set to `false` if your environment doesn't support PTY. |
 | `showFileTree` | `boolean` | No | Whether to show the cloned repository's file tree in the workspace panel after cloning. Defaults to `true`. When enabled, the "All files" and "Changed" tabs display the cloned files and any subsequent modifications. |
+| `source` | `'clone' \| 'local'` | No | Which source the block starts on: clone a remote repo, or use an existing local checkout. Defaults to `local` when `prefilledRepoDir` is set, otherwise `clone`. |
+| `hideSourceSelect` | `boolean` | No | Hides the source picker and locks the block to `source`. Defaults to `false`. |
+| `prefilledRepoDir` | `string` | No | Pre-fills the local checkout directory. Any directory inside the checkout works — the repository root is resolved from it. |
 
 ### Ref Selection
 
@@ -88,6 +121,8 @@ When `showFileTree` is `true` (the default), the GitClone block registers the cl
 - If multiple `<GitClone>` blocks are used in a single runbook, a dropdown in the workspace header lets the user switch between repositories.
 
 Set `showFileTree={false}` if you don't want the cloned repository to appear in the workspace panel (e.g., for helper repositories that the user doesn't need to browse).
+
+A local checkout registers with the workspace the same way. Note that the **Changed** tab then shows any uncommitted changes the checkout already had, not just the ones the runbook makes.
 
 ### Accepted Git URL Formats
 
@@ -167,6 +202,8 @@ After a successful clone, the GitClone block produces outputs that can be refere
 | `org_id` | Immutable GitHub numeric ID of the owning org/user (when a GitHub token is available) | `12345678` |
 | `repo_id` | Immutable GitHub numeric ID of the repository (when a GitHub token is available) | `87654321` |
 | `repo_url` | The full URL of the cloned repository | `https://github.com/acme-corp/infrastructure-live` |
+
+For a local checkout, `clone_path` is the repository root the user selected, and `repo_owner` / `repo_name` come from its `origin` remote (omitted when the repo has no remote).
 
 Reference outputs in downstream blocks using template variables:
 

--- a/electron/main/ipc/git.ts
+++ b/electron/main/ipc/git.ts
@@ -21,6 +21,7 @@ import {
   parseOwnerRepoFromURL,
   type CreatePullRequestParams,
 } from "../../../src/domain/git/operations.ts"
+import { inspectLocalRepo } from "../../../src/domain/git/local-repo.ts"
 import { getRepo } from "../../../src/domain/github/auth.ts"
 import { injectTokenIntoUrl } from "../../../src/domain/git/url.ts"
 import { gitSpawnEnv } from "../../../src/domain/git/env.ts"
@@ -30,6 +31,7 @@ import { isContainedIn } from "../../../src/path-validation.ts"
 import { PathTraversalError, GitError, GitHubApiError, GitLabApiError } from "../../../src/errors/index.ts"
 import { validateSessionPath } from "./path-guard.ts"
 import { makeLogger } from "../logger.ts"
+import type { GitLocalRepoResponse } from "../../shared/channels.ts"
 
 const log = makeLogger("ipc:git:clone")
 
@@ -405,6 +407,92 @@ export function registerGitHandlers(): void {
         }),
         ),
       )
+    },
+  )
+
+  // Select an existing local checkout instead of cloning. The user picks the
+  // directory (native dialog or by typing a path), so registering it as a
+  // worktree here is the grant that lets the workspace/PR handlers touch a
+  // repo outside the session working directory.
+  ipcMain.handle(
+    "git:local-repo",
+    async (
+      _event,
+      params: { path: string; register?: boolean; provider?: "github" | "gitlab" },
+    ): Promise<GitLocalRepoResponse> => {
+      const program = Effect.gen(function* () {
+        const session = yield* sessionManager.getSession()
+        const info = yield* inspectLocalRepo(params.path, session.workingDir)
+
+        if (params.register) {
+          sessionManager.registerWorkTreePath(info.absolutePath)
+          log.debug("registered local checkout as worktree:", info.absolutePath)
+        }
+
+        // Same output contract as a clone, so runbooks referencing
+        // {{ .outputs.<id>.clone_path }} work with either source.
+        const outputs: Record<string, string> = {
+          clone_path: info.absolutePath,
+          ...(info.owner && info.repo
+            ? { repo_owner: info.owner, repo_name: info.repo }
+            : {}),
+        }
+
+        // GitHub numeric IDs, when a token is available — mirrors git:clone.
+        if (params.register && info.owner && info.repo && params.provider !== "gitlab") {
+          const token = yield* Effect.either(
+            getSessionTokenForProvider(
+              "github",
+              () =>
+                new GitError({
+                  command: "resolve git token",
+                  stderr: "no session token",
+                  exitCode: 1,
+                }),
+            ),
+          )
+          if (token._tag === "Right") {
+            const repoResult = yield* Effect.either(
+              getRepo(token.right, info.owner, info.repo),
+            )
+            if (repoResult._tag === "Right") {
+              outputs.org_id = String(repoResult.right.ownerId)
+              outputs.repo_id = String(repoResult.right.id)
+            } else {
+              log.debug(
+                "failed to resolve GitHub org/repo IDs (non-fatal):",
+                repoResult.left,
+              )
+            }
+          }
+        }
+
+        return {
+          status: "success" as const,
+          absolutePath: info.absolutePath,
+          relativePath: info.relativePath,
+          fileCount: info.fileCount,
+          remoteUrl: info.remoteUrl,
+          ref: info.branch,
+          refType: info.refType,
+          commitSha: info.commitSha,
+          outputs,
+        }
+      })
+
+      // A bad directory is user input, not an exception: return the message so
+      // the block renders it inline instead of throwing across IPC.
+      const exit = await runtime.runPromiseExit(program)
+      if (Exit.isSuccess(exit)) return exit.value
+
+      const failure = Cause.failureOption(exit.cause)
+      return {
+        status: "fail" as const,
+        error:
+          failure._tag === "Some"
+            ? errorMessage(failure.value)
+            : Cause.pretty(exit.cause),
+      }
     },
   )
 

--- a/electron/main/ipc/workspace.ts
+++ b/electron/main/ipc/workspace.ts
@@ -21,11 +21,20 @@ import path from "path"
 /**
  * Resolve a renderer-supplied worktree path and fail if it escapes the session
  * working directory (or the runbook directory). Returns the resolved path.
+ *
+ * Paths already registered as worktrees pass regardless of location: a local
+ * checkout the user selected in a <GitClone> block lives wherever they keep
+ * their repos, and that selection is what granted access in the first place
+ * (see the git:local-repo handler). This does not widen the grant — an
+ * unregistered path outside the session still fails.
  */
 const resolveValidatedWorktree = (worktreePath: string) =>
   Effect.gen(function* () {
     const resolved = path.resolve(worktreePath)
     const session = yield* sessionManager.getSession()
+    if (session.registeredWorkTreePaths.includes(resolved)) {
+      return resolved
+    }
     const runbookDir = runbookConfig.localPath ? path.dirname(runbookConfig.localPath) : null
     if (
       !isContainedIn(resolved, session.workingDir) &&

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -19,7 +19,7 @@ const ALLOWED_INVOKE_CHANNELS: Set<string> = new Set<InvokeChannel>([
   "gitlab:validate", "gitlab:env-credentials", "gitlab:cli-credentials", "gitlab:labels", "gitlab:enumerate-hosts",
   "gitlab:host-picked",
   "vcs:cli-status", "vcs:invalidate-cache", "vcs:apply-git-schannel",
-  "git:clone", "git:push", "git:pull-request", "git:merge-request", "git:delete-branch",
+  "git:clone", "git:local-repo", "git:push", "git:pull-request", "git:merge-request", "git:delete-branch",
   "workspace:tree", "workspace:dirs", "workspace:file", "workspace:changes",
   "workspace:register", "workspace:set-active",
   "generated-files:check", "generated-files:delete",

--- a/electron/shared/channels.ts
+++ b/electron/shared/channels.ts
@@ -493,6 +493,10 @@ export interface IpcChannelMap {
     params: GitCloneRequest
     result: { status: string; error?: string; fileCount?: number; absolutePath?: string; relativePath?: string; outputs?: Record<string, string> }
   }
+  "git:local-repo": {
+    params: GitLocalRepoRequest
+    result: GitLocalRepoResponse
+  }
   "git:push": { params: { worktreePath: string; branchName: string; provider?: "github" | "gitlab" }; result: { ok: true } | { error: string } }
   "git:pull-request": { params: PullRequestRequest; result: { url: string; number: number } | { error: string } }
   "git:merge-request": { params: PullRequestRequest; result: { url: string; number: number } | { error: string } }
@@ -813,6 +817,42 @@ export interface GitHubRepo {
 export interface GitHubRef {
   ref: string
   type: "branch" | "tag"
+}
+
+/**
+ * Select an existing local checkout instead of cloning. `path` is the directory
+ * the user picked (absolute, or relative to the session working directory); the
+ * backend resolves it to the repository root before registering it.
+ */
+export interface GitLocalRepoRequest {
+  path: string
+  /**
+   * Register the repo as a session worktree (granting the workspace/PR
+   * handlers access to it). False — the default — only inspects the directory,
+   * which is what the block's live "is this a repo?" preview needs; the user
+   * confirming their selection is what registers it.
+   */
+  register?: boolean
+  /**
+   * Provider of the linked Git Auth block. Only used to decide whether the
+   * numeric GitHub org/repo IDs can be resolved, exactly as in a clone.
+   */
+  provider?: "github" | "gitlab"
+}
+
+/** Result of selecting a local checkout (mirrors the git:clone result shape). */
+export interface GitLocalRepoResponse {
+  status: "success" | "fail"
+  error?: string
+  absolutePath?: string
+  relativePath?: string
+  fileCount?: number
+  remoteUrl?: string
+  /** Checked out branch or tag name; empty for a repo with no commits. */
+  ref?: string
+  refType?: "branch" | "tag" | "detached"
+  commitSha?: string
+  outputs?: Record<string, string>
 }
 
 export interface GitCloneRequest {

--- a/src/domain/git/local-repo.test.ts
+++ b/src/domain/git/local-repo.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "bun:test"
+import { Effect } from "effect"
+import { inspectLocalRepo, resolveLocalRepoPath } from "./local-repo.ts"
+import { makeTestLayer } from "../../test-utils/TestLayer.ts"
+import type { TestLayerOptions } from "../../test-utils/TestLayer.ts"
+import { FileSystem } from "../../services/FileSystem.ts"
+import { GitError } from "../../errors/index.ts"
+
+const WORKING_DIR = "/work/runbook"
+
+const lsFiles = (names: string[]) => ({
+  command: "git",
+  args: ["ls-files"],
+  outputLines: names,
+  exitCode: 0,
+})
+
+/**
+ * Run inspectLocalRepo against a test layer, creating `dirs` first so the
+ * stubbed FileSystem reports them as directories (it only knows about
+ * directories that were mkdir'd).
+ */
+const inspect = (
+  dir: string,
+  options: TestLayerOptions & { dirs?: string[] } = {},
+) => {
+  const { dirs = [], ...layerOptions } = options
+  const layer = makeTestLayer(layerOptions)
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem
+      for (const d of dirs) yield* fs.mkdir(d)
+      return yield* inspectLocalRepo(dir, WORKING_DIR)
+    }).pipe(Effect.provide(layer)),
+  )
+}
+
+/**
+ * The failure text users see. GitError inherits Error but leaves `.message`
+ * empty, so assertions read the tagged `stderr` field instead.
+ */
+const inspectFailure = async (
+  dir: string,
+  options: TestLayerOptions & { dirs?: string[] } = {},
+): Promise<string> => {
+  const { dirs = [], ...layerOptions } = options
+  const layer = makeTestLayer(layerOptions)
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem
+      for (const d of dirs) yield* fs.mkdir(d)
+      return yield* Effect.either(inspectLocalRepo(dir, WORKING_DIR))
+    }).pipe(Effect.provide(layer)),
+  )
+  if (result._tag === "Right") throw new Error("expected inspectLocalRepo to fail")
+  return result.left.stderr
+}
+
+describe("resolveLocalRepoPath", () => {
+  it("keeps absolute paths", () => {
+    expect(resolveLocalRepoPath("/home/me/infra", WORKING_DIR)).toBe("/home/me/infra")
+  })
+
+  it("resolves relative paths against the working directory", () => {
+    expect(resolveLocalRepoPath("checkouts/infra", WORKING_DIR)).toBe(
+      "/work/runbook/checkouts/infra",
+    )
+  })
+})
+
+describe("inspectLocalRepo", () => {
+  it("describes a checkout outside the working directory", async () => {
+    const info = await inspect("/home/me/infra", {
+      dirs: ["/home/me/infra"],
+      commands: [lsFiles(["main.tf", "vars.tf", "README.md"])],
+      git: {
+        getRepoRoot: () => Effect.succeed("/home/me/infra"),
+        getInfo: () =>
+          Effect.succeed({
+            branch: "main",
+            refType: "branch" as const,
+            remoteUrl: "https://github.com/acme/infra.git",
+            commitSha: "abc123",
+          }),
+      },
+    })
+
+    expect(info.absolutePath).toBe("/home/me/infra")
+    // Outside the working dir, the absolute path is the only sensible display form.
+    expect(info.relativePath).toBe("/home/me/infra")
+    expect(info.fileCount).toBe(3)
+    expect(info.branch).toBe("main")
+    expect(info.remoteUrl).toBe("https://github.com/acme/infra.git")
+    expect(info.owner).toBe("acme")
+    expect(info.repo).toBe("infra")
+  })
+
+  it("resolves the repository root when a subdirectory is selected", async () => {
+    const info = await inspect("/home/me/infra/modules/vpc", {
+      dirs: ["/home/me/infra/modules/vpc"],
+      commands: [lsFiles(["main.tf"])],
+      git: {
+        getRepoRoot: () => Effect.succeed("/home/me/infra"),
+        getInfo: () => Effect.succeed({ branch: "main", refType: "branch" as const }),
+      },
+    })
+
+    expect(info.absolutePath).toBe("/home/me/infra")
+  })
+
+  it("reports a path inside the working directory as relative", async () => {
+    const info = await inspect("checkouts/infra", {
+      dirs: ["/work/runbook/checkouts/infra"],
+      commands: [lsFiles(["main.tf"])],
+      git: {
+        getRepoRoot: () => Effect.succeed("/work/runbook/checkouts/infra"),
+        getInfo: () => Effect.succeed({ branch: "main", refType: "branch" as const }),
+      },
+    })
+
+    expect(info.absolutePath).toBe("/work/runbook/checkouts/infra")
+    expect(info.relativePath).toBe("checkouts/infra")
+  })
+
+  it("succeeds for a repo with no commits yet", async () => {
+    const info = await inspect("/home/me/fresh", {
+      dirs: ["/home/me/fresh"],
+      commands: [lsFiles([])],
+      git: {
+        getRepoRoot: () => Effect.succeed("/home/me/fresh"),
+        getInfo: () =>
+          Effect.fail(
+            new GitError({ command: "git rev-parse", stderr: "no HEAD", exitCode: 128 }),
+          ),
+      },
+    })
+
+    expect(info.branch).toBe("")
+    expect(info.fileCount).toBe(0)
+    expect(info.owner).toBeUndefined()
+  })
+
+  it("omits owner/repo when the repo has no remote", async () => {
+    const info = await inspect("/home/me/local-only", {
+      dirs: ["/home/me/local-only"],
+      commands: [lsFiles(["a.txt"])],
+      git: {
+        getRepoRoot: () => Effect.succeed("/home/me/local-only"),
+        getInfo: () => Effect.succeed({ branch: "main", refType: "branch" as const }),
+      },
+    })
+
+    expect(info.remoteUrl).toBeUndefined()
+    expect(info.owner).toBeUndefined()
+    expect(info.repo).toBeUndefined()
+  })
+
+  it("fails when the directory is not a git work tree", async () => {
+    const stderr = await inspectFailure("/home/me/notes", {
+      dirs: ["/home/me/notes"],
+      git: {
+        getRepoRoot: () =>
+          Effect.fail(
+            new GitError({
+              command: "git rev-parse",
+              stderr: "not a git repository",
+              exitCode: 128,
+            }),
+          ),
+      },
+    })
+
+    expect(stderr).toBe("Not a git repository: /home/me/notes")
+  })
+
+  it("fails when the directory does not exist", async () => {
+    expect(await inspectFailure("/home/me/missing")).toBe(
+      "Directory not found: /home/me/missing",
+    )
+  })
+
+  it("fails when the path is a file", async () => {
+    const stderr = await inspectFailure("/home/me/notes.txt", {
+      files: { "/home/me/notes.txt": "hi" },
+    })
+    expect(stderr).toBe("Not a directory: /home/me/notes.txt")
+  })
+
+  it("fails when no directory was given", async () => {
+    expect(await inspectFailure("   ")).toBe("No repository directory selected.")
+  })
+})

--- a/src/domain/git/local-repo.ts
+++ b/src/domain/git/local-repo.ts
@@ -1,0 +1,147 @@
+/**
+ * Inspecting an existing local checkout of a git repository.
+ *
+ * The `<GitClone>` block can either clone a repo or point at a checkout the
+ * user already has on disk. This module covers the second case: resolve the
+ * directory the user picked, confirm it really is a git work tree, and gather
+ * the same metadata a fresh clone would produce (repo root, remote, ref, file
+ * count) so downstream blocks — the workspace file tree, `<GitPullRequest>`,
+ * `<DirPicker>` — behave identically either way.
+ */
+import path from "path"
+import { Effect } from "effect"
+import { GitClient } from "../../services/GitClient.ts"
+import type { GitInfo } from "../../services/GitClient.ts"
+import { FileSystem } from "../../services/FileSystem.ts"
+import { ProcessSpawner } from "../../services/ProcessSpawner.ts"
+import { GitError } from "../../errors/index.ts"
+import { countFiles, parseOwnerRepoFromURL } from "./operations.ts"
+
+/** Metadata describing a local checkout selected by the user. */
+export interface LocalRepoInfo {
+  /** Absolute path of the repository root (not the directory the user picked, if it was a subdirectory). */
+  readonly absolutePath: string
+  /** Path relative to the session working directory; absolute when the repo lives outside it. */
+  readonly relativePath: string
+  /** Number of tracked files (`git ls-files`). */
+  readonly fileCount: number
+  /** `origin` remote URL, when the repo has one. */
+  readonly remoteUrl?: string
+  /** Currently checked out branch/tag, or "HEAD" when detached. */
+  readonly branch: string
+  readonly refType: GitInfo["refType"]
+  readonly commitSha?: string
+  /** Owner/repo parsed from the remote URL, when parseable. */
+  readonly owner?: string
+  readonly repo?: string
+}
+
+/**
+ * Resolve a user-supplied checkout directory. Relative paths resolve against
+ * the session working directory, matching how `resolveClonePaths` treats a
+ * relative `localPath`.
+ */
+export const resolveLocalRepoPath = (dir: string, workingDir: string): string =>
+  path.isAbsolute(dir) ? path.resolve(dir) : path.resolve(workingDir, dir)
+
+/**
+ * Resolve, validate, and describe a local checkout.
+ *
+ * Fails with a GitError carrying a user-facing `stderr` when the directory is
+ * missing, is not a directory, or is not inside a git work tree.
+ */
+export const inspectLocalRepo = (
+  dir: string,
+  workingDir: string,
+): Effect.Effect<
+  LocalRepoInfo,
+  GitError,
+  GitClient | FileSystem | ProcessSpawner
+> =>
+  Effect.gen(function* () {
+    const trimmed = dir.trim()
+    if (!trimmed) {
+      return yield* Effect.fail(
+        new GitError({
+          command: "git rev-parse --show-toplevel",
+          stderr: "No repository directory selected.",
+          exitCode: 1,
+        }),
+      )
+    }
+
+    const selected = resolveLocalRepoPath(trimmed, workingDir)
+    const fs = yield* FileSystem
+
+    const stat = yield* fs.stat(selected).pipe(
+      Effect.catchAll(() =>
+        Effect.fail(
+          new GitError({
+            command: "stat",
+            stderr: `Directory not found: ${selected}`,
+            exitCode: 1,
+          }),
+        ),
+      ),
+    )
+    if (!stat.isDirectory) {
+      return yield* Effect.fail(
+        new GitError({
+          command: "stat",
+          stderr: `Not a directory: ${selected}`,
+          exitCode: 1,
+        }),
+      )
+    }
+
+    // Resolve the work tree root, so picking a subdirectory of a checkout
+    // still registers the repository itself.
+    const git = yield* GitClient
+    const root = yield* git.getRepoRoot(selected).pipe(
+      Effect.catchAll(() =>
+        Effect.fail(
+          new GitError({
+            command: "git rev-parse --show-toplevel",
+            stderr: `Not a git repository: ${selected}`,
+            exitCode: 1,
+          }),
+        ),
+      ),
+    )
+    const absolutePath = root ? path.resolve(root) : selected
+
+    // A repo with no commits yet has no HEAD to describe — treat the whole
+    // lookup as best-effort so an empty checkout is still selectable.
+    const info = yield* git.getInfo(absolutePath).pipe(
+      Effect.catchAll(() =>
+        Effect.succeed({ branch: "", refType: "branch" } as GitInfo),
+      ),
+    )
+
+    const fileCount = yield* countFiles(absolutePath)
+    const parsed = info.remoteUrl ? parseOwnerRepoFromURL(info.remoteUrl) : undefined
+
+    return {
+      absolutePath,
+      relativePath: relativeToWorkingDir(absolutePath, workingDir),
+      fileCount,
+      remoteUrl: info.remoteUrl,
+      branch: info.branch,
+      refType: info.refType,
+      commitSha: info.commitSha,
+      owner: parsed?.owner,
+      repo: parsed?.repo,
+    } satisfies LocalRepoInfo
+  })
+
+/**
+ * Display path for a checkout: relative to the working directory when it lives
+ * inside it, absolute otherwise. A local checkout is usually somewhere else
+ * entirely, and `../../../dev/repo` reads worse than the absolute path.
+ */
+function relativeToWorkingDir(absolutePath: string, workingDir: string): string {
+  const relative = path.relative(workingDir, absolutePath)
+  if (!relative) return "."
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return absolutePath
+  return relative
+}

--- a/src/layers/GitCliClient.ts
+++ b/src/layers/GitCliClient.ts
@@ -179,6 +179,15 @@ function makeGitClient(spawner: ProcessSpawner["Type"]): GitClientShape {
         return lines[0] ?? ""
       }),
 
+    getRepoRoot: (repoPath: string) =>
+      Effect.gen(function* () {
+        // `--show-toplevel` resolves the repo root from anywhere inside the
+        // work tree, so a user who picks a subdirectory of their checkout
+        // still ends up registering the repo itself.
+        const lines = yield* runGit(spawner, ["rev-parse", "--show-toplevel"], repoPath)
+        return lines[0]?.trim() ?? ""
+      }),
+
     getRemoteUrl: (repoPath: string) =>
       Effect.gen(function* () {
         const lines = yield* runGit(spawner, ["remote", "get-url", "origin"], repoPath)

--- a/src/services/GitClient.ts
+++ b/src/services/GitClient.ts
@@ -69,6 +69,8 @@ export interface GitClientShape {
   readonly push: (repoPath: string, remote: string, branch: string, options?: PushOptions) => Effect.Effect<void, GitError | SpawnError>
   readonly deleteBranch: (repoPath: string, branch: string) => Effect.Effect<void, GitError | SpawnError>
   readonly getCurrentBranch: (repoPath: string) => Effect.Effect<string, GitError | SpawnError>
+  /** Absolute path of the repository root containing `repoPath` (`git rev-parse --show-toplevel`). */
+  readonly getRepoRoot: (repoPath: string) => Effect.Effect<string, GitError | SpawnError>
   readonly getRemoteUrl: (repoPath: string) => Effect.Effect<string, GitError | SpawnError>
   readonly getInfo: (repoPath: string) => Effect.Effect<GitInfo, GitError | SpawnError>
   readonly diff: (repoPath: string, filePath?: string) => Effect.Effect<DiffEntry[], GitError | SpawnError>

--- a/src/test-utils/TestLayer.ts
+++ b/src/test-utils/TestLayer.ts
@@ -102,6 +102,8 @@ const makeStubGitClient = (overrides: Partial<GitClientShape> = {}): GitClientSh
     Effect.fail(new GitError({ command: "branch -D", stderr: notConfigured("GitClient", "deleteBranch"), exitCode: 1 })),
   getCurrentBranch: (_repoPath) =>
     Effect.fail(new GitError({ command: "branch", stderr: notConfigured("GitClient", "getCurrentBranch"), exitCode: 1 })),
+  getRepoRoot: (_repoPath) =>
+    Effect.fail(new GitError({ command: "rev-parse", stderr: notConfigured("GitClient", "getRepoRoot"), exitCode: 1 })),
   getRemoteUrl: (_repoPath) =>
     Effect.fail(new GitError({ command: "remote", stderr: notConfigured("GitClient", "getRemoteUrl"), exitCode: 1 })),
   getInfo: (_repoPath) =>

--- a/web/src/components/mdx/GitClone/GitClone.tsx
+++ b/web/src/components/mdx/GitClone/GitClone.tsx
@@ -11,6 +11,8 @@ import { useGitWorkTree } from "@/contexts/useGitWorkTree"
 import { useOutputs } from "@/contexts/useRunbook"
 import { useGitClone } from "./hooks/useGitClone"
 import { GitHubBrowser } from "./components/GitHubBrowser"
+import { SourceSelect } from "./components/SourceSelect"
+import { LocalRepoForm } from "./components/LocalRepoForm"
 import { CloneResultDisplay } from "./components/CloneResult"
 import { CollapsibleToggle } from "@/components/mdx/GitPullRequest/components/CollapsibleToggle"
 import { extractTemplateDependenciesFromString, splitDependencies } from "@/lib/extractTemplateDependencies"
@@ -21,7 +23,8 @@ import { ErrorDisplay } from "@/components/mdx/_shared/components/ErrorDisplay"
 import { useInstructionMode } from "@/contexts/useInstructionMode"
 import { GitCloneInstruction } from "./GitCloneInstruction"
 import type { AppError } from "@/types/error"
-import type { GitCloneProps } from "./types"
+import { resolveInitialSource, defaultDescription } from "./utils"
+import type { GitCloneProps, GitCloneSource } from "./types"
 
 /**
  * Parse owner and repo from a git remote URL (GitHub, GitLab, or self-hosted).
@@ -58,7 +61,7 @@ function parseOwnerRepoFromURL(url: string): { org: string; repo: string } | nul
 function GitCloneInteractive({
   id,
   title = "Clone Repository",
-  description = "Enter a git URL to clone a repository",
+  description,
   inputsId,
   githubAuthId,
   gitAuthId,
@@ -68,6 +71,9 @@ function GitCloneInteractive({
   prefilledLocalPath = '',
   usePty,
   showFileTree = true,
+  source,
+  hideSourceSelect = false,
+  prefilledRepoDir = '',
 }: GitCloneProps) {
   const validationError = useMemo((): AppError | null => {
     if (!id) {
@@ -82,11 +88,11 @@ function GitCloneInteractive({
   // --- Template dependency resolution (resolve inputs/outputs expressions) ---
 
   // 1. EXTRACT — discover dependencies from template-capable props
-  // Blocking dependencies (functional props): prefilledUrl, prefilledRef, prefilledRepoPath, prefilledLocalPath
+  // Blocking dependencies (functional props): prefilledUrl, prefilledRef, prefilledRepoPath, prefilledLocalPath, prefilledRepoDir
   const blockingDeps = useMemo(() => extractTemplateDependenciesFromString(
-    [prefilledUrl, prefilledRef, prefilledRepoPath, prefilledLocalPath]
+    [prefilledUrl, prefilledRef, prefilledRepoPath, prefilledLocalPath, prefilledRepoDir]
       .filter(Boolean).join('\n')
-  ), [prefilledUrl, prefilledRef, prefilledRepoPath, prefilledLocalPath])
+  ), [prefilledUrl, prefilledRef, prefilledRepoPath, prefilledLocalPath, prefilledRepoDir])
 
   // Non-blocking dependencies (display props): title, description
   const nonBlockingDeps = useMemo(() => extractTemplateDependenciesFromString(
@@ -117,8 +123,13 @@ function GitCloneInteractive({
   const resolvedRef = useMemo(() => resolveTemplateReferences(prefilledRef, ctx), [prefilledRef, ctx])
   const resolvedRepoPath = useMemo(() => resolveTemplateReferences(prefilledRepoPath, ctx), [prefilledRepoPath, ctx])
   const resolvedLocalPath = useMemo(() => resolveTemplateReferences(prefilledLocalPath, ctx), [prefilledLocalPath, ctx])
+  const resolvedRepoDir = useMemo(() => resolveTemplateReferences(prefilledRepoDir, ctx), [prefilledRepoDir, ctx])
+  const initialSource = useMemo(() => resolveInitialSource({ source, prefilledRepoDir }), [source, prefilledRepoDir])
   const resolvedTitle = useMemo(() => resolveTemplateReferences(title ?? 'Clone Repository', ctx), [title, ctx])
-  const resolvedDescription = useMemo(() => resolveTemplateReferences(description ?? 'Enter a git URL to clone a repository', ctx), [description, ctx])
+  const resolvedDescription = useMemo(
+    () => resolveTemplateReferences(description ?? defaultDescription(initialSource), ctx),
+    [description, initialSource, ctx],
+  )
 
   // --- End template dependency resolution ---
 
@@ -144,7 +155,14 @@ function GitCloneInteractive({
     tokenChecked,
     gitHubAuthMet,
     workingDir,
+    localPreview,
+    localPreviewStatus,
+    localPreviewError,
     clone,
+    browseForRepoDir,
+    previewLocalRepo,
+    selectLocalRepo,
+    resetLocalPreview,
     cancel,
     reset,
     checkGitHubToken,
@@ -164,6 +182,10 @@ function GitCloneInteractive({
   const [ref, setRef] = useState(resolvedRef)
   const [repoPath, setRepoPath] = useState(resolvedRepoPath)
   const [localPath, setLocalPath] = useState(resolvedLocalPath)
+  const [repoDir, setRepoDir] = useState(resolvedRepoDir)
+  // Which source the block is on. A prefilled checkout directory means the
+  // author expects a local repo, so start there unless told otherwise.
+  const [activeSource, setActiveSource] = useState<GitCloneSource>(initialSource)
   const [copiedPathKey, setCopiedPathKey] = useState<string | null>(null)
   const [showAdditionalSettings, setShowAdditionalSettings] = useState(
     !!(prefilledRef || prefilledRepoPath || prefilledLocalPath)
@@ -176,6 +198,54 @@ function GitCloneInteractive({
   useEffect(() => { setRef(resolvedRef) }, [resolvedRef])
   useEffect(() => { setRepoPath(resolvedRepoPath) }, [resolvedRepoPath])
   useEffect(() => { setLocalPath(resolvedLocalPath) }, [resolvedLocalPath])
+  useEffect(() => { setRepoDir(resolvedRepoDir) }, [resolvedRepoDir])
+
+  // Verify the typed/picked directory as the user edits it. Debounced so a
+  // half-typed path doesn't spawn a git process per keystroke; the check only
+  // inspects the directory — selecting it is the user's explicit confirmation.
+  useEffect(() => {
+    if (activeSource !== 'local' || cloneStatus === 'success') return
+    const trimmed = repoDir.trim()
+    if (!trimmed) {
+      resetLocalPreview()
+      return
+    }
+    const timer = setTimeout(() => { previewLocalRepo(trimmed) }, 400)
+    return () => clearTimeout(timer)
+  }, [repoDir, activeSource, cloneStatus, previewLocalRepo, resetLocalPreview])
+
+  const handleBrowseForRepo = useCallback(async () => {
+    const picked = await browseForRepoDir()
+    // Dialog dismissed — leave the typed path untouched.
+    if (picked) setRepoDir(picked)
+  }, [browseForRepoDir])
+
+  const handleUseLocalRepo = useCallback(async () => {
+    const info = await selectLocalRepo(repoDir)
+    if (!info || !showFileTree) return
+
+    // Register the checkout exactly like a clone, so the workspace file tree
+    // and <GitPullRequest> treat both sources identically.
+    const parsed = info.remoteUrl ? parseOwnerRepoFromURL(info.remoteUrl) : null
+    // Split on both separators: the backend resolves the root with Node's
+    // path module, which yields backslashes on Windows.
+    const dirName = info.absolutePath.split(/[\\/]/).filter(Boolean).pop() ?? info.absolutePath
+    registerWorkTree({
+      id,
+      repoUrl: info.remoteUrl ?? '',
+      localPath: info.absolutePath,
+      gitInfo: {
+        repoUrl: info.remoteUrl ?? '',
+        repoName: parsed?.repo ?? dirName,
+        repoOwner: parsed?.org ?? '',
+        // The checked-out ref is the PR base branch, mirroring the clone path
+        // where the cloned ref plays that role.
+        ref: info.ref || 'main',
+        refType: info.refType === 'detached' ? 'commit' : info.refType,
+        commitSha: info.commitSha,
+      },
+    })
+  }, [selectLocalRepo, repoDir, showFileTree, registerWorkTree, id])
 
   const handleCopyPath = useCallback(async (key: string, value: string) => {
     const ok = await copyTextToClipboard(value)
@@ -234,8 +304,11 @@ function GitCloneInteractive({
     }
   }, [id, isDuplicate, isNormalizedCollision, collidingId, reportError, clearError])
 
-  // Register the cloned repo as a git worktree when clone succeeds
+  // Register the cloned repo as a git worktree when clone succeeds. The local
+  // checkout registers itself in handleUseLocalRepo, which has the repo's real
+  // remote and ref to hand — this path only covers cloning.
   useEffect(() => {
+    if (activeSource === 'local') return
     if (cloneStatus === 'success' && cloneResult && showFileTree) {
       // Parse owner/repoName from the git URL
       const parsed = parseOwnerRepoFromURL(gitUrl)
@@ -268,6 +341,11 @@ function GitCloneInteractive({
   }, [resolvedUrl])
 
   const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false)
+
+  const handleSourceSelect = useCallback((next: GitCloneSource) => {
+    setActiveSource(next)
+    setShowOverwriteConfirm(false)
+  }, [])
 
   const handleClone = useCallback(async (force?: boolean) => {
     if (!gitUrl.trim()) return
@@ -303,8 +381,13 @@ function GitCloneInteractive({
 
   const { bg: statusClasses, icon: IconComponent, iconColor: iconClasses } = statusConfig[cloneStatus] ?? statusConfig.pending
 
-  const isFormDisabled = cloneStatus === 'running' || !gitHubAuthMet || !hasAllBlockingDependencies
+  const isLocalSource = activeSource === 'local'
+  // Selecting a checkout that already exists on disk needs no credentials —
+  // only cloning does. Auth still gates the clone form as before.
+  const isFormDisabled =
+    cloneStatus === 'running' || !hasAllBlockingDependencies || (!isLocalSource && !gitHubAuthMet)
   const isCloneDisabled = isFormDisabled || !gitUrl.trim()
+  const isUseRepoDisabled = isFormDisabled || localPreviewStatus !== 'valid'
 
   // Early return for validation errors (e.g. missing id prop)
   if (validationError) {
@@ -347,8 +430,8 @@ function GitCloneInteractive({
             />
           )}
 
-          {/* Blocked state: waiting for the referenced auth block */}
-          {hasAllBlockingDependencies && !gitHubAuthMet && (
+          {/* Blocked state: waiting for the referenced auth block (cloning only) */}
+          {hasAllBlockingDependencies && !gitHubAuthMet && !isLocalSource && (
             <div className="mb-4 p-3 bg-warning-muted border border-warning/30 rounded-md flex items-start gap-2">
               <AlertTriangle className="size-4 text-warning mt-0.5 shrink-0" />
               <div>
@@ -362,157 +445,189 @@ function GitCloneInteractive({
 
           {/* Success state */}
           {cloneStatus === 'success' && cloneResult ? (
-            <CloneResultDisplay result={cloneResult} onCloneAgain={handleCloneAgain} />
+            <CloneResultDisplay
+              result={cloneResult}
+              source={activeSource}
+              remoteUrl={localPreview?.remoteUrl}
+              onCloneAgain={handleCloneAgain}
+            />
           ) : (
             /* Form state (ready, running, fail) */
             <div className="space-y-3">
-              {/* Separator */}
-              <div className="border-b border-border"></div>
-
-              {/* Git URL input */}
-              <div>
-                <label className="text-sm font-medium text-foreground mb-1 block">
-                  Git URL
-                </label>
-                <input
-                  type="text"
-                  value={gitUrl}
-                  onChange={(e) => setGitUrl(e.target.value)}
-                  placeholder="https://github.com/org/repo.git"
-                  disabled={isFormDisabled}
-                  className="w-full px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
-                />
-              </div>
-
-              {/* GitHub Browser (only if token available) */}
-              {tokenChecked && hasGitHubToken && (
-                <GitHubBrowser
-                  onRepoSelected={handleRepoSelected}
-                  onRefSelected={handleRefSelected}
-                  fetchOrgs={fetchOrgs}
-                  fetchRepos={fetchRepos}
-                  fetchRefs={fetchRefs}
-                  disabled={isFormDisabled}
-                  initialOrg={prefilledGitHub?.org}
-                  initialRepo={prefilledGitHub?.repo}
-                  defaultOpen={false}
+              {/* Repository source: clone a remote repo, or use a local checkout */}
+              {hideSourceSelect ? (
+                <div className="border-b border-border"></div>
+              ) : (
+                <SourceSelect
+                  source={activeSource}
+                  onSelect={handleSourceSelect}
+                  disabled={cloneStatus === 'running'}
                 />
               )}
 
-              {/* Additional Settings (Ref, Repo Path, Local Path) */}
-              <CollapsibleToggle
-                expanded={showAdditionalSettings}
-                onToggle={() => setShowAdditionalSettings(prev => !prev)}
-                label="Additional Settings"
-                disabled={isFormDisabled}
-              >
-                <div className="space-y-3 mt-3">
-                  {/* Ref (branch/tag) */}
+              {isLocalSource && (
+                <LocalRepoForm
+                  repoDir={repoDir}
+                  onRepoDirChange={setRepoDir}
+                  onBrowse={handleBrowseForRepo}
+                  previewStatus={localPreviewStatus}
+                  preview={localPreview}
+                  previewError={localPreviewError}
+                  disabled={isFormDisabled}
+                />
+              )}
+
+              {/* Clone form: remote URL, repo browser, and clone options */}
+              {!isLocalSource && (
+                <>
+                  {/* Git URL input */}
                   <div>
-                    <label className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
-                      Ref <span className="font-normal text-muted-foreground">(optional)</span>
-                      <InfoTooltip>
-                        The branch or tag to clone. Defaults to the repository&apos;s default branch if not specified.
-                        {tokenChecked && hasGitHubToken && (
-                          <>
-                            <br /><br /><strong>Tip:</strong> Use the GitHub browser above to browse branches and tags.
-                          </>
-                        )}
-                      </InfoTooltip>
+                    <label className="text-sm font-medium text-foreground mb-1 block">
+                      Git URL
                     </label>
                     <input
                       type="text"
-                      value={ref}
-                      onChange={(e) => setRef(e.target.value)}
-                      placeholder="Defaults to default branch"
+                      value={gitUrl}
+                      onChange={(e) => setGitUrl(e.target.value)}
+                      placeholder="https://github.com/org/repo.git"
                       disabled={isFormDisabled}
                       className="w-full px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
                     />
                   </div>
 
-                  {/* Repo Path (sparse checkout) */}
-                  <div>
-                    <label className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
-                      Repo Path <span className="font-normal text-muted-foreground">(optional)</span>
-                      <InfoTooltip>
-                        Clone only a specific subdirectory of the repository using sparse checkout. For example, <code>modules/vpc</code> would clone only that path instead of the entire repo.
-                      </InfoTooltip>
-                    </label>
-                    <input
-                      type="text"
-                      value={repoPath}
-                      onChange={(e) => setRepoPath(e.target.value)}
-                      placeholder="e.g., modules/vpc"
+                  {/* GitHub Browser (only if token available) */}
+                  {tokenChecked && hasGitHubToken && (
+                    <GitHubBrowser
+                      onRepoSelected={handleRepoSelected}
+                      onRefSelected={handleRefSelected}
+                      fetchOrgs={fetchOrgs}
+                      fetchRepos={fetchRepos}
+                      fetchRefs={fetchRefs}
                       disabled={isFormDisabled}
-                      className="w-full px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
+                      initialOrg={prefilledGitHub?.org}
+                      initialRepo={prefilledGitHub?.repo}
+                      defaultOpen={false}
                     />
-                  </div>
+                  )}
 
-                  {/* Local Path (destination) */}
-                  <div>
-                    <label className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
-                      Local Path <span className="font-normal text-muted-foreground">(optional)</span>
-                      <InfoTooltip>
-                        The directory where the cloned files will be saved, relative to the current working directory. Defaults to the repository name if not specified.
-                      </InfoTooltip>
-                    </label>
-                    <input
-                      type="text"
-                      value={localPath}
-                      onChange={(e) => setLocalPath(e.target.value)}
-                      placeholder="Defaults to repo name"
-                      disabled={isFormDisabled}
-                      className="w-full px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
-                    />
-                    {pathPreview && (
-                      <div className="mt-1.5 text-xs text-muted-foreground space-y-0.5">
-                        <div className="flex items-center gap-1">
-                          <span className="text-muted-foreground">Relative:</span>
-                          <code className="bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">{pathPreview.relative}</code>
-                          <button
-                            onClick={() => handleCopyPath('relative', pathPreview.relative)}
-                            className="shrink-0 p-0.5 text-muted-foreground hover:text-foreground cursor-pointer"
-                          >
-                            {copiedPathKey === 'relative' ? (
-                              <Check className="size-3 text-success" />
-                            ) : (
-                              <Copy className="size-3" />
+                  {/* Additional Settings (Ref, Repo Path, Local Path) */}
+                  <CollapsibleToggle
+                    expanded={showAdditionalSettings}
+                    onToggle={() => setShowAdditionalSettings(prev => !prev)}
+                    label="Additional Settings"
+                    disabled={isFormDisabled}
+                  >
+                    <div className="space-y-3 mt-3">
+                      {/* Ref (branch/tag) */}
+                      <div>
+                        <label className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
+                          Ref <span className="font-normal text-muted-foreground">(optional)</span>
+                          <InfoTooltip>
+                            The branch or tag to clone. Defaults to the repository&apos;s default branch if not specified.
+                            {tokenChecked && hasGitHubToken && (
+                              <>
+                                <br /><br /><strong>Tip:</strong> Use the GitHub browser above to browse branches and tags.
+                              </>
                             )}
-                          </button>
-                        </div>
-                        <div className="flex items-center gap-1">
-                          <span className="text-muted-foreground">Absolute:</span>
-                          <code className="bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">{pathPreview.absolute}</code>
-                          <button
-                            onClick={() => handleCopyPath('absolute', pathPreview.absolute)}
-                            className="shrink-0 p-0.5 text-muted-foreground hover:text-foreground cursor-pointer"
-                          >
-                            {copiedPathKey === 'absolute' ? (
-                              <Check className="size-3 text-success" />
-                            ) : (
-                              <Copy className="size-3" />
-                            )}
-                          </button>
-                        </div>
+                          </InfoTooltip>
+                        </label>
+                        <input
+                          type="text"
+                          value={ref}
+                          onChange={(e) => setRef(e.target.value)}
+                          placeholder="Defaults to default branch"
+                          disabled={isFormDisabled}
+                          className="w-full px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
+                        />
                       </div>
-                    )}
-                  </div>
-                </div>
-              </CollapsibleToggle>
+
+                      {/* Repo Path (sparse checkout) */}
+                      <div>
+                        <label className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
+                          Repo Path <span className="font-normal text-muted-foreground">(optional)</span>
+                          <InfoTooltip>
+                            Clone only a specific subdirectory of the repository using sparse checkout. For example, <code>modules/vpc</code> would clone only that path instead of the entire repo.
+                          </InfoTooltip>
+                        </label>
+                        <input
+                          type="text"
+                          value={repoPath}
+                          onChange={(e) => setRepoPath(e.target.value)}
+                          placeholder="e.g., modules/vpc"
+                          disabled={isFormDisabled}
+                          className="w-full px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
+                        />
+                      </div>
+
+                      {/* Local Path (destination) */}
+                      <div>
+                        <label className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
+                          Local Path <span className="font-normal text-muted-foreground">(optional)</span>
+                          <InfoTooltip>
+                            The directory where the cloned files will be saved, relative to the current working directory. Defaults to the repository name if not specified.
+                          </InfoTooltip>
+                        </label>
+                        <input
+                          type="text"
+                          value={localPath}
+                          onChange={(e) => setLocalPath(e.target.value)}
+                          placeholder="Defaults to repo name"
+                          disabled={isFormDisabled}
+                          className="w-full px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
+                        />
+                        {pathPreview && (
+                          <div className="mt-1.5 text-xs text-muted-foreground space-y-0.5">
+                            <div className="flex items-center gap-1">
+                              <span className="text-muted-foreground">Relative:</span>
+                              <code className="bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">{pathPreview.relative}</code>
+                              <button
+                                onClick={() => handleCopyPath('relative', pathPreview.relative)}
+                                className="shrink-0 p-0.5 text-muted-foreground hover:text-foreground cursor-pointer"
+                              >
+                                {copiedPathKey === 'relative' ? (
+                                  <Check className="size-3 text-success" />
+                                ) : (
+                                  <Copy className="size-3" />
+                                )}
+                              </button>
+                            </div>
+                            <div className="flex items-center gap-1">
+                              <span className="text-muted-foreground">Absolute:</span>
+                              <code className="bg-muted px-1 py-0.5 rounded font-mono text-muted-foreground">{pathPreview.absolute}</code>
+                              <button
+                                onClick={() => handleCopyPath('absolute', pathPreview.absolute)}
+                                className="shrink-0 p-0.5 text-muted-foreground hover:text-foreground cursor-pointer"
+                              >
+                                {copiedPathKey === 'absolute' ? (
+                                  <Check className="size-3 text-success" />
+                                ) : (
+                                  <Copy className="size-3" />
+                                )}
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </CollapsibleToggle>
+                </>
+              )}
 
               {/* Error message */}
               {errorMessage && cloneStatus === 'fail' && (
                 <div className="p-3 bg-destructive-muted border border-destructive/30 rounded-md flex items-start gap-2">
                   <XCircle className="size-4 text-destructive mt-0.5 shrink-0" />
                   <div>
-                    <p className="text-sm font-medium text-destructive m-0">Clone failed</p>
+                    <p className="text-sm font-medium text-destructive m-0">
+                      {isLocalSource ? "Couldn't use that repository" : 'Clone failed'}
+                    </p>
                     <p className="text-xs text-destructive m-0 mt-0.5 font-mono">{errorMessage}</p>
                   </div>
                 </div>
               )}
 
-              {/* Overwrite confirmation */}
-              {showOverwriteConfirm && (
+              {/* Overwrite confirmation (clone only) */}
+              {showOverwriteConfirm && !isLocalSource && (
                 <div className="p-3 bg-warning-muted border border-warning/30 rounded-md flex items-start gap-2">
                   <AlertTriangle className="size-4 text-warning mt-0.5 shrink-0" />
                   <div className="flex-1">
@@ -545,29 +660,48 @@ function GitCloneInteractive({
               {/* Action buttons */}
               {!showOverwriteConfirm && (
                 <div className="flex items-center gap-2">
-                  <Button
-                    size="sm"
-                    disabled={isCloneDisabled}
-                    onClick={() => handleClone()}
-                  >
-                    {cloneStatus === 'running' ? (
-                      <>
-                        <Loader2 className="size-4 mr-1 animate-spin" />
-                        Cloning...
-                      </>
-                    ) : (
-                      'Clone'
-                    )}
-                  </Button>
-                  {cloneStatus === 'running' && (
+                  {isLocalSource ? (
                     <Button
-                      variant="outline"
                       size="sm"
-                      onClick={cancel}
-                      className="text-destructive hover:text-destructive hover:bg-destructive-muted"
+                      disabled={isUseRepoDisabled}
+                      onClick={handleUseLocalRepo}
                     >
-                      Cancel
+                      {cloneStatus === 'running' ? (
+                        <>
+                          <Loader2 className="size-4 mr-1 animate-spin" />
+                          Selecting...
+                        </>
+                      ) : (
+                        'Use This Repo'
+                      )}
                     </Button>
+                  ) : (
+                    <>
+                      <Button
+                        size="sm"
+                        disabled={isCloneDisabled}
+                        onClick={() => handleClone()}
+                      >
+                        {cloneStatus === 'running' ? (
+                          <>
+                            <Loader2 className="size-4 mr-1 animate-spin" />
+                            Cloning...
+                          </>
+                        ) : (
+                          'Clone'
+                        )}
+                      </Button>
+                      {cloneStatus === 'running' && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={cancel}
+                          className="text-destructive hover:text-destructive hover:bg-destructive-muted"
+                        >
+                          Cancel
+                        </Button>
+                      )}
+                    </>
                   )}
                 </div>
               )}

--- a/web/src/components/mdx/GitClone/GitCloneInstruction.tsx
+++ b/web/src/components/mdx/GitClone/GitCloneInstruction.tsx
@@ -4,6 +4,7 @@ import { Instruction } from '@/components/mdx/_shared'
 import { useTemplateContext } from '@/contexts/useRunbook'
 import { resolveTemplateReferences } from '@/lib/templateUtils'
 import { buildGitCloneCommand } from '@/components/mdx/_shared/lib/instructionCommands'
+import { resolveInitialSource, defaultDescription } from './utils'
 import type { GitCloneProps } from './types'
 
 /**
@@ -12,24 +13,30 @@ import type { GitCloneProps } from './types'
  * sub-path is configured. No clone is performed. Built as a separate component
  * so the interactive path's `useGitClone` (session + token IPC) never runs.
  *
+ * A block set to the local-checkout source has nothing to clone, so it renders
+ * a `cd` into the checkout instead.
+ *
  * The raw `prefilled*` props (with `{{ … }}` intact) flow into <Instruction>,
  * which resolves inputs and surfaces manual fields for any output references.
  */
 export function GitCloneInstruction({
   id,
   title,
-  description = 'Enter a git URL to clone a repository',
+  description,
   inputsId,
   prefilledUrl = '',
   prefilledRef = '',
   prefilledRepoPath = '',
   prefilledLocalPath = '',
+  prefilledRepoDir = '',
+  source,
 }: GitCloneProps) {
   const templateContext = useTemplateContext(inputsId)
+  const isLocalSource = resolveInitialSource({ source, prefilledRepoDir }) === 'local'
 
   const resolvedDescription = useMemo(
-    () => (description ? resolveTemplateReferences(description, templateContext) : undefined),
-    [description, templateContext],
+    () => resolveTemplateReferences(description ?? defaultDescription(isLocalSource ? 'local' : 'clone'), templateContext),
+    [description, isLocalSource, templateContext],
   )
   const resolvedRepoPath = useMemo(
     () => resolveTemplateReferences(prefilledRepoPath, templateContext),
@@ -40,24 +47,32 @@ export function GitCloneInstruction({
   // surfaces manual fields for any {{ .outputs.* }} references.
   const command = useMemo(
     () =>
-      buildGitCloneCommand({
-        url: prefilledUrl,
-        ref: prefilledRef || undefined,
-        localPath: prefilledLocalPath || undefined,
-      }),
-    [prefilledUrl, prefilledRef, prefilledLocalPath],
+      isLocalSource
+        ? `cd ${prefilledRepoDir || '<path-to-your-checkout>'}`
+        : buildGitCloneCommand({
+            url: prefilledUrl,
+            ref: prefilledRef || undefined,
+            localPath: prefilledLocalPath || undefined,
+          }),
+    [isLocalSource, prefilledRepoDir, prefilledUrl, prefilledRef, prefilledLocalPath],
   )
 
   return (
     <Instruction
       id={id}
       icon={GitBranch}
-      title={title ? resolveTemplateReferences(title, templateContext) : 'Clone this repository:'}
+      title={
+        title
+          ? resolveTemplateReferences(title, templateContext)
+          : isLocalSource
+            ? 'Switch to your local checkout of this repository:'
+            : 'Clone this repository:'
+      }
       description={resolvedDescription}
       command={command}
       templateContext={templateContext}
       note={
-        resolvedRepoPath ? (
+        resolvedRepoPath && !isLocalSource ? (
           <span>
             Only the sub-path <code className="font-mono">{resolvedRepoPath}</code>{' '}
             is needed — use a{' '}

--- a/web/src/components/mdx/GitClone/__tests__/GitClone.instruction.test.tsx
+++ b/web/src/components/mdx/GitClone/__tests__/GitClone.instruction.test.tsx
@@ -27,6 +27,27 @@ describe('GitClone — instruction mode', () => {
     expect(useGitCloneSpy).not.toHaveBeenCalled()
   })
 
+  it('tells the reader to cd into their checkout when the source is local', () => {
+    render(
+      <TestWrapper>
+        <GitClone id="clone" source="local" prefilledRepoDir="/home/me/infra" />
+      </TestWrapper>,
+    )
+    expect(screen.getByText(/Switch to your local checkout/i)).toBeInTheDocument()
+    expect(screen.getByText('cd /home/me/infra')).toBeInTheDocument()
+    expect(screen.queryByText(/git clone/i)).toBeNull()
+    expect(useGitCloneSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a placeholder path when the checkout directory is unset', () => {
+    render(
+      <TestWrapper>
+        <GitClone id="clone" source="local" />
+      </TestWrapper>,
+    )
+    expect(screen.getByText('cd <path-to-your-checkout>')).toBeInTheDocument()
+  })
+
   it('shows a sparse-checkout note when a repo sub-path is set', () => {
     render(
       <TestWrapper>

--- a/web/src/components/mdx/GitClone/__tests__/GitClone.local.test.tsx
+++ b/web/src/components/mdx/GitClone/__tests__/GitClone.local.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { TestWrapper } from "@/test/test-utils"
+import GitClone from ".."
+
+// The IPC boundary is the only thing mocked — the real useGitClone drives the
+// block, so these tests cover the hook's preview/select logic too.
+const invoke = vi.fn()
+
+vi.mock("@/contexts/ApiContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/contexts/ApiContext")>()
+  return { ...actual, useApi: () => ({ invoke, on: vi.fn(() => () => {}) }) }
+})
+
+const registerWorkTree = vi.fn()
+vi.mock("@/contexts/useGitWorkTree", () => ({
+  useGitWorkTree: () => ({
+    registerWorkTree,
+    activeWorkTree: null,
+    workTrees: [],
+    setActiveWorkTree: vi.fn(),
+    resetWorkTrees: vi.fn(),
+    invalidateGitFileTree: vi.fn(),
+    treeVersion: 0,
+    activeWorkTreeId: null,
+  }),
+}))
+
+const REPO = {
+  status: "success" as const,
+  absolutePath: "/home/me/infra",
+  relativePath: "/home/me/infra",
+  fileCount: 42,
+  remoteUrl: "https://github.com/acme/infra.git",
+  ref: "main",
+  refType: "branch" as const,
+  commitSha: "abc123",
+  outputs: { clone_path: "/home/me/infra", repo_owner: "acme", repo_name: "infra" },
+}
+
+/** Answer every channel the block calls on mount, plus git:local-repo. */
+function mockIpc(localRepo: unknown = REPO) {
+  invoke.mockImplementation(async (channel: string) => {
+    if (channel === "git:local-repo") return localRepo
+    if (channel === "session:get") return { workingDir: "/work" }
+    if (channel === "github:orgs") return []
+    return {}
+  })
+}
+
+function renderGitClone(props: Record<string, unknown> = {}) {
+  return render(
+    <TestWrapper>
+      <GitClone id="test-clone" {...props} />
+    </TestWrapper>,
+  )
+}
+
+// Matched by placeholder: the field's <label> also wraps an info-tooltip
+// button, so a label-text query resolves to more than one element.
+const repoDirInput = () => screen.getByPlaceholderText("/path/to/your/repo")
+
+beforeEach(() => {
+  invoke.mockReset()
+  registerWorkTree.mockReset()
+  mockIpc()
+})
+
+describe("GitClone — repository source picker", () => {
+  it("offers both sources and starts on clone", () => {
+    renderGitClone()
+    expect(screen.getByRole("tab", { name: /Clone from remote/i })).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByRole("tab", { name: /Use local checkout/i })).toHaveAttribute("aria-selected", "false")
+    expect(screen.getByPlaceholderText("https://github.com/org/repo.git")).toBeInTheDocument()
+  })
+
+  it("switching to the local source swaps the clone form for a directory picker", async () => {
+    const user = userEvent.setup()
+    renderGitClone()
+
+    await user.click(screen.getByRole("tab", { name: /Use local checkout/i }))
+
+    expect(repoDirInput()).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText("https://github.com/org/repo.git")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Use This Repo/i })).toBeInTheDocument()
+  })
+
+  it("starts on the local source when a checkout directory is prefilled", () => {
+    renderGitClone({ prefilledRepoDir: "/home/me/infra" })
+    expect(screen.getByRole("tab", { name: /Use local checkout/i })).toHaveAttribute("aria-selected", "true")
+    expect(repoDirInput()).toHaveValue("/home/me/infra")
+  })
+
+  it("hides the picker when the author locks the source", () => {
+    renderGitClone({ source: "local", hideSourceSelect: true })
+    expect(screen.queryByRole("tab", { name: /Use local checkout/i })).not.toBeInTheDocument()
+    expect(repoDirInput()).toBeInTheDocument()
+  })
+
+  it("does not wait on an auth block to select a local checkout", () => {
+    renderGitClone({ source: "local", gitAuthId: "git-auth" })
+    expect(screen.queryByText(/Waiting for git authentication/i)).not.toBeInTheDocument()
+    expect(repoDirInput()).not.toBeDisabled()
+  })
+})
+
+describe("GitClone — local checkout", () => {
+  it("previews the directory without registering it", async () => {
+    renderGitClone({ source: "local", prefilledRepoDir: "/home/me/infra" })
+
+    await waitFor(
+      () => expect(screen.getByText(/Git repository/i)).toBeInTheDocument(),
+      { timeout: 2000 },
+    )
+
+    expect(invoke).toHaveBeenCalledWith("git:local-repo", { path: "/home/me/infra" })
+    expect(screen.getByText(/https:\/\/github.com\/acme\/infra.git/)).toBeInTheDocument()
+    expect(screen.getByText(/42 tracked files/)).toBeInTheDocument()
+  })
+
+  it("keeps the confirm button disabled until the directory checks out", async () => {
+    const user = userEvent.setup()
+    renderGitClone({ source: "local" })
+
+    const confirm = screen.getByRole("button", { name: /Use This Repo/i })
+    expect(confirm).toBeDisabled()
+
+    await user.type(repoDirInput(), "/home/me/infra")
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 2000 })
+  })
+
+  it("fills the path from the native folder picker", async () => {
+    const user = userEvent.setup()
+    invoke.mockImplementation(async (channel: string) => {
+      if (channel === "native:show-open-dialog") return { filePaths: ["/home/me/infra"] }
+      if (channel === "git:local-repo") return REPO
+      return {}
+    })
+    renderGitClone({ source: "local" })
+
+    await user.click(screen.getByRole("button", { name: /Browse/i }))
+
+    await waitFor(() => expect(repoDirInput()).toHaveValue("/home/me/infra"))
+    expect(invoke).toHaveBeenCalledWith("native:show-open-dialog", {
+      properties: ["openDirectory"],
+    })
+  })
+
+  it("leaves the path alone when the picker is dismissed", async () => {
+    const user = userEvent.setup()
+    invoke.mockImplementation(async (channel: string) => {
+      if (channel === "native:show-open-dialog") return { filePaths: [] }
+      if (channel === "git:local-repo") return REPO
+      return {}
+    })
+    renderGitClone({ source: "local", prefilledRepoDir: "/home/me/infra" })
+
+    await user.click(screen.getByRole("button", { name: /Browse/i }))
+
+    expect(repoDirInput()).toHaveValue("/home/me/infra")
+  })
+
+  it("registers the checkout as a worktree and reports success", async () => {
+    const user = userEvent.setup()
+    renderGitClone({ source: "local", prefilledRepoDir: "/home/me/infra" })
+
+    const confirm = screen.getByRole("button", { name: /Use This Repo/i })
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 2000 })
+    await user.click(confirm)
+
+    await waitFor(() => expect(screen.getByText(/Using local checkout/i)).toBeInTheDocument())
+
+    expect(invoke).toHaveBeenCalledWith("git:local-repo", {
+      path: "/home/me/infra",
+      register: true,
+    })
+    expect(registerWorkTree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "test-clone",
+        localPath: "/home/me/infra",
+        repoUrl: "https://github.com/acme/infra.git",
+        gitInfo: expect.objectContaining({
+          repoOwner: "acme",
+          repoName: "infra",
+          ref: "main",
+          refType: "branch",
+        }),
+      }),
+    )
+    expect(screen.getByText(/42 tracked files/)).toBeInTheDocument()
+  })
+
+  it("explains why a directory can't be used and blocks the confirm", async () => {
+    mockIpc({ status: "fail", error: "Not a git repository: /home/me/notes" })
+    renderGitClone({ source: "local", prefilledRepoDir: "/home/me/notes" })
+
+    await waitFor(
+      () => expect(screen.getByText(/Can't use this directory/i)).toBeInTheDocument(),
+      { timeout: 2000 },
+    )
+    expect(screen.getByText("Not a git repository: /home/me/notes")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Use This Repo/i })).toBeDisabled()
+    expect(registerWorkTree).not.toHaveBeenCalled()
+  })
+
+  it("warns when the checkout has no remote to open pull requests against", async () => {
+    mockIpc({ ...REPO, remoteUrl: undefined, outputs: { clone_path: "/home/me/infra" } })
+    renderGitClone({ source: "local", prefilledRepoDir: "/home/me/infra" })
+
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText(/remote — blocks that open a pull request need one/i),
+        ).toBeInTheDocument(),
+      { timeout: 2000 },
+    )
+  })
+})

--- a/web/src/components/mdx/GitClone/components/CloneResult.tsx
+++ b/web/src/components/mdx/GitClone/components/CloneResult.tsx
@@ -1,16 +1,22 @@
 import { CheckCircle, FolderOpen, Copy, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
-import type { CloneResult } from "../types"
+import type { CloneResult, GitCloneSource } from "../types"
 
 interface CloneResultDisplayProps {
   result: CloneResult
+  /** Where the repo came from — drives the copy, since nothing was downloaded
+   *  when the user picked a checkout they already had. Defaults to 'clone'. */
+  source?: GitCloneSource
+  /** Remote of the selected local checkout, shown so the user can confirm it. */
+  remoteUrl?: string
   onCloneAgain: () => void
 }
 
-export function CloneResultDisplay({ result, onCloneAgain }: CloneResultDisplayProps) {
+export function CloneResultDisplay({ result, source = 'clone', remoteUrl, onCloneAgain }: CloneResultDisplayProps) {
   const relative = useCopyToClipboard(2000)
   const absolute = useCopyToClipboard(2000)
+  const isLocal = source === 'local'
 
   return (
     <div className="space-y-3">
@@ -18,17 +24,32 @@ export function CloneResultDisplay({ result, onCloneAgain }: CloneResultDisplayP
       <div className="bg-success-muted border border-success/30 rounded-md p-4 space-y-2">
         <div className="flex items-center gap-2 text-success font-medium">
           <CheckCircle className="size-5 text-success" />
-          Clone complete
+          {isLocal ? 'Using local checkout' : 'Clone complete'}
         </div>
 
         <div className="flex items-center gap-2 text-success">
           <FolderOpen className="size-4 text-success" />
-          <span>Downloaded {result.fileCount} files</span>
+          <span>
+            {isLocal
+              ? `${result.fileCount} tracked ${result.fileCount === 1 ? 'file' : 'files'}`
+              : `Downloaded ${result.fileCount} files`}
+          </span>
         </div>
 
+        {isLocal && remoteUrl && (
+          <div className="text-sm text-success">
+            Remote: <code className="font-mono">{remoteUrl}</code>
+          </div>
+        )}
+
         <div className="space-y-1">
-          <span className="text-sm font-medium text-success">Local path:</span>
-          <div className="flex items-center gap-1.5">
+          <span className="text-sm font-medium text-success">
+            {isLocal ? 'Repository path:' : 'Local path:'}
+          </span>
+          {/* A checkout outside the working directory has no meaningful
+              relative form — the domain layer returns the absolute path for
+              both, so don't print it twice. */}
+          <div className={`flex items-center gap-1.5 ${result.relativePath === result.absolutePath ? 'hidden' : ''}`}>
             <span className="text-xs text-success">Relative:</span>
             <code className="text-sm bg-success-muted px-1.5 py-0.5 rounded font-mono text-success">
               {result.relativePath}
@@ -63,14 +84,14 @@ export function CloneResultDisplay({ result, onCloneAgain }: CloneResultDisplayP
         </div>
       </div>
 
-      {/* Clone again button */}
+      {/* Start over: clone again, or pick a different checkout */}
       <Button
         variant="outline"
         size="sm"
         onClick={onCloneAgain}
         className="text-muted-foreground"
       >
-        Clone again
+        {isLocal ? 'Choose a different repo' : 'Clone again'}
       </Button>
     </div>
   )

--- a/web/src/components/mdx/GitClone/components/LocalRepoForm.tsx
+++ b/web/src/components/mdx/GitClone/components/LocalRepoForm.tsx
@@ -1,0 +1,121 @@
+import { CheckCircle, FolderOpen, Loader2, XCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { InfoTooltip } from "@/components/mdx/GitPullRequest/components/InfoTooltip"
+import type { LocalRepoInfo } from "../types"
+
+export type LocalPreviewStatus = 'idle' | 'checking' | 'valid' | 'invalid'
+
+interface LocalRepoFormProps {
+  /** Current directory in the input (may be a subdirectory of the repo). */
+  repoDir: string
+  onRepoDirChange: (value: string) => void
+  /** Opens the native folder picker. */
+  onBrowse: () => void
+  previewStatus: LocalPreviewStatus
+  preview: LocalRepoInfo | null
+  previewError: string | null
+  disabled?: boolean
+}
+
+/**
+ * Directory picker for an existing local checkout: a path field (typed or
+ * filled by the native folder dialog) plus an inline verdict on whether that
+ * directory is a git work tree, and what it holds.
+ */
+export function LocalRepoForm({
+  repoDir,
+  onRepoDirChange,
+  onBrowse,
+  previewStatus,
+  preview,
+  previewError,
+  disabled,
+}: LocalRepoFormProps) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label
+          htmlFor="git-clone-repo-dir"
+          className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5"
+        >
+          Repository directory
+          <InfoTooltip>
+            A repository you have already cloned. Pick any directory inside the
+            checkout — the repository root is resolved for you. Nothing is
+            cloned, fetched, or modified when you select it.
+          </InfoTooltip>
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="git-clone-repo-dir"
+            type="text"
+            value={repoDir}
+            onChange={(e) => onRepoDirChange(e.target.value)}
+            placeholder="/path/to/your/repo"
+            disabled={disabled}
+            className="flex-1 px-3 py-2 text-sm border border-input rounded-md bg-card focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring disabled:bg-muted disabled:text-muted-foreground placeholder:text-muted-foreground"
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={onBrowse}
+            disabled={disabled}
+          >
+            <FolderOpen className="size-4 mr-1" />
+            Browse…
+          </Button>
+        </div>
+      </div>
+
+      {/* Inline verdict on the directory currently in the field */}
+      {previewStatus === 'checking' && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          Checking directory…
+        </div>
+      )}
+
+      {previewStatus === 'valid' && preview && (
+        <div className="p-3 bg-success-muted border border-success/30 rounded-md space-y-1">
+          <div className="flex items-center gap-2 text-sm font-medium text-success">
+            <CheckCircle className="size-4 shrink-0" />
+            Git repository
+          </div>
+          <div className="text-xs text-success space-y-0.5">
+            <div>
+              Root: <code className="font-mono">{preview.absolutePath}</code>
+            </div>
+            {preview.remoteUrl && (
+              <div>
+                Remote: <code className="font-mono">{preview.remoteUrl}</code>
+              </div>
+            )}
+            <div>
+              {preview.ref
+                ? <>On {preview.refType === 'tag' ? 'tag' : preview.refType === 'detached' ? 'commit' : 'branch'} <code className="font-mono">{preview.ref}</code></>
+                : 'No commits yet'}
+              {' · '}
+              {preview.fileCount} tracked {preview.fileCount === 1 ? 'file' : 'files'}
+            </div>
+            {!preview.remoteUrl && (
+              <div className="text-warning-foreground">
+                No <code className="font-mono">origin</code> remote — blocks that open a pull request need one.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {previewStatus === 'invalid' && (
+        <div className="p-3 bg-destructive-muted border border-destructive/30 rounded-md flex items-start gap-2">
+          <XCircle className="size-4 text-destructive mt-0.5 shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-destructive m-0">Can&apos;t use this directory</p>
+            <p className="text-xs text-destructive m-0 mt-0.5 font-mono">{previewError}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/mdx/GitClone/components/SourceSelect.tsx
+++ b/web/src/components/mdx/GitClone/components/SourceSelect.tsx
@@ -1,0 +1,50 @@
+import { Cloud, FolderGit2 } from "lucide-react"
+import type { GitCloneSource } from "../types"
+
+interface SourceSelectProps {
+  source: GitCloneSource
+  onSelect: (source: GitCloneSource) => void
+  disabled?: boolean
+}
+
+const OPTIONS: ReadonlyArray<{ id: GitCloneSource; label: string; Icon: typeof Cloud }> = [
+  { id: 'clone', label: 'Clone from remote', Icon: Cloud },
+  { id: 'local', label: 'Use local checkout', Icon: FolderGit2 },
+] as const
+
+/**
+ * Segmented control choosing where the repository comes from. Styled like
+ * GitAuth's ProviderSelect so the git blocks read as one family. Hidden by the
+ * parent when the author sets hideSourceSelect.
+ */
+export function SourceSelect({ source, onSelect, disabled }: SourceSelectProps) {
+  return (
+    <div
+      className="flex gap-1 mb-2 border-b border-border"
+      role="tablist"
+      aria-label="Repository source"
+    >
+      {OPTIONS.map(({ id, label, Icon }) => {
+        const active = source === id
+        return (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            disabled={disabled}
+            onClick={() => onSelect(id)}
+            className={`px-4 py-2 text-sm font-medium flex items-center gap-2 transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 ${
+              active
+                ? 'text-foreground border-b-2 border-primary -mb-px'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <Icon className="size-4" />
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/mdx/GitClone/hooks/useGitClone.ts
+++ b/web/src/components/mdx/GitClone/hooks/useGitClone.ts
@@ -5,7 +5,7 @@ import { useRunbookContext } from '@/contexts/useRunbook'
 import { normalizeBlockId } from '@/lib/utils'
 import { deriveProviderFromAuth } from '@/components/mdx/_shared/lib/gitProvider'
 import type { LogEntry } from '@/hooks/useApiExec'
-import type { GitCloneStatus, CloneResult, GitHubOrg, GitHubRepo, GitHubRef } from '../types'
+import type { GitCloneStatus, CloneResult, GitHubOrg, GitHubRepo, GitHubRef, LocalRepoInfo } from '../types'
 
 const CloneLogEventSchema = z.object({
   line: z.string(),
@@ -39,6 +39,15 @@ export function useGitClone({ id, githubAuthId, gitAuthId }: UseGitCloneOptions)
   const [hasGitHubToken, setHasGitHubToken] = useState(false)
   const [tokenChecked, setTokenChecked] = useState(false)
   const [workingDir, setWorkingDir] = useState<string | null>(null)
+
+  // Local-checkout preview: what `git:local-repo` reports about the directory
+  // currently typed/picked, before the user confirms it.
+  const [localPreview, setLocalPreview] = useState<LocalRepoInfo | null>(null)
+  const [localPreviewStatus, setLocalPreviewStatus] = useState<'idle' | 'checking' | 'valid' | 'invalid'>('idle')
+  const [localPreviewError, setLocalPreviewError] = useState<string | null>(null)
+
+  // Guards against a slow preview for an earlier path landing after a newer one.
+  const previewSeqRef = useRef(0)
 
   // Ref to the progress listener unsubscriber so cancel() can clean up
   const unsubLogRef = useRef<(() => void) | null>(null)
@@ -197,6 +206,92 @@ export function useGitClone({ id, githubAuthId, gitAuthId }: UseGitCloneOptions)
     }
   }, [api, id, registerOutputs, authProvider])
 
+  // Open the native folder picker and return the chosen directory, if any.
+  // Kept in the hook so every IPC call this block makes goes through useApi().
+  const browseForRepoDir = useCallback(async (): Promise<string | null> => {
+    try {
+      const result = await api.invoke('native:show-open-dialog', {
+        properties: ['openDirectory'],
+      })
+      return result?.filePaths?.[0] ?? null
+    } catch {
+      // Dialog dismissed or unavailable.
+      return null
+    }
+  }, [api])
+
+  // Inspect a local checkout WITHOUT registering it, to drive the inline
+  // "is this a git repo?" preview as the user types or browses.
+  const previewLocalRepo = useCallback(async (repoDir: string) => {
+    const seq = ++previewSeqRef.current
+    if (!repoDir.trim()) {
+      setLocalPreview(null)
+      setLocalPreviewStatus('idle')
+      setLocalPreviewError(null)
+      return
+    }
+
+    setLocalPreviewStatus('checking')
+    try {
+      const result = await api.invoke('git:local-repo', { path: repoDir.trim() })
+      if (seq !== previewSeqRef.current) return // superseded by a newer path
+      if (result.status === 'success') {
+        setLocalPreview(result as LocalRepoInfo)
+        setLocalPreviewStatus('valid')
+        setLocalPreviewError(null)
+      } else {
+        setLocalPreview(null)
+        setLocalPreviewStatus('invalid')
+        setLocalPreviewError(result.error ?? 'Not a git repository')
+      }
+    } catch (error) {
+      if (seq !== previewSeqRef.current) return
+      setLocalPreview(null)
+      setLocalPreviewStatus('invalid')
+      setLocalPreviewError(error instanceof Error ? error.message : 'Failed to inspect directory')
+    }
+  }, [api])
+
+  // Confirm a local checkout: register it as a session worktree and emit the
+  // same outputs a clone would, so downstream blocks can't tell the difference.
+  // Returns the repo metadata so the caller can register the worktree in the
+  // renderer's GitWorkTree context.
+  const selectLocalRepo = useCallback(async (repoDir: string): Promise<LocalRepoInfo | null> => {
+    setCloneStatus('running')
+    setErrorMessage(null)
+    setCloneResult(null)
+
+    try {
+      const result = await api.invoke('git:local-repo', {
+        path: repoDir.trim(),
+        register: true,
+        ...(authProvider ? { provider: authProvider } : {}),
+      })
+
+      if (result.status !== 'success') {
+        setErrorMessage(result.error ?? 'Failed to use local checkout')
+        setCloneStatus('fail')
+        return null
+      }
+
+      if (result.outputs) {
+        registerOutputs(id, result.outputs)
+      }
+      setCloneResult({
+        fileCount: result.fileCount ?? 0,
+        absolutePath: result.absolutePath ?? '',
+        relativePath: result.relativePath ?? '',
+      })
+      setCloneStatus('success')
+      return result as LocalRepoInfo
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'An unexpected error occurred'
+      setErrorMessage(msg)
+      setCloneStatus('fail')
+      return null
+    }
+  }, [api, id, registerOutputs, authProvider])
+
   // Cancel an in-progress clone by unsubscribing from progress events
   const cancel = useCallback(() => {
     if (unsubLogRef.current) {
@@ -214,6 +309,15 @@ export function useGitClone({ id, githubAuthId, gitAuthId }: UseGitCloneOptions)
     setErrorMessage(null)
   }, [])
 
+  // The local checkout's own metadata survives a reset — the preview is
+  // re-run from the form's current path when the user returns to it.
+  const resetLocalPreview = useCallback(() => {
+    previewSeqRef.current++
+    setLocalPreview(null)
+    setLocalPreviewStatus('idle')
+    setLocalPreviewError(null)
+  }, [])
+
   return {
     // State
     cloneStatus,
@@ -224,9 +328,16 @@ export function useGitClone({ id, githubAuthId, gitAuthId }: UseGitCloneOptions)
     tokenChecked,
     gitHubAuthMet,
     workingDir,
+    localPreview,
+    localPreviewStatus,
+    localPreviewError,
 
     // Actions
     clone,
+    browseForRepoDir,
+    previewLocalRepo,
+    selectLocalRepo,
+    resetLocalPreview,
     cancel,
     reset,
     checkGitHubToken,

--- a/web/src/components/mdx/GitClone/index.ts
+++ b/web/src/components/mdx/GitClone/index.ts
@@ -5,7 +5,9 @@ export default GitClone
 
 export type {
   GitCloneProps,
+  GitCloneSource,
   GitCloneStatus,
+  LocalRepoInfo,
   CloneResult,
   GitHubOrg,
   GitHubRepo,

--- a/web/src/components/mdx/GitClone/types.ts
+++ b/web/src/components/mdx/GitClone/types.ts
@@ -24,12 +24,37 @@ export interface GitCloneProps {
   usePty?: boolean
   /** Whether to show the file tree in the workspace panel after cloning. Defaults to true. */
   showFileTree?: boolean
+  /**
+   * Which repository source is selected initially: clone a remote repo, or use
+   * a checkout the user already has on disk. Defaults to 'local' when
+   * `prefilledRepoDir` is set, otherwise 'clone'.
+   */
+  source?: GitCloneSource
+  /** When true, the source picker is hidden and the block is locked to `source`. */
+  hideSourceSelect?: boolean
+  /** Pre-fill the local checkout directory (supports template expressions) */
+  prefilledRepoDir?: string
+}
+
+/** Where the repository comes from: a fresh clone, or an existing local checkout. */
+export type GitCloneSource = 'clone' | 'local'
+
+/** Metadata for a local checkout selected by the user (git:local-repo result). */
+export interface LocalRepoInfo {
+  absolutePath: string
+  relativePath: string
+  fileCount: number
+  remoteUrl?: string
+  /** Checked out branch or tag; empty for a repo with no commits. */
+  ref?: string
+  refType?: 'branch' | 'tag' | 'detached'
+  commitSha?: string
 }
 
 /** Status of the clone operation */
 export type GitCloneStatus = 'pending' | 'ready' | 'running' | 'success' | 'fail'
 
-/** Result of a successful clone */
+/** Result of a successful clone, or of selecting a local checkout */
 export interface CloneResult {
   fileCount: number
   absolutePath: string

--- a/web/src/components/mdx/GitClone/utils.ts
+++ b/web/src/components/mdx/GitClone/utils.ts
@@ -1,0 +1,19 @@
+import type { GitCloneProps, GitCloneSource } from './types'
+
+/**
+ * Which source the block starts on. An author who prefills a checkout
+ * directory means "use that local repo", so it wins over the clone default;
+ * an explicit `source` prop always wins over both.
+ */
+export function resolveInitialSource(
+  props: Pick<GitCloneProps, 'source' | 'prefilledRepoDir'>,
+): GitCloneSource {
+  return props.source ?? (props.prefilledRepoDir ? 'local' : 'clone')
+}
+
+/** Default block description, which differs per source when the author sets none. */
+export function defaultDescription(source: GitCloneSource): string {
+  return source === 'local'
+    ? 'Select a repository you already have checked out on this machine'
+    : 'Enter a git URL to clone a repository'
+}


### PR DESCRIPTION
## What

`<GitClone>` gets a repository-source picker: **Clone from remote** (unchanged) or **Use local checkout**.

```
┌─ Clone Repository ──────────────── [git_clone] ─┐
│ ( ) Clone from remote   (•) Use local checkout  │
│                                                 │
│ Repository directory                            │
│ [ /Users/me/dev/infra-live      ] [ Browse… ]   │
│ ✓ Git repository                                │
│   Root: /Users/me/dev/infra-live                │
│   Remote: https://github.com/acme/infra-live    │
│   On branch main · 428 tracked files            │
│                                                 │
│ [ Use This Repo ]                               │
└─────────────────────────────────────────────────┘
```

## Why

Users often already have the repo — a long-lived `infrastructure-live` checkout, a work in progress branch, a monorepo nobody wants to re-download. Today the only way into a runbook is a fresh clone.

## How it works

Picking a directory **reads it only**. The block resolves the work tree root with `git rev-parse --show-toplevel` (so any subdirectory of the checkout works), reads the `origin` remote and current branch, and counts tracked files. That runs as you type or browse, so a wrong directory says so immediately — nothing is fetched, pulled, or modified, and no credentials are needed.

Confirming with **Use This Repo** registers the checkout as a session worktree and emits the same outputs a clone does, so nothing downstream can tell the two apart: same `clone_path` / `repo_owner` / `repo_name`, same `$REPO_FILES`, same workspace file tree, same `<GitPullRequest>` flow — a PR opens against the checkout's own remote and current branch.

New props: `source` (`'clone' | 'local'`), `hideSourceSelect`, `prefilledRepoDir` (setting it starts the block on the local source).

## Notable implementation points

- **`git:local-repo` has a `register` flag.** The live preview passes `register: false`; only the user confirming registers the worktree and resolves the GitHub numeric IDs. A half-typed path never grants anything.
- **`resolveValidatedWorktree` now accepts already-registered worktrees** (`electron/main/ipc/workspace.ts`). Without this, `workspace:register` / `workspace:set-active` silently rejected any checkout outside the session working directory — which is exactly where local checkouts live — so the active-worktree selection didn't stick and `REPO_FILES` could point at the wrong repo. This does **not** widen the grant: an unregistered path outside the session still fails. The user's explicit selection is what grants access.
- **Auth is only required for cloning.** Selecting files already on disk waits on nothing; the clone form still gates on a linked auth block as before.
- **A checkout with no `origin`** is still selectable, with an inline warning that PR blocks need a remote. A repo with no commits works too.
- **Instruction mode** renders `cd <path>` rather than a `git clone` command.
- **Test framework support**: the runbook test CLI adopts a checkout for `source="local"` instead of cloning, counting tracked files rather than walking `.git`.

## Testing

- 11 domain tests for `inspectLocalRepo` — subdirectory → root resolution, relative vs absolute display paths, no remote, no commits, and each failure mode (missing dir, a file, not a work tree, empty input).
- 12 component tests driving the **real** `useGitClone` against a mocked IPC boundary: source switching, prefill behaviour, the preview not registering, the confirm registering the worktree with the right owner/ref, the native folder picker, and the no-remote warning.
- 2 instruction-mode tests, 2 CLI executor tests against a real `git init` fixture.

992 backend + 604 web tests pass; typecheck, lint, and `just test-docs` clean.

**Not verified in the desktop app** — the UI is covered by component tests only, no live Electron run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)