### PR TITLE
fix(GitClone): local checkout produces the same outputs as a clone

### DIFF
--- a/docs/src/content/docs/authoring/blocks/GitClone.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitClone.mdx
@@ -43,7 +43,9 @@ When paired with a `<GitHubAuth>` block, the GitClone block enables a "Browse Gi
 
 Users often already have the repository cloned — a long-lived `infrastructure-live` checkout, a work in progress branch, a monorepo they never want to re-download. The block's source picker lets them choose **Use local checkout** and select that directory instead of cloning.
 
-Selecting a directory reads it only: the block resolves the repository root (so any subdirectory of the checkout works), reads the `origin` remote and current branch, and registers the repo exactly as a clone would. Nothing is fetched, pulled, or modified, and no credentials are needed — the files are already there.
+Selecting a directory reads it only: the block resolves the repository root (so any subdirectory of the checkout works), reads the repository's remote and current branch, and registers the repo exactly as a clone would. Nothing is fetched, pulled, or modified.
+
+Browsing and checking a directory needs no credentials. Confirming one does wait on a linked auth block, exactly as cloning does — the GitHub `org_id` / `repo_id` outputs are resolved from the session token at that moment, so adopting a checkout before authentication finishes would leave the block without them.
 
 ```mdx
 <GitClone
@@ -66,7 +68,7 @@ Setting `prefilledRepoDir` starts the block on the local source. Use `source` to
 Everything downstream behaves the same either way: the same `clone_path`, `repo_owner`, and `repo_name` outputs, the same `$REPO_FILES` variable, the same workspace file tree, and the same [`<GitPullRequest>`](/authoring/blocks/gitpullrequest) integration — a pull request opens against the checkout's `origin` remote and current branch.
 
 <Aside type="caution">
-A checkout with no `origin` remote can still be selected, but blocks that open a pull request need one. The block says so inline when it finds no remote.
+A checkout with no remote at all can still be selected, but it produces no `repo_owner` / `repo_name` (nor the GitHub ids derived from them), and blocks that open a pull request need one. The block says so inline when it finds no remote. `origin` is preferred; if the checkout names its remote something else, that one is used.
 </Aside>
 
 ### Pre-filled Values
@@ -203,7 +205,7 @@ After a successful clone, the GitClone block produces outputs that can be refere
 | `repo_id` | Immutable GitHub numeric ID of the repository (when a GitHub token is available) | `87654321` |
 | `repo_url` | The full URL of the cloned repository | `https://github.com/acme-corp/infrastructure-live` |
 
-For a local checkout, `clone_path` is the repository root the user selected, and `repo_owner` / `repo_name` come from its `origin` remote (omitted when the repo has no remote).
+For a local checkout, `clone_path` is the repository root the user selected, and `repo_owner` / `repo_name` come from its remote — `origin` when present, otherwise whichever remote the checkout has. They are omitted entirely when the repo has no remote, which also means no `org_id` / `repo_id`, since those are looked up from the owner and name.
 
 Reference outputs in downstream blocks using template variables:
 

--- a/docs/src/content/docs/authoring/blocks/GitClone.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitClone.mdx
@@ -43,9 +43,11 @@ When paired with a `<GitHubAuth>` block, the GitClone block enables a "Browse Gi
 
 Users often already have the repository cloned — a long-lived `infrastructure-live` checkout, a work in progress branch, a monorepo they never want to re-download. The block's source picker lets them choose **Use local checkout** and select that directory instead of cloning.
 
-Selecting a directory reads it only: the block resolves the repository root (so any subdirectory of the checkout works), reads the repository's remote and current branch, and registers the repo exactly as a clone would. Nothing is fetched, pulled, or modified.
+Choosing a directory only **inspects** it: the block resolves the repository root (so any subdirectory of the checkout works), reads the repository's remote and current branch, and counts its tracked files. Nothing is fetched, pulled, or modified, and nothing is registered yet — the directory is reported on, not adopted.
 
