### PR TITLE
uptick to 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runbooks",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "private": true,
   "description": "Gruntwork Runbooks",
   "author": {


### PR DESCRIPTION
Bumps the app version from `0.21.2` to `0.22.0`.

Minor bump: since 0.21.2, main picked up the GitClone empty-repository flow (#196) and the `defaultTab` prop for the auth blocks (#197) — new author-facing behavior, no breaking changes.

`package.json` is the only place the version appears in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)