### PR TITLE
feat(auth blocks): let authors pick the tab the block opens on

### DIFF
--- a/docs/src/content/docs/authoring/blocks/AwsAuth.mdx
+++ b/docs/src/content/docs/authoring/blocks/AwsAuth.mdx
@@ -31,6 +31,18 @@ The AwsAuth block provides three ways to authenticate:
 | **AWS SSO** | Use AWS IAM Identity Center (formerly AWS SSO) | 
 | **Local Profile** | Use a profile from `~/.aws/credentials` | 
 
+Static Credentials is the tab users land on. Set `defaultTab` to open on a different one:
+
+```mdx
+<AwsAuth
+  id="aws-auth"
+  defaultTab="sso"
+  ssoStartUrl="https://my-company.awsapps.com/start"
+/>
+```
+
+The user can still switch tabs — `defaultTab` only chooses the starting one.
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -39,6 +51,7 @@ The AwsAuth block provides three ways to authenticate:
 | `title` | string | "AWS Authentication" | Display title shown in the UI |
 | `description` | string | - | Description of the authentication purpose |
 | `defaultRegion` | string | "us-east-1" | Default AWS region for CLI commands. Sets `AWS_REGION` environment variable |
+| `defaultTab` | `'credentials'`, `'sso'`, or `'profile'` | `'credentials'` | Which authentication tab the block opens on. An unrecognized value falls back to `'credentials'` |
 | `detectCredentials` | `false` or `CredentialSource[]` | `['env']` | Whether and how to detect existing credentials. See [Credential Detection](#credential-detection) |
 | `ssoStartUrl` | string | - | AWS SSO start URL (e.g., `https://my-company.awsapps.com/start`). Required for SSO |
 | `ssoRegion` | string | "us-east-1" | AWS region where IAM Identity Center is configured |

--- a/docs/src/content/docs/authoring/blocks/GitAuth.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitAuth.mdx
@@ -66,6 +66,7 @@ Only `gitlab.com` and `github.com` are supported today. Self-managed GitLab and 
 | `oauthClientId` | `string` | No | Gruntwork's app | Custom GitHub OAuth App client ID. GitHub only. |
 | `oauthScopes` | `string[]` | No | `['repo']` (GitHub) | OAuth scopes to request. |
 | `detectCredentials` | `false \| GitCredentialSource[]` | No | `['env', 'cli']` | Credential auto-detection sources, applied to the selected provider. Set to `false` to disable. |
+| `defaultTab` | `'oauth' \| 'pat'` | No | `'oauth'` (GitHub), `'pat'` (GitLab) | Which authentication tab the block opens on. GitLab has no OAuth flow, so `'oauth'` falls back to `'pat'` there. Re-applied when the user switches providers. |
 | `inputsId` | `string \| string[]` | No | — | Reference one or more `<Inputs>` blocks for template expressions in props. |
 
 ## Usage

--- a/docs/src/content/docs/authoring/blocks/GitHubAuth.mdx
+++ b/docs/src/content/docs/authoring/blocks/GitHubAuth.mdx
@@ -62,6 +62,7 @@ The GitHubAuth block supports GitHub.com, GitHub Enterprise Cloud and GitHub Ent
 | `detectCredentials` | `false` or `CredentialSource[]` | `['env', 'cli']` | Whether and how the block should automatically detect credentials in the user's environment |
 | `oauthClientId` | string | Gruntwork default | Custom OAuth App client ID |
 | `oauthScopes` | string[] | `["repo"]` | OAuth scopes to request |
+| `defaultTab` | `'oauth'` or `'pat'` | `'oauth'` | Which authentication tab the block opens on |
 
 ## Usage
 

--- a/docs/src/content/docs/authoring/blocks/GoogleAuth.mdx
+++ b/docs/src/content/docs/authoring/blocks/GoogleAuth.mdx
@@ -33,6 +33,14 @@ The GoogleAuth block provides three ways to authenticate:
 
 All three tabs also offer an optional **Default Region** picker, which seeds the region environment variables for subsequent commands.
 
+Service Account Key is the tab users land on. Set `defaultTab` to open on a different one:
+
+```mdx
+<GoogleAuth id="gcp-auth" defaultTab="gcloud" />
+```
+
+The user can still switch tabs — `defaultTab` only chooses the starting one.
+
 <Aside type="note">
 Runbooks never shells out to the `gcloud` binary. Service account keys are validated by minting a real access token, sign-in uses a loopback OAuth redirect, and the gcloud tab reads gcloud's own configuration files directly. You do not need the Google Cloud CLI installed for any of the three tabs — though the gcloud tab is only useful if you have used it before to create credentials.
 </Aside>
@@ -48,6 +56,7 @@ Runbooks never shells out to the `gcloud` binary. Service account keys are valid
 | `defaultRegion` | `string` | — | Default compute region for subsequent commands. Sets `GOOGLE_CLOUD_REGION`, `CLOUDSDK_COMPUTE_REGION`, and `GOOGLE_REGION` |
 | `defaultZone` | `string` | — | Default compute zone for subsequent commands. Sets `CLOUDSDK_COMPUTE_ZONE` and `GOOGLE_ZONE` |
 | `gcloudConfiguration` | `string` | — | Pre-select a named gcloud configuration in the gcloud Config tab (supports template expressions) |
+| `defaultTab` | `'service_account'`, `'oauth'`, or `'gcloud'` | `'service_account'` | Which authentication tab the block opens on. An unrecognized value falls back to `'service_account'` |
 | `scopes` | `string[]` | `cloud-platform`, `userinfo.email`, `openid` | OAuth scopes requested by Google Sign-In. When set, also **required** of any auto-detected or gcloud user ADC this block will accept (service-account keys are exempt) |
 | `oauthClientId` | `string` | — | Client ID of a Google Cloud "Desktop app" OAuth client. Must be paired with `oauthClientSecret`. Mutually exclusive with `oauthClientFile`. See [Using your own OAuth client](#using-your-own-oauth-client) |
 | `oauthClientSecret` | `string` | — | Client secret issued alongside the Desktop OAuth client. Required whenever `oauthClientId` is set. Per RFC 8252 this value is not confidential; Google simply issues one with every Desktop client |

--- a/testdata/feature-demos/aws-auth/runbook.mdx
+++ b/testdata/feature-demos/aws-auth/runbook.mdx
@@ -40,6 +40,25 @@ The simplest form of AwsAuth. With no `detectCredentials` prop, it defaults to `
   usePty={false}
 />
 
+### 1a. Choosing the Default Tab
+
+The block opens on the Static Credentials tab. `defaultTab` picks a different starting tab -- `"credentials"`, `"sso"`, or `"profile"`. The user can still switch tabs; this only chooses which one is selected first.
+
+```mdx
+<AwsAuth id="aws-auth-sso-first" defaultTab="sso" ssoStartUrl="..." />
+```
+
+<AwsAuth
+  id="aws-auth-sso-first"
+  title="SSO First"
+  description="Opens on the AWS SSO tab instead of Static Credentials."
+  defaultTab="sso"
+  defaultRegion="us-west-2"
+  ssoRegion="us-west-2"
+  ssoStartUrl="https://d-9267d384ee.awsapps.com/start"
+  detectCredentials={false}
+/>
+
 ---
 
 ## 2. Credential Detection Options

--- a/testdata/feature-demos/google-auth/runbook.mdx
+++ b/testdata/feature-demos/google-auth/runbook.mdx
@@ -52,6 +52,22 @@ The simplest form of GoogleAuth. With no `detectCredentials` prop, it defaults t
   failMessage="No usable Google Cloud credentials in the session environment."
 />
 
+### 1a. Choosing the Default Tab
+
+The block opens on the Service Account Key tab. `defaultTab` picks a different starting tab -- `"service_account"`, `"oauth"`, or `"gcloud"`. The user can still switch tabs; this only chooses which one is selected first.
+
+```mdx
+<GoogleAuth id="google-auth-gcloud-first" defaultTab="gcloud" />
+```
+
+<GoogleAuth
+  id="google-auth-gcloud-first"
+  title="gcloud Config First"
+  description="Opens on the gcloud Config tab instead of Service Account Key."
+  defaultTab="gcloud"
+  detectCredentials={false}
+/>
+
 ---
 
 ## 2. Credential Detection Options

--- a/web/src/components/mdx/AwsAuth/AwsAuth.tsx
+++ b/web/src/components/mdx/AwsAuth/AwsAuth.tsx
@@ -36,6 +36,7 @@ function AwsAuthInteractive({
   ssoRoleName,
   defaultRegion = "us-east-1",
   detectCredentials = ['env'],  // Default: auto-detect from env vars
+  defaultTab,
   inputsId,
 }: AwsAuthProps) {
   const validationError = useMemo((): AppError | null => {
@@ -78,6 +79,7 @@ function AwsAuthInteractive({
     ssoRoleName,
     defaultRegion,
     detectCredentials,
+    defaultTab,
   })
 
   // Track block render on mount

--- a/web/src/components/mdx/AwsAuth/hooks/__tests__/useAwsAuth.test.ts
+++ b/web/src/components/mdx/AwsAuth/hooks/__tests__/useAwsAuth.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAwsAuth } from '../useAwsAuth'
+
+/**
+ * Which tab the block opens on is decided once, at mount, from the author's
+ * `defaultTab` prop. Detection is switched off in these tests so no IPC runs —
+ * the starting tab is the only behaviour under test.
+ */
+
+vi.mock('@/contexts/useRunbook', () => ({
+  useRunbookContext: () => ({ registerOutputs: vi.fn(), blockOutputs: {} }),
+}))
+vi.mock('@/contexts/useSession', () => ({
+  useSession: () => ({ isReady: true }),
+}))
+
+const originalApi = window.api
+
+afterEach(() => {
+  window.api = originalApi
+})
+
+const renderAwsAuth = (defaultTab?: string) =>
+  renderHook(() =>
+    useAwsAuth({
+      id: 'aws',
+      ssoRegion: 'us-east-1',
+      defaultRegion: 'us-east-1',
+      detectCredentials: false,
+      defaultTab,
+    }),
+  )
+
+describe('useAwsAuth — defaultTab', () => {
+  it('opens on Static Credentials when no defaultTab is set', () => {
+    expect(renderAwsAuth().result.current.authMethod).toBe('credentials')
+  })
+
+  it('opens on the tab the author asked for', () => {
+    expect(renderAwsAuth('sso').result.current.authMethod).toBe('sso')
+    expect(renderAwsAuth('profile').result.current.authMethod).toBe('profile')
+  })
+
+  it('falls back to Static Credentials for an unrecognized tab name', () => {
+    // MDX props are untyped, so a typo must not leave the block formless.
+    expect(renderAwsAuth('sso-tab').result.current.authMethod).toBe('credentials')
+  })
+})

--- a/web/src/components/mdx/AwsAuth/hooks/useAwsAuth.ts
+++ b/web/src/components/mdx/AwsAuth/hooks/useAwsAuth.ts
@@ -14,6 +14,7 @@ import type {
   AwsCredentialSource,
   DetectedAwsCredentials,
 } from "../types"
+import { resolveDefaultAuthMethod } from "../utils"
 
 interface UseAwsAuthOptions {
   id: string
@@ -23,6 +24,8 @@ interface UseAwsAuthOptions {
   ssoRoleName?: string
   defaultRegion: string
   detectCredentials?: false | AwsCredentialSource[]
+  /** Tab to open on; validated by resolveDefaultAuthMethod. */
+  defaultTab?: string
 }
 
 export function useAwsAuth({
@@ -33,12 +36,16 @@ export function useAwsAuth({
   ssoRoleName,
   defaultRegion,
   detectCredentials = ['env'],  // Default: auto-detect from env vars
+  defaultTab,
 }: UseAwsAuthOptions) {
   const { registerOutputs, blockOutputs } = useRunbookContext()
   const { isReady: sessionReady } = useSession()
 
   // Core auth state
-  const [authMethod, setAuthMethod] = useState<AuthMethod>('credentials')
+  // The starting tab is the author's `defaultTab` (validated), not a constant.
+  // Only the initial value is taken from the prop — the user's tab clicks own
+  // it from then on.
+  const [authMethod, setAuthMethod] = useState<AuthMethod>(() => resolveDefaultAuthMethod(defaultTab))
   const [authStatus, setAuthStatus] = useState<AuthStatus>('pending')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [warningMessage, setWarningMessage] = useState<string | null>(null)

--- a/web/src/components/mdx/AwsAuth/types.ts
+++ b/web/src/components/mdx/AwsAuth/types.ts
@@ -75,6 +75,12 @@ export interface AwsAuthProps {
   /** Default AWS region for CLI commands that don't specify a region */
   defaultRegion?: string
   /**
+   * Which authentication tab the block opens on: 'credentials' (Static
+   * Credentials), 'sso' (AWS SSO), or 'profile' (Local Profile).
+   * Default: 'credentials'. An unrecognized value falls back to the default.
+   */
+  defaultTab?: AuthMethod
+  /**
    * Credential detection configuration.
    * - `false`: Disable auto-detection, show manual auth only
    * - Array of sources: Try each source in order until one succeeds

--- a/web/src/components/mdx/AwsAuth/utils.ts
+++ b/web/src/components/mdx/AwsAuth/utils.ts
@@ -1,5 +1,5 @@
 import { CheckCircle, XCircle, Loader2, KeyRound, User } from "lucide-react"
-import type { AuthStatus, AwsDetectionSource } from "./types"
+import type { AuthMethod, AuthStatus, AwsDetectionSource } from "./types"
 import { makeStatusStyles } from "../_shared/lib/statusStyles"
 
 // Status-based styling for the container, icon, and icon color. Maps are
@@ -44,4 +44,21 @@ export function getSourceLabel(source: AwsDetectionSource): string | null {
     default:
       return null
   }
+}
+
+// The tab the block opens on when the author sets no `defaultTab`.
+const FALLBACK_AUTH_METHOD: AuthMethod = 'credentials'
+
+const AUTH_METHODS: readonly AuthMethod[] = ['credentials', 'sso', 'profile']
+
+/**
+ * Resolve the `defaultTab` prop to the tab the block opens on. Runbook authors
+ * write raw MDX with no type checking, so the value is validated here: an
+ * unrecognized tab name falls back to Static Credentials rather than leaving
+ * the block with no form showing at all.
+ */
+export function resolveDefaultAuthMethod(defaultTab: string | undefined): AuthMethod {
+  return AUTH_METHODS.includes(defaultTab as AuthMethod)
+    ? (defaultTab as AuthMethod)
+    : FALLBACK_AUTH_METHOD
 }

--- a/web/src/components/mdx/GitAuth/GitAuth.tsx
+++ b/web/src/components/mdx/GitAuth/GitAuth.tsx
@@ -17,7 +17,7 @@ import type { AppError } from "@/types/error"
 import type { GitAuthProps, GitProvider } from "./types"
 import { PROVIDERS } from "./providers"
 import { useGitAuth } from "./hooks/useGitAuth"
-import { getStatusClasses, getStatusIcon, getStatusIconClasses } from "./utils"
+import { getStatusClasses, getStatusIcon, getStatusIconClasses, resolveDefaultAuthMethod } from "./utils"
 import { ProviderSelect } from "./components/ProviderSelect"
 import { HostSelect } from "./components/HostSelect"
 import { AuthTabs } from "./components/AuthTabs"
@@ -41,6 +41,7 @@ function GitAuthInteractive({
   oauthScopes,
   detectCredentials,
   host,
+  defaultTab,
   inputsId,
   __registryType = 'GitAuth',
 }: GitAuthInternalProps) {
@@ -87,19 +88,21 @@ function GitAuthInteractive({
     oauthScopes: effectiveOAuthScopes,
     detectCredentials,
     host,
+    defaultTab,
   })
 
   // Switch providers: cancel any in-flight OAuth poll, drop the prior
   // provider's outputs, reset transient + detection state so detection re-runs,
   // and reset the auth method to the new provider's default (GitLab has no
-  // OAuth, so a leftover 'oauth' method would render no form at all).
+  // OAuth, so a leftover 'oauth' method would render no form at all). The
+  // author's `defaultTab` applies again here when the new provider offers it.
   const handleSelectProvider = (next: GitProvider) => {
     if (next === provider) return
     auth.cancelOAuth()
     auth.clearRegisteredOutputs(next)
     auth.resetAuth()
     auth.resetDetectionState()
-    auth.setAuthMethod(PROVIDERS[next].supportsOAuth ? 'oauth' : 'pat')
+    auth.setAuthMethod(resolveDefaultAuthMethod(PROVIDERS[next], defaultTab))
     setCustomOAuthDismissed(false)
     setUseDefaultOAuth(false)
     setProvider(next)

--- a/web/src/components/mdx/GitAuth/__tests__/GitAuth.switch.test.tsx
+++ b/web/src/components/mdx/GitAuth/__tests__/GitAuth.switch.test.tsx
@@ -116,3 +116,45 @@ describe('GitAuth — provider switch (real hook)', () => {
     })
   })
 })
+
+describe('GitAuth — defaultTab (real hook)', () => {
+  it('opens on the PAT form when the author asks for it', () => {
+    render(
+      <TestWrapper>
+        <GitAuth id="git" defaultTab="pat" detectCredentials={false} />
+      </TestWrapper>,
+    )
+
+    expect(screen.getByPlaceholderText(/github_pat_/i)).toBeInTheDocument()
+    expect(screen.queryByText(/redirected to authorize/i)).toBeNull()
+  })
+
+  it('re-applies defaultTab after a provider switch', async () => {
+    render(
+      <TestWrapper>
+        <GitAuth id="git" provider="gitlab" defaultTab="pat" detectCredentials={false} />
+      </TestWrapper>,
+    )
+
+    expect(screen.getByPlaceholderText(/GitLab access token/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /GitHub/ }))
+
+    // GitHub defaults to OAuth, but the author pinned the PAT tab.
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/github_pat_/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByText(/redirected to authorize/i)).toBeNull()
+  })
+
+  it('ignores a tab the provider does not offer', () => {
+    // GitLab has no OAuth device flow — the PAT form must still render.
+    render(
+      <TestWrapper>
+        <GitAuth id="git" provider="gitlab" defaultTab="oauth" detectCredentials={false} />
+      </TestWrapper>,
+    )
+
+    expect(screen.getByPlaceholderText(/GitLab access token/i)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/mdx/GitAuth/__tests__/utils.test.ts
+++ b/web/src/components/mdx/GitAuth/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
-import { normalizeInstanceBaseUrl } from "../utils"
+import { normalizeInstanceBaseUrl, resolveDefaultAuthMethod } from "../utils"
+import { PROVIDERS } from "../providers"
 
 // Mirrors the backend's normalizeGitLabBaseUrl (src/domain/git/gitlab-host.ts),
 // but returns null (rather than the gitlab.com default) so the PAT form can fall
@@ -30,5 +31,32 @@ describe("normalizeInstanceBaseUrl", () => {
   it("returns null for a non-http(s) scheme rather than mangling it", () => {
     // Guards the `https://ftp` foot-gun from naive scheme-prefixing.
     expect(normalizeInstanceBaseUrl("ftp://gitlab.acme.com")).toBeNull()
+  })
+})
+
+// Which tab the block opens on. The valid set is provider-dependent — GitLab
+// has no OAuth flow — so a tab the provider does not offer must fall back
+// rather than render an empty pane.
+describe("resolveDefaultAuthMethod", () => {
+  it("defaults to the provider's own tab when no defaultTab is set", () => {
+    expect(resolveDefaultAuthMethod(PROVIDERS.github, undefined)).toBe("oauth")
+    expect(resolveDefaultAuthMethod(PROVIDERS.gitlab, undefined)).toBe("pat")
+  })
+
+  it("honors a tab the provider offers", () => {
+    expect(resolveDefaultAuthMethod(PROVIDERS.github, "pat")).toBe("pat")
+    expect(resolveDefaultAuthMethod(PROVIDERS.github, "oauth")).toBe("oauth")
+    expect(resolveDefaultAuthMethod(PROVIDERS.gitlab, "pat")).toBe("pat")
+  })
+
+  it("falls back when the provider does not offer the requested tab", () => {
+    // GitLab has no OAuth device flow; 'oauth' would render no form at all.
+    expect(resolveDefaultAuthMethod(PROVIDERS.gitlab, "oauth")).toBe("pat")
+  })
+
+  it("falls back for an unrecognized tab name", () => {
+    // MDX props are untyped, so a typo must not leave the block formless.
+    expect(resolveDefaultAuthMethod(PROVIDERS.github, "token")).toBe("oauth")
+    expect(resolveDefaultAuthMethod(PROVIDERS.gitlab, "")).toBe("pat")
   })
 })