-Browsing and checking a directory needs no credentials. Confirming one does wait on a linked auth block, exactly as cloning does — the GitHub `org_id` / `repo_id` outputs are resolved from the session token at that moment, so adopting a checkout before authentication finishes would leave the block without them.
+Confirming with **Use This Repo** is what registers the checkout and produces the block's outputs, exactly as a completed clone does. Until then the block has produced nothing, and any later block referencing its outputs still reports them as missing.
+
+Inspecting a directory needs no credentials, so browsing works while a linked auth block is still pending. Confirming does wait on it, exactly as cloning does — the GitHub `org_id` / `repo_id` outputs are resolved from the session token at that moment, so adopting a checkout before authentication finishes would leave the block without them.
 
 ```mdx
 <GitClone
@@ -65,7 +67,7 @@ Setting `prefilledRepoDir` starts the block on the local source. Use `source` to
 <GitClone id="repo" source="clone" hideSourceSelect prefilledUrl="https://github.com/acme/infra" />
 ```
 
-Everything downstream behaves the same either way: the same `clone_path`, `repo_owner`, and `repo_name` outputs, the same `$REPO_FILES` variable, the same workspace file tree, and the same [`<GitPullRequest>`](/authoring/blocks/gitpullrequest) integration — a pull request opens against the checkout's `origin` remote and current branch.
+Everything downstream behaves the same either way: the same `clone_path`, `repo_owner`, and `repo_name` outputs, the same `$REPO_FILES` variable, the same workspace file tree, and the same [`<GitPullRequest>`](/authoring/blocks/gitpullrequest) integration — a pull request opens against the checkout's remote and current branch.
 
 <Aside type="caution">
 A checkout with no remote at all can still be selected, but it produces no `repo_owner` / `repo_name` (nor the GitHub ids derived from them), and blocks that open a pull request need one. The block says so inline when it finds no remote. `origin` is preferred; if the checkout names its remote something else, that one is used.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runbooks",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "description": "Gruntwork Runbooks",
   "author": {

--- a/src/domain/git/local-repo.test.ts
+++ b/src/domain/git/local-repo.test.ts
@@ -140,6 +140,31 @@ describe("inspectLocalRepo", () => {
     expect(info.owner).toBeUndefined()
   })
 
+  it("falls back to a non-origin remote when there is no origin", async () => {
+    const info = await inspect("/home/me/fork", {
+      dirs: ["/home/me/fork"],
+      commands: [
+        { command: "git", args: ["remote"], outputLines: ["upstream"], exitCode: 0 },
+        {
+          command: "git",
+          args: ["remote", "get-url", "upstream"],
+          outputLines: ["git@github.com:acme/infra.git"],
+          exitCode: 0,
+        },
+        lsFiles(["main.tf"]),
+      ],
+      git: {
+        getRepoRoot: () => Effect.succeed("/home/me/fork"),
+        // getInfo only looks at origin, which this checkout doesn't have.
+        getInfo: () => Effect.succeed({ branch: "main", refType: "branch" as const }),
+      },
+    })
+
+    expect(info.remoteUrl).toBe("git@github.com:acme/infra.git")
+    expect(info.owner).toBe("acme")
+    expect(info.repo).toBe("infra")
+  })
+
   it("omits owner/repo when the repo has no remote", async () => {
     const info = await inspect("/home/me/local-only", {
       dirs: ["/home/me/local-only"],

--- a/src/domain/git/local-repo.ts
+++ b/src/domain/git/local-repo.ts
@@ -150,28 +150,33 @@ export const inspectLocalRepo = (
  */
 const firstRemoteUrl = (repoPath: string) =>
   Effect.gen(function* () {
-    const spawner = yield* ProcessSpawner
-    const proc = yield* spawner.spawn("git", ["remote"], {
-      cwd: repoPath,
-      env: gitSpawnEnv(),
-    })
-    const names = Chunk.toArray(yield* Stream.runCollect(proc.output))
-      .filter((l) => l.source === "stdout")
-      .map((l) => l.line.trim())
-      .filter(Boolean)
-    if ((yield* proc.exitCode) !== 0 || names.length === 0) return undefined
-
-    const urlProc = yield* spawner.spawn("git", ["remote", "get-url", names[0]], {
-      cwd: repoPath,
-      env: gitSpawnEnv(),
-    })
-    const urls = Chunk.toArray(yield* Stream.runCollect(urlProc.output))
-      .filter((l) => l.source === "stdout")
-      .map((l) => l.line.trim())
-      .filter(Boolean)
-    if ((yield* urlProc.exitCode) !== 0) return undefined
+    const names = yield* readGitLines(repoPath, ["remote"])
+    if (names.length === 0) return undefined
+    const urls = yield* readGitLines(repoPath, ["remote", "get-url", names[0]])
     return urls[0]
   }).pipe(Effect.catchAll(() => Effect.succeed(undefined)))
+
+/**
+ * Run a short git query and return its stdout lines, or none if it failed.
+ *
+ * `Effect.ensuring` kills the child if this effect is interrupted mid-flight.
+ * On the normal path the process has already exited and the signal is a no-op,
+ * so this costs nothing and leaves no orphan behind if a caller ever gains a
+ * cancellation path.
+ */
+const readGitLines = (repoPath: string, args: string[]) =>
+  Effect.gen(function* () {
+    const spawner = yield* ProcessSpawner
+    const proc = yield* spawner.spawn("git", args, { cwd: repoPath, env: gitSpawnEnv() })
+
+    return yield* Effect.gen(function* () {
+      const lines = Chunk.toArray(yield* Stream.runCollect(proc.output))
+        .filter((l) => l.source === "stdout")
+        .map((l) => l.line.trim())
+        .filter(Boolean)
+      return (yield* proc.exitCode) === 0 ? lines : []
+    }).pipe(Effect.ensuring(proc.kill.pipe(Effect.ignore)))
+  })
 
 /**
  * Display path for a checkout: relative to the working directory when it lives

--- a/src/domain/git/local-repo.ts
+++ b/src/domain/git/local-repo.ts
@@ -9,12 +9,13 @@
  * `<DirPicker>` — behave identically either way.
  */
 import path from "path"
-import { Effect } from "effect"
+import { Effect, Stream, Chunk } from "effect"
 import { GitClient } from "../../services/GitClient.ts"
 import type { GitInfo } from "../../services/GitClient.ts"
 import { FileSystem } from "../../services/FileSystem.ts"
 import { ProcessSpawner } from "../../services/ProcessSpawner.ts"
 import { GitError } from "../../errors/index.ts"
+import { gitSpawnEnv } from "./env.ts"
 import { countFiles, parseOwnerRepoFromURL } from "./operations.ts"
 
 /** Metadata describing a local checkout selected by the user. */
@@ -118,14 +119,21 @@ export const inspectLocalRepo = (
       ),
     )
 
+    // getInfo only knows about `origin`. A checkout can legitimately name its
+    // remote something else — a fork whose upstream is the interesting one, or
+    // a repo re-pointed after `git init` — and without a remote there is no
+    // repo_owner/repo_name (nor the GitHub ids derived from them) for
+    // downstream blocks to consume. Fall back to whatever remote does exist.
+    const remoteUrl = info.remoteUrl ?? (yield* firstRemoteUrl(absolutePath))
+
     const fileCount = yield* countFiles(absolutePath)
-    const parsed = info.remoteUrl ? parseOwnerRepoFromURL(info.remoteUrl) : undefined
+    const parsed = remoteUrl ? parseOwnerRepoFromURL(remoteUrl) : undefined
 
     return {
       absolutePath,
       relativePath: relativeToWorkingDir(absolutePath, workingDir),
       fileCount,
-      remoteUrl: info.remoteUrl,
+      remoteUrl,
       branch: info.branch,
       refType: info.refType,
       commitSha: info.commitSha,
@@ -133,6 +141,37 @@ export const inspectLocalRepo = (
       repo: parsed?.repo,
     } satisfies LocalRepoInfo
   })
+
+/**
+ * URL of the first remote the repo has, or undefined when it has none. Only
+ * consulted after `origin` comes up empty, so remote order decides nothing in
+ * the common case. Best-effort: a repo we can't read remotes from is still a
+ * usable checkout, it just yields no owner/repo.
+ */
+const firstRemoteUrl = (repoPath: string) =>
+  Effect.gen(function* () {
+    const spawner = yield* ProcessSpawner
+    const proc = yield* spawner.spawn("git", ["remote"], {
+      cwd: repoPath,
+      env: gitSpawnEnv(),
+    })
+    const names = Chunk.toArray(yield* Stream.runCollect(proc.output))
+      .filter((l) => l.source === "stdout")
+      .map((l) => l.line.trim())
+      .filter(Boolean)
+    if ((yield* proc.exitCode) !== 0 || names.length === 0) return undefined
+
+    const urlProc = yield* spawner.spawn("git", ["remote", "get-url", names[0]], {
+      cwd: repoPath,
+      env: gitSpawnEnv(),
+    })
+    const urls = Chunk.toArray(yield* Stream.runCollect(urlProc.output))
+      .filter((l) => l.source === "stdout")
+      .map((l) => l.line.trim())
+      .filter(Boolean)
+    if ((yield* urlProc.exitCode) !== 0) return undefined
+    return urls[0]
+  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)))
 
 /**
  * Display path for a checkout: relative to the working directory when it lives

--- a/web/src/components/mdx/GitClone/GitClone.tsx
+++ b/web/src/components/mdx/GitClone/GitClone.tsx
@@ -382,12 +382,17 @@ function GitCloneInteractive({
   const { bg: statusClasses, icon: IconComponent, iconColor: iconClasses } = statusConfig[cloneStatus] ?? statusConfig.pending
 
   const isLocalSource = activeSource === 'local'
-  // Selecting a checkout that already exists on disk needs no credentials —
-  // only cloning does. Auth still gates the clone form as before.
+  // Browsing and checking a directory needs no credentials, so the local form
+  // stays usable while a linked auth block is still pending.
   const isFormDisabled =
     cloneStatus === 'running' || !hasAllBlockingDependencies || (!isLocalSource && !gitHubAuthMet)
   const isCloneDisabled = isFormDisabled || !gitUrl.trim()
-  const isUseRepoDisabled = isFormDisabled || localPreviewStatus !== 'valid'
+  // Confirming, though, waits for auth exactly like cloning does. The GitHub
+  // org/repo ids are resolved once, at confirm time, from the session token —
+  // adopting a checkout before the auth block finishes would silently produce a
+  // block missing org_id/repo_id, which is precisely the parity with clone that
+  // this source is supposed to keep.
+  const isUseRepoDisabled = isFormDisabled || !gitHubAuthMet || localPreviewStatus !== 'valid'
 
   // Early return for validation errors (e.g. missing id prop)
   if (validationError) {
@@ -430,14 +435,15 @@ function GitCloneInteractive({
             />
           )}
 
-          {/* Blocked state: waiting for the referenced auth block (cloning only) */}
-          {hasAllBlockingDependencies && !gitHubAuthMet && !isLocalSource && (
+          {/* Blocked state: waiting for the referenced auth block */}
+          {hasAllBlockingDependencies && !gitHubAuthMet && (
             <div className="mb-4 p-3 bg-warning-muted border border-warning/30 rounded-md flex items-start gap-2">
               <AlertTriangle className="size-4 text-warning mt-0.5 shrink-0" />
               <div>
                 <p className="text-sm font-medium text-warning-foreground m-0">Waiting for git authentication</p>
                 <p className="text-xs text-warning-foreground m-0 mt-0.5">
-                  Complete the &apos;{githubAuthId ?? gitAuthId}&apos; authentication block above before cloning.
+                  Complete the &apos;{githubAuthId ?? gitAuthId}&apos; authentication block above
+                  before {isLocalSource ? 'selecting a repository' : 'cloning'}.
                 </p>
               </div>
             </div>

--- a/web/src/components/mdx/GitClone/__tests__/GitClone.local.test.tsx
+++ b/web/src/components/mdx/GitClone/__tests__/GitClone.local.test.tsx
@@ -112,7 +112,7 @@ describe("GitClone — repository source picker", () => {
     // from the session token at confirm time and can't be filled in later.
     expect(screen.getByText(/Waiting for git authentication/i)).toBeInTheDocument()
     await waitFor(
-      () => expect(screen.getByText(/Git repository/i)).toBeInTheDocument(),
+      () => expect(screen.getByText(/Git repository found/i)).toBeInTheDocument(),
       { timeout: 2000 },
     )
     expect(screen.getByRole("button", { name: /Use This Repo/i })).toBeDisabled()
@@ -124,7 +124,7 @@ describe("GitClone — local checkout", () => {
     renderGitClone({ source: "local", prefilledRepoDir: "/home/me/infra" })
 
     await waitFor(
-      () => expect(screen.getByText(/Git repository/i)).toBeInTheDocument(),
+      () => expect(screen.getByText(/Git repository found/i)).toBeInTheDocument(),
       { timeout: 2000 },
     )
 
@@ -173,6 +173,22 @@ describe("GitClone — local checkout", () => {
     await user.click(screen.getByRole("button", { name: /Browse/i }))
 
     expect(repoDirInput()).toHaveValue("/home/me/infra")
+  })
+
+  it("tells the user the checked directory is not in use until confirmed", async () => {
+    renderGitClone({ source: "local", prefilledRepoDir: "/home/me/infra" })
+
+    await waitFor(
+      () => expect(screen.getByText(/Git repository found/i)).toBeInTheDocument(),
+      { timeout: 2000 },
+    )
+
+    // The preview must not read as a finished block: nothing is registered
+    // until "Use This Repo", and a block with no outputs leaves every consumer
+    // waiting on outputs that were never produced.
+    expect(screen.getByText(/Not in use yet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Using local checkout/i)).not.toBeInTheDocument()
+    expect(registerWorkTree).not.toHaveBeenCalled()
   })
 
   it("registers the checkout as a worktree and reports success", async () => {
@@ -225,7 +241,7 @@ describe("GitClone — local checkout", () => {
     await waitFor(
       () =>
         expect(
-          screen.getByText(/remote — blocks that open a pull request need one/i),
+          screen.getByText(/blocks that open a pull request need one/i),
         ).toBeInTheDocument(),
       { timeout: 2000 },
     )

--- a/web/src/components/mdx/GitClone/__tests__/GitClone.local.test.tsx
+++ b/web/src/components/mdx/GitClone/__tests__/GitClone.local.test.tsx
@@ -98,10 +98,24 @@ describe("GitClone — repository source picker", () => {
     expect(repoDirInput()).toBeInTheDocument()
   })
 
-  it("does not wait on an auth block to select a local checkout", () => {
+  it("keeps the directory form usable while a linked auth block is pending", () => {
     renderGitClone({ source: "local", gitAuthId: "git-auth" })
-    expect(screen.queryByText(/Waiting for git authentication/i)).not.toBeInTheDocument()
+    // Browsing and checking a directory needs no credentials...
     expect(repoDirInput()).not.toBeDisabled()
+    expect(screen.getByRole("button", { name: /Browse/i })).not.toBeDisabled()
+  })
+
+  it("waits for a linked auth block before a checkout can be confirmed", async () => {
+    renderGitClone({ source: "local", gitAuthId: "git-auth", prefilledRepoDir: "/home/me/infra" })
+
+    // ...but confirming does wait, because the GitHub org/repo ids are resolved
+    // from the session token at confirm time and can't be filled in later.
+    expect(screen.getByText(/Waiting for git authentication/i)).toBeInTheDocument()
+    await waitFor(
+      () => expect(screen.getByText(/Git repository/i)).toBeInTheDocument(),
+      { timeout: 2000 },
+    )
+    expect(screen.getByRole("button", { name: /Use This Repo/i })).toBeDisabled()
   })
 })
 

--- a/web/src/components/mdx/GitClone/components/LocalRepoForm.tsx
+++ b/web/src/components/mdx/GitClone/components/LocalRepoForm.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, FolderOpen, Loader2, XCircle } from "lucide-react"
+import { FolderGit2, FolderOpen, Loader2, XCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { InfoTooltip } from "@/components/mdx/GitPullRequest/components/InfoTooltip"
 import type { LocalRepoInfo } from "../types"
@@ -76,13 +76,18 @@ export function LocalRepoForm({
         </div>
       )}
 
+      {/* Deliberately NOT success-styled: this only reports what the directory
+          is, and no outputs exist until the user confirms below. Green is
+          reserved for the completed state, or a checked directory reads as a
+          finished block and downstream blocks look broken for want of outputs
+          nobody produced yet. */}
       {previewStatus === 'valid' && preview && (
-        <div className="p-3 bg-success-muted border border-success/30 rounded-md space-y-1">
-          <div className="flex items-center gap-2 text-sm font-medium text-success">
-            <CheckCircle className="size-4 shrink-0" />
-            Git repository
+        <div className="p-3 bg-info-muted border border-info/40 rounded-md space-y-1">
+          <div className="flex items-center gap-2 text-sm font-medium text-info">
+            <FolderGit2 className="size-4 shrink-0" />
+            Git repository found
           </div>
-          <div className="text-xs text-success space-y-0.5">
+          <div className="text-xs text-muted-foreground space-y-0.5">
             <div>
               Root: <code className="font-mono">{preview.absolutePath}</code>
             </div>
@@ -100,9 +105,14 @@ export function LocalRepoForm({
             </div>
             {!preview.remoteUrl && (
               <div className="text-warning-foreground">
-                No <code className="font-mono">origin</code> remote — blocks that open a pull request need one.
+                No remote — this repo produces no <code className="font-mono">repo_owner</code> or{' '}
+                <code className="font-mono">repo_name</code>, and blocks that open a pull request need one.
               </div>
             )}
+            <div className="pt-1 text-foreground">
+              Not in use yet — choose <strong>Use This Repo</strong> to make this repository
+              and its outputs available to later blocks.
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Follow-up to #193. These two fixes were pushed to that branch after it had already been merged, so they never landed — this puts them on `main`.

Symptom: a runbook consuming a local checkout sat on **"Waiting for outputs from: clone_repo (repo_owner, org_id, repo_name, repo_id)"**, which reads as those outputs being unsupported for a local checkout. Three separate causes, all fixed here.

## 1. Remote resolution only ever looked at `origin`

`GitClient.getInfo` runs `git remote get-url origin` and swallows the failure. A checkout naming its remote something else — a fork whose upstream is the interesting one, a repo re-pointed after `git init` — yielded no remote, so no `repo_owner`/`repo_name`, and no `org_id`/`repo_id` either, since those are looked up *from* the owner and name.

`inspectLocalRepo` now falls back to whichever remote the repo does have. `origin` is still preferred, so remote order decides nothing in the common case. Verified against a real repo with only an `upstream` remote.

## 2. The GitHub ids need a token at confirm time

They're resolved once, when the checkout is confirmed, from the session token. Because selecting a checkout deliberately didn't wait on the linked auth block, confirming before authenticating produced a block permanently missing `org_id`/`repo_id`.

Confirming now waits on a linked auth block exactly as cloning does. The path field, folder picker, and inline repo check stay usable while auth is pending, since none of them need credentials.

## 3. The preview looked like a finished block  ← the one users actually hit

The "is this a git repo?" check rendered in the **same green success styling as the completed state** — check icon, root, remote, branch, file count. But the preview passes `register: false` by design: nothing is registered and no outputs exist until **Use This Repo** is confirmed.

And a block that has produced *no* outputs makes `computeUnmetOutputDependencies` list **every** referenced name rather than just the missing ones — which is exactly the four names above, and why it reads as "local checkout doesn't support these outputs" instead of "this block hasn't run".

The preview is now informational rather than success-styled (green reserved for the completed state) and says outright: *"Not in use yet — choose **Use This Repo** to make this repository and its outputs available to later blocks."* The no-remote warning now names the outputs that go missing with it.

## Testing

993 backend + 606 web tests pass; typecheck, lint, and `just test-docs` clean. New coverage: the non-`origin` remote fallback, auth gating the confirm while leaving the form usable, and the preview stating it isn't in use yet. Docs updated — the local source no longer claims to need no credentials.

Confirmed working end to end in a dev build against a GitHub SaaS checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local repository browsing and validation can now continue while authentication is pending.
  * Repository discovery falls back to another configured remote when `origin` is unavailable.
  * Repositories without remotes remain selectable, with unavailable metadata clearly indicated.

* **Bug Fixes**
  * Prevented local repositories from being marked as in use before confirmation.
  * Improved authentication guidance for local and remote repository flows.

* **Documentation**
  * Clarified remote fallback behavior, authentication requirements, and metadata limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Also bumps `package.json` 0.21.0 → 0.21.1, so these fixes ship as a patch release on top of #193.
