### PR TITLE
uptick to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runbooks",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "private": true,
   "description": "Gruntwork Runbooks",
   "author": {


### PR DESCRIPTION
Bumps `package.json` from `0.20.1` to `0.21.0` — a minor, since what's landing on top of 0.20.1 is feature work rather than fixes alone.

`package.json` is the only place the version is pinned (checked: no other source, docs, or workflow file references it), so this matches the shape of the previous bump, fe3dee5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->