--- a/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
+++ b/web/src/components/mdx/GitAuth/hooks/useGitAuth.ts
@@ -19,6 +19,7 @@ import type {
 } from "../types"
 import { isCliAuthFound, OTHER_INSTANCE_SENTINEL } from "../types"
 import type { ProviderConfig } from "../providers"
+import { resolveDefaultAuthMethod } from "../utils"
 
 interface UseGitAuthOptions {
   id: string
@@ -28,6 +29,8 @@ interface UseGitAuthOptions {
   oauthClientId?: string
   oauthScopes?: string[]
   detectCredentials?: false | GitCredentialSource[]
+  /** Tab to open on; validated against the provider by resolveDefaultAuthMethod. */
+  defaultTab?: string
   /** GitLab only: an authored host that pins the instance and hides the picker. */
   host?: string
 }
@@ -60,14 +63,17 @@ export function useGitAuth({
   oauthScopes = ['repo'],
   detectCredentials = ['env', 'cli'],
   host,
+  defaultTab,
 }: UseGitAuthOptions) {
   const { registerOutputs, blockOutputs } = useRunbookContext()
   const { isReady: sessionReady } = useSession()
 
-  // Core auth state. The default manual method depends on the provider: GitHub
-  // defaults to OAuth, GitLab (no OAuth) to PAT.
+  // Core auth state. The starting tab is the author's `defaultTab` when the
+  // provider offers it; otherwise the provider's own default (GitHub → OAuth,
+  // GitLab → PAT, as it has no OAuth). Only the initial value comes from the
+  // prop — the user's tab clicks own it from then on.
   const [authMethod, setAuthMethod] = useState<GitAuthMethod>(
-    provider.supportsOAuth ? 'oauth' : 'pat'
+    () => resolveDefaultAuthMethod(provider, defaultTab)
   )
   const [authStatus, setAuthStatus] = useState<GitAuthStatus>('pending')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)

--- a/web/src/components/mdx/GitAuth/types.ts
+++ b/web/src/components/mdx/GitAuth/types.ts
@@ -87,6 +87,13 @@ export interface GitAuthProps {
   /** Credential detection configuration (default: ['env', 'cli']). */
   detectCredentials?: false | GitCredentialSource[]
   /**
+   * Which authentication tab the block opens on: 'oauth' (Sign in with
+   * GitHub) or 'pat' (Personal Access Token). Default: 'oauth' for GitHub,
+   * 'pat' for GitLab, which has no OAuth flow. A value the selected provider
+   * does not offer — or an unrecognized one — falls back to that default.
+   */
+  defaultTab?: GitAuthMethod
+  /**
    * GitLab only: pin the GitLab instance to authenticate against (e.g.
    * "gitlab.gruntwork.io"). When set, the host picker is hidden and detection
    * targets this host. When omitted, the block enumerates the hosts the user is

--- a/web/src/components/mdx/GitAuth/utils.ts
+++ b/web/src/components/mdx/GitAuth/utils.ts
@@ -1,5 +1,6 @@
 import { CheckCircle, XCircle, Loader2, KeyRound } from "lucide-react"
-import type { GitAuthStatus } from "./types"
+import type { GitAuthMethod, GitAuthStatus } from "./types"
+import type { ProviderConfig } from "./providers"
 import { makeStatusStyles } from "../_shared/lib/statusStyles"
 
 /**
@@ -48,3 +49,20 @@ export const { getStatusClasses, getStatusIcon, getStatusIconClasses } = makeSta
     pending: 'text-info',
   },
 })
+
+/**
+ * Resolve the `defaultTab` prop to the tab the block opens on for a given
+ * provider. Unlike AwsAuth/GoogleAuth the valid set is provider-dependent —
+ * GitLab has no OAuth flow — so a tab the provider does not offer falls back
+ * to that provider's default (OAuth where supported, otherwise PAT), as does
+ * an unrecognized value from untyped MDX.
+ */
+export function resolveDefaultAuthMethod(
+  provider: ProviderConfig,
+  defaultTab: string | undefined,
+): GitAuthMethod {
+  if (defaultTab && provider.manualMethods.includes(defaultTab as GitAuthMethod)) {
+    return defaultTab as GitAuthMethod
+  }
+  return provider.supportsOAuth ? 'oauth' : 'pat'
+}

--- a/web/src/components/mdx/GoogleAuth/GoogleAuth.tsx
+++ b/web/src/components/mdx/GoogleAuth/GoogleAuth.tsx
@@ -39,6 +39,7 @@ function GoogleAuthInteractive({
   defaultZone,
   gcloudConfiguration,
   detectCredentials = ['env', 'adc'],  // Default: env vars, then the well-known ADC file
+  defaultTab,
   inputsId,
 }: GoogleAuthProps) {
   const validationError = useMemo((): AppError | null => {
@@ -98,6 +99,7 @@ function GoogleAuthInteractive({
     ...(defaultZone ? { defaultZone } : {}),
     ...(resolvedConfiguration ? { gcloudConfiguration: resolvedConfiguration } : {}),
     detectCredentials,
+    defaultTab,
   })
 
   // Track block render on mount

--- a/web/src/components/mdx/GoogleAuth/hooks/__tests__/useGoogleAuth.test.ts
+++ b/web/src/components/mdx/GoogleAuth/hooks/__tests__/useGoogleAuth.test.ts
@@ -1462,3 +1462,26 @@ describe('useGoogleAuth — post-authentication', () => {
     ])
   })
 })
+
+// Which tab the block opens on. Decided once, at mount, from the author's
+// `defaultTab`; the user's tab clicks own it from then on.
+describe('useGoogleAuth — defaultTab', () => {
+  const renderWithTab = (defaultTab?: string) => {
+    installApi(() => ({}))
+    return renderGoogleAuth({ id: 'gcp', detectCredentials: false, defaultTab })
+  }
+
+  it('opens on the Service Account Key tab when no defaultTab is set', () => {
+    expect(renderWithTab().result.current.authMethod).toBe('service_account')
+  })
+
+  it('opens on the tab the author asked for', () => {
+    expect(renderWithTab('oauth').result.current.authMethod).toBe('oauth')
+    expect(renderWithTab('gcloud').result.current.authMethod).toBe('gcloud')
+  })
+
+  it('falls back to the Service Account Key tab for an unrecognized tab name', () => {
+    // MDX props are untyped, so a typo must not leave the block formless.
+    expect(renderWithTab('sign-in').result.current.authMethod).toBe('service_account')
+  })
+})

--- a/web/src/components/mdx/GoogleAuth/hooks/useGoogleAuth.ts
+++ b/web/src/components/mdx/GoogleAuth/hooks/useGoogleAuth.ts
@@ -15,6 +15,7 @@ import type {
   GoogleDetectionStatus,
   GoogleProjectInfo,
 } from "../types"
+import { resolveDefaultAuthMethod } from "../utils"
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -112,6 +113,8 @@ export interface UseGoogleAuthOptions {
   defaultZone?: string
   gcloudConfiguration?: string
   detectCredentials?: false | GoogleCredentialSource[]
+  /** Tab to open on; validated by resolveDefaultAuthMethod. */
+  defaultTab?: string
 }
 
 export interface UseGoogleAuthReturn {
@@ -238,13 +241,17 @@ export function useGoogleAuth({
   defaultZone,
   gcloudConfiguration,
   detectCredentials = ['env', 'adc'],
+  defaultTab,
 }: UseGoogleAuthOptions): UseGoogleAuthReturn {
   const api = useApi()
   const { registerOutputs, blockOutputs } = useRunbookContext()
   const { isReady: sessionReady } = useSession()
 
   // ---- Core auth state ------------------------------------------------------
-  const [authMethod, setAuthMethod] = useState<GoogleAuthMethod>('service_account')
+  // The starting tab is the author's `defaultTab` (validated), not a constant.
+  // Only the initial value comes from the prop — the user's tab clicks own it
+  // from then on.
+  const [authMethod, setAuthMethod] = useState<GoogleAuthMethod>(() => resolveDefaultAuthMethod(defaultTab))
   const [authStatus, setAuthStatus] = useState<GoogleAuthStatus>('pending')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [warningMessage, setWarningMessage] = useState<string | null>(null)

--- a/web/src/components/mdx/GoogleAuth/types.ts
+++ b/web/src/components/mdx/GoogleAuth/types.ts
@@ -163,6 +163,12 @@ export interface GoogleAuthProps {
   /** Pin the named gcloud configuration used by the third tab. */
   gcloudConfiguration?: string
   /**
+   * Which authentication tab the block opens on: 'service_account' (Service
+   * Account Key), 'oauth' (Google Sign-In), or 'gcloud' (gcloud Config).
+   * Default: 'service_account'. An unrecognized value falls back to the default.
+   */
+  defaultTab?: GoogleAuthMethod
+  /**
    * Credential detection configuration.
    * - `false`: disable auto-detection, show manual auth only
    * - Array of sources: try each source in order until one succeeds

--- a/web/src/components/mdx/GoogleAuth/utils.ts
+++ b/web/src/components/mdx/GoogleAuth/utils.ts
@@ -1,5 +1,5 @@
 import { CheckCircle, XCircle, Loader2, KeyRound, FolderOpen } from "lucide-react"
-import type { GoogleAuthStatus, GoogleDetectionSource } from "./types"
+import type { GoogleAuthMethod, GoogleAuthStatus, GoogleDetectionSource } from "./types"
 import { makeStatusStyles } from "../_shared/lib/statusStyles"
 
 // Status-based styling for the container, icon, and icon color. Maps are
@@ -47,4 +47,21 @@ export function getSourceLabel(source: GoogleDetectionSource): string | null {
     default:
       return null
   }
+}
+
+// The tab the block opens on when the author sets no `defaultTab`.
+const FALLBACK_AUTH_METHOD: GoogleAuthMethod = 'service_account'
+
+const AUTH_METHODS: readonly GoogleAuthMethod[] = ['service_account', 'oauth', 'gcloud']
+
+/**
+ * Resolve the `defaultTab` prop to the tab the block opens on. Runbook authors
+ * write raw MDX with no type checking, so the value is validated here: an
+ * unrecognized tab name falls back to the Service Account Key tab rather than
+ * leaving the block with no form showing at all.
+ */
+export function resolveDefaultAuthMethod(defaultTab: string | undefined): GoogleAuthMethod {
+  return AUTH_METHODS.includes(defaultTab as GoogleAuthMethod)
+    ? (defaultTab as GoogleAuthMethod)
+    : FALLBACK_AUTH_METHOD
 }


### PR DESCRIPTION
## What

Adds a `defaultTab` prop to `AwsAuth`, `GoogleAuth`, and `GitAuth` (and therefore the locked `GitHubAuth` / `GitLabAuth` wrappers) so a runbook author can choose which authentication tab the block opens on.

Each block previously hard-coded its starting tab. A runbook whose users always authenticate one way still landed them on the wrong form and made them click across before they could do anything.

`defaultTab` seeds the initial state only — the user's own tab clicks own it from then on.

## Valid values

| Block | Values | Default |
| --- | --- | --- |
| `AwsAuth` | `'credentials'`, `'sso'`, `'profile'` | `'credentials'` |
| `GoogleAuth` | `'service_account'`, `'oauth'`, `'gcloud'` | `'service_account'` |
| `GitAuth` | `'oauth'`, `'pat'` | `'oauth'` (GitHub), `'pat'` (GitLab) |

MDX props are untyped, so each block validates the value in a `resolveDefaultAuthMethod` helper and falls back to its default rather than rendering a pane with no form in it.

`GitAuth` is the interesting case: the valid set is provider-dependent — GitLab has no OAuth device flow, so `defaultTab="oauth"` falls back to `'pat'` there. The prop is also re-applied on a provider switch, which previously always reset to the new provider's own default.

## Test plan

- New unit tests for `resolveDefaultAuthMethod` in `GitAuth` (provider-aware fallback) and for the starting tab in `useAwsAuth` / `useGoogleAuth`.
- New `GitAuth` component tests: opens on the authored tab, re-applies it across a provider switch, ignores a tab the provider does not offer.
- `npx vitest run src/components/mdx/{AwsAuth,GitAuth,GoogleAuth}` — 154 tests pass.
- `tsc --noEmit` and `oxlint` clean on the touched directories.
- Manual: the `aws-auth` and `google-auth` feature demos each gained a section demonstrating a non-default starting tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)